### PR TITLE
Only match migration files ending in .js

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -95,7 +95,7 @@ module.exports = function(options){
 
   function loadMigrationFiles(){
     fs.readdirSync( options.dir + '/' ).forEach(function(file) {
-      if (file.match(/.+\.js/g) !== null && file !== 'index.js') {
+      if (file.match(/.+\.js$/g) !== null && file !== 'index.js') {
         var name = file.replace('.js', '');
         // console.log( '> loading migration: '+name)
         var file_path = options.dir +'/'+ file;


### PR DESCRIPTION
Avoids matching .js~ and .js.swp files created by some editors.
