### PR TITLE
Fix dropIndex operation

### DIFF
--- a/lib/operations/indexes.js
+++ b/lib/operations/indexes.js
@@ -32,6 +32,7 @@ var ops = module.exports = {
 
   drop: function ( table_name, columns, options ) {
     options = options || {};
+    if (_.isArray(columns)) columns = columns.join(', ');
     var index_name = generateIndexName( table_name, columns, options );
     return utils.t('DROP INDEX {index};', { index: index_name } );
   }


### PR DESCRIPTION
drop did not take an array like create does.

This broke the automatic down migration of creating indexes.
