### PR TITLE
Replaced escape with Dollar Quoted String Constant

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -35,7 +35,7 @@ export const escapeValue = (val) => {
     return val.toString();
   }
   if (typeof val === 'string') {
-    return `'${escape(val)}'`;
+    return `$DollarQuotedStringConstant$${val}$DollarQuotedStringConstant$`;
   }
   if (typeof val === 'number') {
     return val;


### PR DESCRIPTION
`escape()` is Javascript based and breaks setting default expressions like `now()` properly. 

By using Dollar-quoted String Constants https://www.postgresql.org/docs/9.6/static/sql-syntax-lexical.html it can be assured that the string constant is intact without having to escape the string's contents