### PR TITLE
[UPDATE] add space before `USING` keyword

### DIFF
--- a/lib/operations/tables.js
+++ b/lib/operations/tables.js
@@ -215,7 +215,7 @@ export const alterColumn = (table_name, column_name, options) => {
     actions.push(`SET DEFAULT ${escapeValue(defaultValue)}`);
   }
   if (type) {
-    actions.push(`SET DATA TYPE ${applyTypeAdapters(type)}${collation ? `COLLATE ${collation}` : ''}${using ? `USING ${using}` : ''}`);
+    actions.push(`SET DATA TYPE ${applyTypeAdapters(type)}${collation ? `COLLATE ${collation}` : ''}${using ? ` USING ${using}` : ''}`);
   }
   if (notNull) {
     actions.push('SET NOT NULL');


### PR DESCRIPTION
Hi, I noticed we can't use the `using` property because it creates queries like `ALTER "tablename" SET DATA TYPE "type"USING ...`.