### PR TITLE
Handle rejections in migration actions

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -41,14 +41,14 @@ class Migration {
   }
 
   _apply(action, pgm) {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       if (action.length === 2) {
         action(pgm, resolve);
       } else {
         const result = action(pgm);
         // result conforms to Promises/A+ spec
         if (typeof result === 'object' && typeof result.then === 'function') {
-          result.then(resolve);
+          result.then(resolve).catch(err => reject(err));
         } else {
           resolve();
         }


### PR DESCRIPTION
If an asynchronous up/down migration function is rejected, node-pg-migrate at the moment fails, causing a unhandled rejection error!

This patch adds support for action rejections.
