### PR TITLE
Add no lock option

### DIFF
--- a/bin/node-pg-migrate
+++ b/bin/node-pg-migrate
@@ -121,6 +121,12 @@ const argv = yargs
     type: 'string',
   })
 
+  .option('no-lock', {
+    default: false,
+    describe: 'Disables locking mechanism and checks',
+    type: 'boolean',
+  })
+
   .help()
   .argv;
 
@@ -233,6 +239,11 @@ if (action === 'create') {
     console.log('dry run');
   }
 
+  const noLock = argv['no-lock'];
+  if (noLock) {
+    console.log('no lock');
+  }
+
   const updownArg = argv._.length ? argv._[0] : null;
   let numMigrations;
   let migrationName;
@@ -258,6 +269,7 @@ if (action === 'create') {
     checkOrder: CHECK_ORDER,
     typeShorthands: TYPE_SHORTHANDS,
     direction,
+    noLock,
   });
   const promise = action === 'redo'
     ? migrationRunner(options('down')).then(() => migrationRunner(options('up')))

--- a/index.d.ts
+++ b/index.d.ts
@@ -402,6 +402,7 @@ export interface RunnerOption {
     file?: string
     dryRun?: boolean
     typeShorthands?: { [name: string]: string }
+    noLock?: boolean
 }
 
 export default function (options: RunnerOption): Promise<void>

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -96,12 +96,16 @@ const getRunMigrations = (db, options) => {
       (migrationTables && migrationTables.length === 1)
       || db.query(`CREATE TABLE "${schema}"."${options.migrations_table}" ( id SERIAL, ${nameColumn} varchar(255) NOT NULL, ${runOnColumn} timestamp NOT NULL)`)
     )
-    .then(() =>
-      lock(db, options)
-    )
-    .then(() =>
-      db.addBeforeCloseListener(() => unlock(db, options))
-    )
+    .then(() => (
+      !options.noLock
+        ? lock(db, options)
+        : null
+    ))
+    .then(() => (
+      !options.noLock
+        ? db.addBeforeCloseListener(() => unlock(db, options))
+        : null
+    ))
     .then(() =>
       db.column(`SELECT ${nameColumn} FROM "${schema}"."${options.migrations_table}" ORDER BY ${runOnColumn}`, nameColumn)
     )


### PR DESCRIPTION
Add a no lock option to run migrations without trying to lock the migration table.

This requires more work from the developer to ensure migrations won't collide.

But this is useful for use in Postgres-like databases that don't support `LOCK` and/or `COMMENT` commands (e.g. CockroachDB).