### PR TITLE
Add --single-transaction option

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ You can adjust defaults by passing arguments to `node-pg-migrate`:
 
 * `check-order` - Check order of migrations before running them (defaults to `true`, to switch it off supply `--no-check-order` on command line).
                   (There should be no migration with timestamp lesser than last run migration.)
+* `single-transaction` - When true, combines all pending migrations into a single transaction so that if any migration fails, all will be rolled back (defaults to `false`)
 * `no-lock` - Disables locking mechanism and checks (useful for DBs which does not support SQL commands used for [locking](#locking))
 
 See all by running `node-pg-migrate --help`.
@@ -160,6 +161,7 @@ which takes options argument with following structure (similar to [command line 
 * `ignorePattern` _[string]_ - Regex pattern for file names to ignore
 * `file` _[string]_ - Run only migration with this name
 * `typeShorthands` _[object]_ - Object with column type shorthands
+* `single_transaction` _[boolean]_ - When true, combines all pending migrations into a single transaction so that if any migration fails, all will be rolled back (defaults to `false`)
 * `noLock` _[boolean]_ - Disables locking mechanism and checks
 * `dryRun` _[boolean]_
 

--- a/bin/node-pg-migrate
+++ b/bin/node-pg-migrate
@@ -37,6 +37,7 @@ const checkOrderArg = 'check-order';
 const configValueArg = 'config-value';
 const configFileArg = 'config-file';
 const ignorePatternArg = 'ignore-pattern';
+const singleTransactionArg = 'single-transaction';
 const noLockArg = 'no-lock';
 const timestampArg = 'timestamp';
 const dryRunArg = 'dry-run';
@@ -136,6 +137,12 @@ const argv = yargs
     choices: ['js', 'ts'],
     describe: 'Language of the migration file (Only valid with the create action)',
     type: 'string',
+  })
+
+  .option(singleTransactionArg, {
+    default: false,
+    describe: 'Combines all pending migrations into a single database transaction so that if any migration fails, all will be rolled back',
+    type: 'boolean',
   })
 
   .option(noLockArg, {
@@ -268,6 +275,8 @@ if (action === 'create') {
     console.log('dry run');
   }
 
+  const singleTransaction = argv[singleTransactionArg];
+
   const noLock = argv[noLockArg];
   if (noLock) {
     console.log('no lock');
@@ -301,6 +310,7 @@ if (action === 'create') {
     create_schema: CREATE_SCHEMA,
     create_migrations_schema: CREATE_MIGRATIONS_SCHEMA,
     direction,
+    single_transaction: singleTransaction,
     noLock,
   });
   const promise = action === 'redo'

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -73,9 +73,13 @@ class Migration {
       }
 
       if (pgm.isUsingTransaction()) {
-        // wrap in a transaction, combine into one sql statement
-        sqlSteps.unshift('BEGIN;');
-        sqlSteps.push('COMMIT;');
+        // in single_transaction mode we are already wrapped in a
+        // global transaction
+        if (!this.options.single_transaction) {
+          // otherwise we need to create our own transaction
+          sqlSteps.unshift('BEGIN;');
+          sqlSteps.push('COMMIT;');
+        }
       } else {
         this.log('#> WARNING: This migration is not wrapped in a transaction! <');
       }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -141,6 +141,14 @@ const getMigrationsToRun = (options, runNames, migrations) => {
   );
 };
 
+const ifSingleTransaction = (operation, options, db) => {
+  if (options.single_transaction) {
+    return db.query(operation);
+  }
+  return Promise.resolve();
+};
+
+
 export default (options) => {
   const db = Db(options.database_url);
   return Promise.resolve()
@@ -187,14 +195,15 @@ export default (options) => {
         console.log(`> - ${m.name}`);
       });
 
-      return toRun.reduce(
-        (promise, migration) => promise.then(() => (
-          options.direction === 'up'
-            ? migration.applyUp()
-            : migration.applyDown()
-        )),
-        Promise.resolve()
-      );
+      return ifSingleTransaction('BEGIN', options, db)
+        .then(() => toRun.reduce(
+          (promise, migration) => promise.then(() => (
+            options.direction === 'up'
+              ? migration.applyUp()
+              : migration.applyDown()
+          )),
+          Promise.resolve()
+        )).then(() => ifSingleTransaction('COMMIT', options, db));
     })
     .catch((e) => {
       console.log('> Rolling back attempted migration ...');


### PR DESCRIPTION
This adds a new boolean option, `--single-transaction`. When true, all pending migrations are combined into a single database transaction. This is useful if you want to ensure that your database will get either _all_ of the pending migrations or _none_ of them, without ending up in an indeterminate state in between.