### PR TITLE
Implement failsafe locking

### DIFF
--- a/bin/node-pg-migrate
+++ b/bin/node-pg-migrate
@@ -10,7 +10,6 @@ const Migration = require("../dist/migration").default; // eslint-disable-line i
 const runner = require("../dist/runner"); // eslint-disable-line import/no-unresolved,import/extensions
 
 const migrationRunner = runner.default;
-const unlockRunner = runner.unlockRunner;
 
 process.on("uncaughtException", err => {
   console.log(err.stack);
@@ -43,7 +42,7 @@ const timestampArg = "timestamp";
 const dryRunArg = "dry-run";
 
 const argv = yargs
-  .usage("Usage: $0 [up|down|create|unlock|redo] [migrationName] [options]")
+  .usage("Usage: $0 [up|down|create|redo] [migrationName] [options]")
 
   .option("d", {
     alias: databaseUrlVarArg,
@@ -259,27 +258,6 @@ if (action === "create") {
     MIGRATIONS_FILE_LANGUAGE
   );
   console.log(util.format("Created migration -- %s", migration.path));
-} else if (action === "unlock") {
-  if (!DATABASE_URL) {
-    console.error(
-      `The $${argv[databaseUrlVarArg]} environment variable is not set.`
-    );
-    process.exit(1);
-  }
-  unlockRunner({
-    databaseUrl: DATABASE_URL,
-    schema: SCHEMA,
-    migrationsSchema: MIGRATIONS_SCHEMA,
-    migrationsTable: MIGRATIONS_TABLE
-  })
-    .then(() => {
-      console.log("Unlocked!");
-      process.exit(0);
-    })
-    .catch(err => {
-      console.log(err.stack);
-      process.exit(1);
-    });
 } else if (action === "up" || action === "down" || action === "redo") {
   if (!DATABASE_URL) {
     console.error(
@@ -351,7 +329,7 @@ if (action === "create") {
       process.exit(1);
     });
 } else {
-  console.log("Invalid Action: Must be [up|down|create|unlock|redo].");
+  console.log("Invalid Action: Must be [up|down|create|redo].");
   yargs.showHelp();
   process.exit(1);
 }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,11 +1,13 @@
 import path from "path";
-import crypto from "crypto";
 import fs from "fs";
 import Db from "./db";
 import Migration from "./migration";
 import { getMigrationTableSchema, finallyPromise, template } from "./utils";
 
 export { PgLiteral } from "./utils";
+
+// Random but well-known identifier shared by all instances of node-pg-migrate
+const PG_MIGRATE_LOCK_ID = 7241865325823964;
 
 const readdir = (...args) =>
   new Promise(
@@ -64,55 +66,16 @@ const loadMigrationFiles = (db, options, log) =>
       throw new Error(`Can't get migration files: ${err.stack}`);
     });
 
-const lock = (db, options) => {
-  const schema = getMigrationTableSchema(options);
-  const { migrationsTable } = options;
-  const fullTableName = {
-    schema,
-    name: migrationsTable
-  };
-  const lockName = crypto.randomBytes(30).toString("base64");
-  const getCurrentLockName = () =>
-    db
-      .select(
-        `SELECT obj_description(c.oid) as "comment"
-                FROM pg_class c join pg_namespace n ON (c.relnamespace = n.oid)
-                WHERE c.relname = '${migrationsTable}' and c.relkind = 'r' and n.nspname = '${schema}'`
-      )
-      .then(rows => {
-        if (rows.length > 1) {
-          throw new Error("More then one migration table");
-        } else if (rows.length === 1) {
-          return rows[0].comment;
-        }
-        return null;
-      });
-
-  return db
-    .query("BEGIN")
-    .then(() =>
-      db.query(template`LOCK "${fullTableName}" IN ACCESS EXCLUSIVE MODE`)
+const lock = db =>
+  db
+    .query(
+      `select pg_try_advisory_lock(${PG_MIGRATE_LOCK_ID}) as lock_obtained`
     )
-    .then(getCurrentLockName)
-    .then(currentLockName => {
-      if (currentLockName) {
+    .then(result => {
+      if (!result.rows[0].lock_obtained) {
         throw new Error("Another migration is already running");
       }
-    })
-    .then(() =>
-      db.query(template`COMMENT ON TABLE "${fullTableName}" IS '${lockName}'`)
-    )
-    .then(() => db.query("COMMIT"));
-};
-
-const unlock = (db, options) => {
-  const schema = getMigrationTableSchema(options);
-  const fullTableName = {
-    schema,
-    name: options.migrationsTable
-  };
-  return db.query(template`COMMENT ON TABLE "${fullTableName}" IS NULL`);
-};
+    });
 
 const getRunMigrations = (db, options) => {
   const schema = getMigrationTableSchema(options);
@@ -133,12 +96,6 @@ const getRunMigrations = (db, options) => {
         )
     )
     .then(() => (!options.noLock ? lock(db, options) : null))
-    .then(
-      () =>
-        !options.noLock
-          ? db.addBeforeCloseListener(() => unlock(db, options))
-          : null
-    )
     .then(() =>
       db.column(
         template`SELECT ${nameColumn} FROM "${fullTableName}" ORDER BY ${runOnColumn}`,
@@ -270,9 +227,4 @@ export default options => {
       );
     })
     .then(...finallyPromise(db.close));
-};
-
-export const unlockRunner = options => {
-  const db = Db(options.databaseUrl);
-  return unlock(db, options).then(...finallyPromise(db.close));
 };


### PR DESCRIPTION
This switches to PostgreSQL's advisory locking. Unlike the current strategy of using a table comment, it cannot leave a dead lock lying around, even if node-pg-migrate crashes. This is an implementation of what I suggested in #232.

I removed the manual `unlock` command because there's nothing for it to do. The only way to get stuck is if you have an actual node-pg-migrate process that is connected to the database and hung, in which case you should just kill it and that will release the lock.