### PR TITLE
Fix unexpected behaviour

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -145,7 +145,7 @@ const getMigrationsToRun = (options, runNames, migrations) => {
 };
 
 const ifSingleTransaction = (operation, options, db) =>
-  options.singleTransaction === false ? Promise.resolve() : db.query(operation);
+  options.singleTransaction ? db.query(operation) : Promise.resolve();
 
 export default options => {
   const log = options.log || console.log;


### PR DESCRIPTION
- Fix singleTransaction turned on even if config wasn't passed through

If using the library through (instead of through CLI) and singleTransaction option isn't passed through (missing from object instead of being explicitly set to true or false) then transactions are nested.

This causes issues for databases like CockroachDB which don't support nested transactions.