### PR TITLE
opclass parens typo

### DIFF
--- a/lib/operations/indexes.js
+++ b/lib/operations/indexes.js
@@ -47,7 +47,7 @@ export const createIndex = (tableName, columns, options = {}) => {
   const where = options.where ? ` WHERE ${options.where}` : "";
   const opclass = options.opclass ? ` ${options.opclass}` : "";
 
-  return template`CREATE ${unique} INDEX ${concurrently} "${indexName}" ON "${tableName}"${method} (${columnsString})${opclass}${where};`;
+  return template`CREATE ${unique} INDEX ${concurrently} "${indexName}" ON "${tableName}"${method} (${columnsString}${opclass})${where};`;
 };
 
 export const dropIndex = (tableName, columns, options = {}) => {

--- a/test/indexes-test.js
+++ b/test/indexes-test.js
@@ -18,7 +18,7 @@ describe("lib/operations/indexes", () => {
         where: "some condition"
       });
       expect(sql).to.equal(
-        'CREATE  INDEX  "z" ON "x" USING gist ("y") some_opclass WHERE some condition;'
+        'CREATE  INDEX  "z" ON "x" USING gist ("y" some_opclass) WHERE some condition;'
       );
     });
   });


### PR DESCRIPTION
The parens should be after the opclass when creating an index