### PR TITLE
respect configured logger

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -169,7 +169,7 @@ const ifSingleTransaction = (operation, options, db) =>
 
 export default options => {
   const log = options.log || console.log;
-  const db = Db(options.databaseUrl);
+  const db = Db(options.databaseUrl, log);
   return Promise.resolve()
     .then(() => {
       let promise = Promise.resolve();


### PR DESCRIPTION
This is a bugfix, this code was still using the console log even when there was a configured log function. 