### PR TITLE
implemented renaming of enum values

### DIFF
--- a/lib/migration-builder.js
+++ b/lib/migration-builder.js
@@ -78,6 +78,7 @@ module.exports = class MigrationBuilder {
     this.addType = this.createType;
     this.renameType = wrap(types.renameType);
     this.renameTypeAttribute = wrap(types.renameTypeAttribute);
+    this.renameTypeValue = wrap(types.renameTypeValue);
     this.addTypeAttribute = wrap(types.addTypeAttribute(typeShorthands));
     this.dropTypeAttribute = wrap(types.dropTypeAttribute);
     this.setTypeAttribute = wrap(types.setTypeAttribute(typeShorthands));

--- a/lib/operations/types.js
+++ b/lib/operations/types.js
@@ -73,8 +73,16 @@ function renameTypeAttribute(typeName, attributeName, newAttributeName) {
 const undoRenameTypeAttribute = (typeName, attributeName, newAttributeName) =>
   renameTypeAttribute(typeName, newAttributeName, attributeName);
 
+export function renameTypeValue(typeName, value, newValue) {
+  return template`ALTER TYPE "${typeName}" RENAME VALUE "${value}" TO "${newValue}";`;
+}
+
+const undoRenameTypeValue = (typeName, value, newValue) =>
+  renameTypeValue(typeName, newValue, value);
+
 renameType.reverse = undoRename;
 renameTypeAttribute.reverse = undoRenameTypeAttribute;
+renameTypeValue.reverse = undoRenameTypeValue;
 
 module.exports = {
   createType,
@@ -84,5 +92,6 @@ module.exports = {
   dropTypeAttribute,
   setTypeAttribute,
   renameTypeAttribute,
+  renameTypeValue,
   addTypeValue
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Postgresql database migration management tool for node.js",
   "author": "Theo Ephraim",
   "contributors": [
-    "Jan Doležel <dolezel.jan@gmail.com> (http://www.eithel.net/)"
+    "Jan Doležel <dolezel.jan@gmail.com> (http://www.eithel.net/)",
+    "Christopher Quadflieg <chrissi92@hotmail.de>"
   ],
   "bin": {
     "node-pg-migrate": "bin/node-pg-migrate"


### PR DESCRIPTION
```sql
ALTER TYPE name RENAME VALUE existing_enum_value TO new_enum_value;
```

made possible by https://commitfest.postgresql.org/10/588
solution found on https://stackoverflow.com/a/45444822/6897682

this is only compatible with PostgreSQL 10+

docu: https://www.postgresql.org/docs/10/static/sql-altertype.html