### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ exports.up = pgm => {
     },
     body: { type: "text", notNull: true },
     createdAt: {
-      type: "",
+      type: "timestamp",
       notNull: true,
       default: pgm.func("current_timestamp")
     }


### PR DESCRIPTION
I was working through the example in the readme file and got stuck because `"timestamp"` was missing.