### PR TITLE
Fix migration name substitution

### DIFF
--- a/bin/node-pg-migrate
+++ b/bin/node-pg-migrate
@@ -250,7 +250,7 @@ if (action === "create") {
   // replaces spaces with dashes - should help fix some errors
   let newMigrationName = argv._.length ? argv._.join("-") : "";
   // forces use of dashes in names - keep thing clean
-  newMigrationName = newMigrationName.replace(/_ /g, "-");
+  newMigrationName = newMigrationName.replace(/_/g, "-");
 
   if (!newMigrationName) {
     console.log("'migrationName' is required.");


### PR DESCRIPTION
Faulty regex from the beginning of the project ([here](https://github.com/salsita/node-pg-migrate/commit/c45c134ac8d09998ba36d0c94f6c60f391bfad59#diff-ce8a2ea7cd9adb478caf84a5d1b79f42R91))