### PR TITLE
Fix empty migration files (#399)

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -55,10 +55,14 @@ module.exports = class Migration {
 
     // copy the default migration template to the new file location
     // eslint-disable-next-line security/detect-non-literal-fs-filename
-    fs.createReadStream(
-      path.resolve(__dirname, `./migration-template.${suffix}`)
-      // eslint-disable-next-line security/detect-non-literal-fs-filename
-    ).pipe(fs.createWriteStream(newFile));
+    await new Promise(resolve => {
+      fs.createReadStream(
+        path.resolve(__dirname, `./migration-template.${suffix}`)
+      )
+        // eslint-disable-next-line security/detect-non-literal-fs-filename
+        .pipe(fs.createWriteStream(newFile))
+        .on("end", resolve);
+    });
 
     return new Migration(null, newFile);
   }


### PR DESCRIPTION
Fixes https://github.com/salsita/node-pg-migrate/issues/399.

Waits for file copy to be done before exiting.