### PR TITLE
update template files

### DIFF
--- a/lib/migration-template.js
+++ b/lib/migration-template.js
@@ -1,3 +1,5 @@
+/* eslint-disable camelcase */
+
 exports.shorthands = undefined;
 
 exports.up = (pgm) => {

--- a/lib/migration-template.ts
+++ b/lib/migration-template.ts
@@ -1,11 +1,10 @@
+/* eslint-disable @typescript-eslint/camelcase */
 import { MigrationBuilder } from 'node-pg-migrate';
 
 export const shorthands = undefined;
 
-export const up = (pgm: MigrationBuilder) => {
+export async function up(pgm: MigrationBuilder): Promise<void> {
+}
 
-};
-
-export const down = (pgm: MigrationBuilder) => {
-
-};
+export async function down(pgm: MigrationBuilder): Promise<void> {
+}


### PR DESCRIPTION
This is what we currently use, satisfying our linting rules:
* snake_case names for columns are quite standard in SQL, so don't have eslint complain about them
* add return type to the TypeScript functions