### PR TITLE
Various improvements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,27 +1,26 @@
 module.exports = {
   extends: [
-    "eslint:recommended",
-    "eslint-config-airbnb-base",
-    "plugin:import/errors",
-    "plugin:import/warnings",
-    "plugin:security/recommended",
-    "plugin:prettier/recommended"
+    'eslint:recommended',
+    'eslint-config-airbnb-base',
+    'plugin:import/errors',
+    'plugin:import/warnings',
+    'plugin:security/recommended',
+    'plugin:prettier/recommended'
   ],
-  parser: "babel-eslint",
+  parser: 'babel-eslint',
   env: {
     node: true,
     mocha: true
   },
   rules: {
-    "no-console": 0,
-    "no-underscore-dangle": 0,
-    "security/detect-object-injection": 0,
-    "import/no-extraneous-dependencies": [
-      "error",
+    'no-underscore-dangle': 0,
+    'security/detect-object-injection': 0,
+    'import/no-extraneous-dependencies': [
+      'error',
       {
-        devDependencies: ["mocha.bootstrap.js", "/test/**"]
+        devDependencies: ['mocha.bootstrap.js', '/test/**']
       }
     ]
   },
-  plugins: ["import", "security"]
+  plugins: ['import', 'security']
 };

--- a/bin/node-pg-migrate
+++ b/bin/node-pg-migrate
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-/* eslint-disable strict */
+/* eslint-disable strict, no-console */
 
 'use strict';
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -21,5 +21,6 @@ which takes options argument with following structure (similar to [command line 
 - `noLock` _[boolean]_ - Disables locking mechanism and checks
 - `fake` _[boolean]_ - Mark migrations as run without actually performing them (use with caution!)
 - `dryRun` _[boolean]_
-- `log` _[function]_ - Redirect log messages to this function, rather than `console.log`
+- `log` _[function]_ - Redirect log messages to this function, rather than `console`
+- `logger` _[object with debug/info/warn/error methods]_ - Redirect messages to this logger object, rather than `console`
 - `decamelize` _[boolean]_ - Runs [`decamelize`](https://github.com/sindresorhus/decamelize) on table/column/etc. names (experimental)

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -23,7 +23,7 @@
   - `replace` _[boolean]_ - create or replace function
   - `window` _[boolean]_ - window function
   - `behavior` _[string]_ - `IMMUTABLE`, `STABLE`, or `VOLATILE`
-  - `strict` _[boolean]_ - `RETURNS NULL ON NULL INPUT`
+  - `strict` _[boolean]_ - `RETURNS NULL/CALLED ON NULL INPUT`
   - `onNull` _[string]_ (deprecated) - alias for `strict`, also accepts `NULL` or `CALLED`
   - `parallel` _[string]_ - `UNSAFE`, `RESTRICTED`, or `SAFE`
   - `cost` _[number]_ - estimated execution cost
@@ -45,6 +45,26 @@
 - `drop_options` _[object]_ - options:
   - `ifExists` _[boolean]_ - drops function only if it exists
   - `cascade` _[boolean]_ - drops also dependent objects
+
+---
+
+### `pgm.alterFunction( function_name, function_params, function_options )`
+
+> Alter a function - [postgres docs](http://www.postgresql.org/docs/current/static/sql-alterfunction.html)
+
+**Arguments:**
+
+- `function_name` _[[Name](migrations.md#type)]_ - name of the function to drop
+- `function_params` _[array]_ - [see](#pgmcreatefunction-function_name-function_params-function_options-definition-)
+- `function_options` _[object]_ - options:
+  - `owner` _[string]_ - the new owner of the function
+  - `window` _[boolean]_ - window function
+  - `behavior` _[string]_ - `IMMUTABLE`, `STABLE`, or `VOLATILE`
+  - `strict` _[boolean]_ - `RETURNS NULL/CALLED ON NULL INPUT`
+  - `onNull` _[string]_ (deprecated) - alias for `strict`, also accepts `NULL` or `CALLED`
+  - `parallel` _[string]_ - `UNSAFE`, `RESTRICTED`, or `SAFE`
+  - `cost` _[number]_ - estimated execution cost
+  - `rows` _[number]_ - estimated number of result rows
 
 ---
 

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -23,8 +23,11 @@
   - `replace` _[boolean]_ - create or replace function
   - `window` _[boolean]_ - window function
   - `behavior` _[string]_ - `IMMUTABLE`, `STABLE`, or `VOLATILE`
-  - `onNull` _[boolean]_ - `RETURNS NULL ON NULL INPUT`
+  - `strict` _[boolean]_ - `RETURNS NULL ON NULL INPUT`
+  - `onNull` _[string]_ (deprecated) - alias for `strict`, also accepts `NULL` or `CALLED`
   - `parallel` _[string]_ - `UNSAFE`, `RESTRICTED`, or `SAFE`
+  - `cost` _[number]_ - estimated execution cost
+  - `rows` _[number]_ - estimated number of result rows
 - `definition` _[string]_ - definition of function
 
 **Reverse Operation:** `dropFunction`

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -28,6 +28,7 @@
   - `parallel` _[string]_ - `UNSAFE`, `RESTRICTED`, or `SAFE`
   - `cost` _[number]_ - estimated execution cost
   - `rows` _[number]_ - estimated number of result rows
+  - `comment` _[string]_ - comment on function
 - `definition` _[string]_ - definition of function
 
 **Reverse Operation:** `dropFunction`
@@ -65,6 +66,7 @@
   - `parallel` _[string]_ - `UNSAFE`, `RESTRICTED`, or `SAFE`
   - `cost` _[number]_ - estimated execution cost
   - `rows` _[number]_ - estimated number of result rows
+  - `comment` _[string]_ - comment on function
 
 ---
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -41,7 +41,7 @@ Another way how to perform some async operation is to return [Promise](https://p
 
 ```javascript
 exports.up = function(pgm) {
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
     // doSomethingAsync
     resolve();
   });

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -14,6 +14,7 @@
   - `role` _[string or array]_ - the role(s) to which the policy is to be applied
   - `using` _[string]_ - SQL conditional expression for visibility check
   - `check` _[string]_ - SQL conditional expression for insert/update check
+  - `comment` _[string or null]_ - comment on the policy
 
 **Reverse Operation:** `dropPolicy`
 
@@ -44,6 +45,7 @@
   - `role` _[string or array]_ - the role(s) to which the policy is to be applied
   - `using` _[string]_ - SQL conditional expression for visibility check
   - `check` _[string]_ - SQL conditional expression for insert/update check
+  - `comment` _[string or null]_ - comment on the policy
 
 ---
 

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -9,6 +9,7 @@
 - `tableName` _[[Name](migrations.md#type)]_ - name of the table to alter
 - `policyName` _[string]_ - name of the new policy
 - `options` _[object]_ - options:
+  - `restrictive` _[boolean]_ - `RESTRICTIVE` instead of `PERMISSIVE`
   - `command` _[string]_ - `ALL`, `SELECT`, `INSERT`, `UPDATE`, or `DELETE`
   - `role` _[string or array]_ - the role(s) to which the policy is to be applied
   - `using` _[string]_ - SQL conditional expression for visibility check

--- a/index.d.ts
+++ b/index.d.ts
@@ -260,11 +260,7 @@ export interface FunctionParamType {
 }
 
 export type FunctionParam = string | FunctionParamType
-
-export interface FunctionOptions {
-    returns?: string
-    language: string
-    replace?: boolean
+interface FunctionOptions {
     window?: boolean
     behavior?: 'IMMUTABLE' | 'STABLE' | 'VOLATILE' | 'LEAKPROOF'
     onNull?: boolean | 'NULL' | 'CALLED'
@@ -274,6 +270,20 @@ export interface FunctionOptions {
     cost?: number
     rows?: number
 }
+
+interface CreateFunctionOptionsEn {
+    returns?: string
+    language: string
+    replace?: boolean
+}
+
+interface AlterFunctionOptionsEn {
+    owner?: string
+}
+
+export type CreateFunctionOptions = CreateFunctionOptionsEn & FunctionOptions
+
+export type AlterFunctionOptions = AlterFunctionOptionsEn & FunctionOptions
 
 interface TriggerOptions {
     when?: 'BEFORE' | 'AFTER' | 'INSTEAD OF'
@@ -470,13 +480,14 @@ export interface MigrationBuilder {
     renameRole(oldRoleName: Name, newRoleName: Name): void
 
     // Functions
-    createFunction(functionName: Name, functionParams: FunctionParam[], functionOptions: FunctionOptions, definition: Value): void
+    createFunction(functionName: Name, functionParams: FunctionParam[], functionOptions: CreateFunctionOptions, definition: Value): void
     dropFunction(functionName: Name, functionParams: FunctionParam[], dropOptions?: DropOptions): void
+    alterFunction(functionName: Name, functionParams: FunctionParam[], functionOptions: AlterFunctionOptions): void
     renameFunction(oldFunctionName: Name, functionParams: FunctionParam[], newFunctionName: Name): void
 
     // Triggers
     createTrigger(tableName: Name, triggerName: Name, triggerOptions: TriggerOptions): void
-    createTrigger(tableName: Name, triggerName: Name, triggerOptions: TriggerOptions & FunctionOptions, definition: Value): void
+    createTrigger(tableName: Name, triggerName: Name, triggerOptions: TriggerOptions & CreateFunctionOptions, definition: Value): void
     dropTrigger(tableName: Name, triggerName: Name, dropOptions?: DropOptions): void
     renameTrigger(tableName: Name, oldTriggerName: Name, newTriggerName: Name): void
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -269,6 +269,7 @@ interface FunctionOptions {
     parallel?: 'UNSAFE' | 'RESTRICTED' | 'SAFE'
     cost?: number
     rows?: number
+    comment?: string | null
 }
 
 interface CreateFunctionOptionsEn {

--- a/index.d.ts
+++ b/index.d.ts
@@ -267,8 +267,12 @@ export interface FunctionOptions {
     replace?: boolean
     window?: boolean
     behavior?: 'IMMUTABLE' | 'STABLE' | 'VOLATILE'
-    onNull?: boolean
+    onNull?: boolean | 'NULL' | 'CALLED'
+    strict?: boolean
+    security?: 'DEFINER' | 'INVOKER'
     parallel?: 'UNSAFE' | 'RESTRICTED' | 'SAFE'
+    cost?: number
+    rows?: number
 }
 
 interface TriggerOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ export type Action = 'NO ACTION' | 'RESTRICT' | 'CASCADE' | 'SET NULL' | 'SET DE
 
 export interface ReferencesOptions {
     referencesConstraintName?: string
-    referencesConstraintComment?: string
+    referencesConstraintComment?: string | null
     references?: Name
     onDelete?: Action
     onUpdate?: Action
@@ -38,7 +38,7 @@ export interface ConstraintOptions {
     exclude?: string
     deferrable?: boolean
     deferred?: boolean
-    comment?: string
+    comment?: string | null
 }
 
 export interface ColumnDefinition extends ReferencesOptions {
@@ -374,8 +374,9 @@ export interface OperatorListDefinition {
 
 export interface PolicyOptions {
     role: string | string[]
-    using: string
-    check: string
+    using?: string
+    check?: string
+    comment?: string | null
 }
 
 export interface CreatePolicyOptionsEn {

--- a/index.d.ts
+++ b/index.d.ts
@@ -576,6 +576,7 @@ export interface RunnerOptionClient {
     dbClient: Client
 }
 
+export type LogFn = (msg:string) => void
 export interface RunnerOptionConfig {
     migrationsTable: string
     migrationsSchema?: string
@@ -591,10 +592,11 @@ export interface RunnerOptionConfig {
     createSchema?: boolean
     createMigrationsSchema?: boolean
     singleTransaction?: boolean
-    noLock?: boolean,
-    fake?: boolean,
-    decamelize?: boolean,
-    log?: (msg:string) => void;
+    noLock?: boolean
+    fake?: boolean
+    decamelize?: boolean
+    log?: LogFn
+    logger?: { debug: LogFn; info: LogFn; warn: LogFn; error: LogFn }
 }
 
 export type RunnerOption = RunnerOptionConfig & (RunnerOptionClient | RunnerOptionUrl)

--- a/index.d.ts
+++ b/index.d.ts
@@ -368,7 +368,8 @@ export interface PolicyOptions {
 }
 
 export interface CreatePolicyOptionsEn {
-    command: 'ALL' | 'SELECT' | 'INSERT' | 'UPDATE' | 'DELETE'
+    restrictive?: boolean
+    command?: 'ALL' | 'SELECT' | 'INSERT' | 'UPDATE' | 'DELETE'
 }
 
 export type CreatePolicyOptions = CreatePolicyOptionsEn & PolicyOptions

--- a/index.d.ts
+++ b/index.d.ts
@@ -266,7 +266,7 @@ export interface FunctionOptions {
     language: string
     replace?: boolean
     window?: boolean
-    behavior?: 'IMMUTABLE' | 'STABLE' | 'VOLATILE'
+    behavior?: 'IMMUTABLE' | 'STABLE' | 'VOLATILE' | 'LEAKPROOF'
     onNull?: boolean | 'NULL' | 'CALLED'
     strict?: boolean
     security?: 'DEFINER' | 'INVOKER'

--- a/lib/db.js
+++ b/lib/db.js
@@ -6,7 +6,7 @@ const pg = require('pg');
 // or native libpq bindings
 // const pg = require('pg/native');
 
-module.exports = (connection, log = console.error) => {
+module.exports = (connection, logger = console) => {
   const isExternalClient = connection instanceof pg.Client;
   let clientActive = false;
 
@@ -20,7 +20,7 @@ module.exports = (connection, log = console.error) => {
         ? resolve()
         : client.connect(err => {
             if (err) {
-              log('could not connect to postgres', err);
+              logger.error('could not connect to postgres', err);
               return reject(err);
             }
             clientActive = true;
@@ -43,14 +43,14 @@ module.exports = (connection, log = console.error) => {
         const stringEnd = string.substr(endLineWrapPos);
         const startLineWrapPos = stringStart.lastIndexOf('\n') + 1;
         const padding = ' '.repeat(position - startLineWrapPos - 1);
-        log(`Error executing:
+        logger.error(`Error executing:
 ${stringStart}
 ${padding}^^^^${stringEnd}
 
 ${message}
 `);
       } else {
-        log(`Error executing:
+        logger.error(`Error executing:
 ${string}
 ${err}
 `);
@@ -77,7 +77,7 @@ ${err}
     close: async () => {
       await beforeCloseListeners.reduce(
         (promise, listener) =>
-          promise.then(listener).catch(err => log(err.stack || err)),
+          promise.then(listener).catch(err => logger.error(err.stack || err)),
         Promise.resolve()
       );
       if (!isExternalClient) {

--- a/lib/migration-builder.js
+++ b/lib/migration-builder.js
@@ -101,6 +101,7 @@ module.exports = class MigrationBuilder {
 
     this.createFunction = wrap(functions.createFunction(options));
     this.dropFunction = wrap(functions.dropFunction(options));
+    this.alterFunction = wrap(functions.alterFunction(options));
     this.renameFunction = wrap(functions.renameFunction(options));
 
     this.createTrigger = wrap(triggers.createTrigger(options));

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -73,7 +73,7 @@ module.exports = class Migration {
     { up, down } = {},
     options = {},
     typeShorthands,
-    log = console.log
+    logger = console
   ) {
     this.db = db;
     this.path = migrationPath;
@@ -83,7 +83,7 @@ module.exports = class Migration {
     this.down = down;
     this.options = options;
     this.typeShorthands = typeShorthands;
-    this.log = log;
+    this.logger = logger;
   }
 
   _getMarkAsRun(action) {
@@ -92,10 +92,10 @@ module.exports = class Migration {
     const { name } = this;
     switch (action) {
       case this.down:
-        this.log(`### MIGRATION ${this.name} (DOWN) ###`);
+        this.logger.info(`### MIGRATION ${this.name} (DOWN) ###`);
         return `DELETE FROM "${schema}"."${migrationsTable}" WHERE name='${name}';`;
       case this.up:
-        this.log(`### MIGRATION ${this.name} (UP) ###`);
+        this.logger.info(`### MIGRATION ${this.name} (UP) ###`);
         return `INSERT INTO "${schema}"."${migrationsTable}" (name, run_on) VALUES ('${name}', NOW());`;
       default:
         throw new Error('Unknown direction');
@@ -119,14 +119,16 @@ module.exports = class Migration {
       sqlSteps.push('COMMIT;');
     } else if (this.options.singleTransaction && !pgm.isUsingTransaction()) {
       // in singleTransaction mode we are already wrapped in a global transaction
-      this.log('#> WARNING: Need to break single transaction! <');
+      this.logger.warn('#> WARNING: Need to break single transaction! <');
       sqlSteps.unshift('COMMIT;');
       sqlSteps.push('BEGIN;');
     } else if (!this.options.singleTransaction || !pgm.isUsingTransaction()) {
-      this.log('#> WARNING: This migration is not wrapped in a transaction! <');
+      this.logger.warn(
+        '#> WARNING: This migration is not wrapped in a transaction! <'
+      );
     }
 
-    this.log(`${sqlSteps.join('\n')}\n\n`);
+    this.logger.debug(`${sqlSteps.join('\n')}\n\n`);
 
     return sqlSteps.reduce(
       (promise, sql) =>

--- a/lib/operations/functions.js
+++ b/lib/operations/functions.js
@@ -3,7 +3,7 @@ const { escapeValue, formatParams } = require('../utils');
 function getOptionString(functionOptions) {
   const {
     window,
-    behavior = 'VOLATILE',
+    behavior,
     onNull,
     strict,
     security,
@@ -19,8 +19,14 @@ function getOptionString(functionOptions) {
   if (window) {
     options.push('WINDOW');
   }
-  if (onNull === true || onNull === 'NULL' || strict) {
-    options.push('RETURNS NULL ON NULL INPUT');
+  if (typeof onNull !== 'undefined' || typeof strict !== 'undefined') {
+    options.push(
+      `${
+        onNull === true || onNull === 'NULL' || strict
+          ? 'RETURNS NULL'
+          : 'CALLED'
+      } ON NULL INPUT`
+    );
   }
   if (security) {
     options.push(`SECURITY ${security}`);
@@ -80,6 +86,24 @@ function createFunction(mOptions) {
   return _create;
 }
 
+function alterFunction(mOptions) {
+  const _alter = (functionName, functionParams = [], functionOptions) => {
+    const idStr =
+      mOptions.literal(functionName) + formatParams(functionParams, mOptions);
+    const stmts = [];
+    const options = getOptionString(functionOptions);
+    if (functionOptions.owner) {
+      stmts.push(`ALTER FUNCTION ${idStr}
+  OWNER TO ${functionOptions.owner};`);
+    }
+    if (options) {
+      stmts.push(`ALTER FUNCTION ${idStr}${options};`);
+    }
+    return stmts.join('\n');
+  };
+  return _alter;
+}
+
 function renameFunction(mOptions) {
   const _rename = (oldName, functionParams = [], newName) => {
     const paramsStr = formatParams(functionParams, mOptions);
@@ -112,5 +136,6 @@ function renameFunction(mOptions) {
 module.exports = {
   createFunction,
   dropFunction,
+  alterFunction,
   renameFunction
 };

--- a/lib/operations/functions.js
+++ b/lib/operations/functions.js
@@ -83,11 +83,28 @@ function createFunction(mOptions) {
 }
 
 function renameFunction(mOptions) {
-  const _rename = (oldFunctionName, functionParams = [], newFunctionName) => {
+  const _rename = (oldName, functionParams = [], newName) => {
     const paramsStr = formatParams(functionParams, mOptions);
-    const oldFunctionNameStr = mOptions.literal(oldFunctionName);
-    const newFunctionNameStr = mOptions.literal(newFunctionName);
-    return `ALTER FUNCTION ${oldFunctionNameStr}${paramsStr} RENAME TO ${newFunctionNameStr};`;
+    let oldFn = typeof oldName === 'string' ? { name: oldName } : oldName;
+    const newFn = typeof newName === 'string' ? { name: newName } : newName;
+
+    const stmts = [];
+    if (newFn.schema && newFn.schema !== oldFn.schema) {
+      const oldFunctionNameStr = mOptions.literal(oldFn);
+      const newFunctionSchemaStr = mOptions.literal(newFn.schema);
+      stmts.push(
+        `ALTER FUNCTION ${oldFunctionNameStr}${paramsStr} SET SCHEMA ${newFunctionSchemaStr};`
+      );
+      oldFn = { ...oldFn, schema: newFn.schema };
+    }
+    if (newFn.name !== oldFn.name) {
+      const oldFunctionNameStr = mOptions.literal(oldFn);
+      const newFunctionNameStr = mOptions.literal(newFn.name);
+      stmts.push(
+        `ALTER FUNCTION ${oldFunctionNameStr}${paramsStr} RENAME TO ${newFunctionNameStr};`
+      );
+    }
+    return stmts.join('\n');
   };
   _rename.reverse = (oldFunctionName, functionParams, newFunctionName) =>
     _rename(newFunctionName, functionParams, oldFunctionName);

--- a/lib/operations/functions.js
+++ b/lib/operations/functions.js
@@ -1,4 +1,4 @@
-const { escapeValue, formatParams } = require('../utils');
+const { escapeValue, formatParams, comment: makeComment } = require('../utils');
 
 function getOptionString(functionOptions) {
   const {
@@ -67,7 +67,7 @@ function createFunction(mOptions) {
     functionOptions = {},
     definition
   ) => {
-    const { replace, returns = 'void', language } = functionOptions;
+    const { replace, returns = 'void', language, comment } = functionOptions;
     const replaceStr = replace ? ' OR REPLACE' : '';
     const paramsStr = formatParams(functionParams, mOptions);
     const functionNameStr = mOptions.literal(functionName);
@@ -77,10 +77,16 @@ function createFunction(mOptions) {
         `Language for function ${functionNameStr} have to be specified`
       );
     }
-    return `CREATE${replaceStr} FUNCTION ${functionNameStr}${paramsStr}
+    const stmts = [
+      `CREATE${replaceStr} FUNCTION ${functionNameStr}${paramsStr}
   RETURNS ${returns}
   LANGUAGE ${language}
-  AS ${escapeValue(definition)}${getOptionString(functionOptions)};`;
+  AS ${escapeValue(definition)}${getOptionString(functionOptions)};`
+    ];
+    if (typeof comment !== 'undefined') {
+      stmts.push(makeComment('FUNCTION', functionNameStr + paramsStr, comment));
+    }
+    return stmts.join('\n');
   };
   _create.reverse = dropFunction(mOptions);
   return _create;
@@ -90,14 +96,18 @@ function alterFunction(mOptions) {
   const _alter = (functionName, functionParams = [], functionOptions) => {
     const idStr =
       mOptions.literal(functionName) + formatParams(functionParams, mOptions);
-    const stmts = [];
+    const { owner, comment } = functionOptions;
     const options = getOptionString(functionOptions);
-    if (functionOptions.owner) {
+    const stmts = [];
+    if (owner) {
       stmts.push(`ALTER FUNCTION ${idStr}
-  OWNER TO ${functionOptions.owner};`);
+  OWNER TO ${owner};`);
     }
     if (options) {
       stmts.push(`ALTER FUNCTION ${idStr}${options};`);
+    }
+    if (typeof comment !== 'undefined') {
+      stmts.push(makeComment('FUNCTION', idStr, comment));
     }
     return stmts.join('\n');
   };

--- a/lib/operations/functions.js
+++ b/lib/operations/functions.js
@@ -1,5 +1,44 @@
 const { escapeValue, formatParams } = require('../utils');
 
+function getOptionString(functionOptions) {
+  const {
+    window,
+    behavior = 'VOLATILE',
+    onNull,
+    strict,
+    security,
+    parallel,
+    cost,
+    rows,
+    support
+  } = functionOptions;
+  const options = [];
+  if (behavior) {
+    options.push(behavior);
+  }
+  if (window) {
+    options.push('WINDOW');
+  }
+  if (onNull === true || onNull === 'NULL' || strict) {
+    options.push('RETURNS NULL ON NULL INPUT');
+  }
+  if (security) {
+    options.push(`SECURITY ${security}`);
+  }
+  if (parallel) {
+    options.push(`PARALLEL ${parallel}`);
+  }
+  if (typeof cost !== 'undefined') {
+    options.push(`COST ${cost}`);
+  }
+  if (typeof rows !== 'undefined') {
+    options.push(`ROWS ${rows}`);
+  }
+  if (support) {
+    options.push(`SUPPORT ${support}`);
+  }
+  return options.map(o => `\n  ${o}`).join('');
+}
 function dropFunction(mOptions) {
   const _drop = (
     functionName,
@@ -22,61 +61,20 @@ function createFunction(mOptions) {
     functionOptions = {},
     definition
   ) => {
-    const {
-      replace,
-      returns = 'void',
-      language,
-      window,
-      behavior = 'VOLATILE',
-      onNull,
-      strict,
-      security,
-      parallel,
-      cost,
-      rows,
-      support
-    } = functionOptions;
-    const options = [];
-    if (behavior) {
-      options.push(behavior);
-    }
-    if (language) {
-      options.push(`LANGUAGE ${language}`);
-    } else {
-      throw new Error(
-        `Language for function ${functionName} have to be specified`
-      );
-    }
-    if (window) {
-      options.push('WINDOW');
-    }
-    if (onNull === true || onNull === 'NULL' || strict) {
-      options.push('RETURNS NULL ON NULL INPUT');
-    }
-    if (security) {
-      options.push(`SECURITY ${security}`);
-    }
-    if (parallel) {
-      options.push(`PARALLEL ${parallel}`);
-    }
-    if (typeof cost !== 'undefined') {
-      options.push(`COST ${cost}`);
-    }
-    if (typeof rows !== 'undefined') {
-      options.push(`ROWS ${rows}`);
-    }
-    if (support) {
-      options.push(`SUPPORT ${support}`);
-    }
-
+    const { replace, returns = 'void', language } = functionOptions;
     const replaceStr = replace ? ' OR REPLACE' : '';
     const paramsStr = formatParams(functionParams, mOptions);
     const functionNameStr = mOptions.literal(functionName);
 
+    if (!language) {
+      throw new Error(
+        `Language for function ${functionNameStr} have to be specified`
+      );
+    }
     return `CREATE${replaceStr} FUNCTION ${functionNameStr}${paramsStr}
   RETURNS ${returns}
-  AS ${escapeValue(definition)}
-  ${options.join('\n  ')};`;
+  LANGUAGE ${language}
+  AS ${escapeValue(definition)}${getOptionString(functionOptions)};`;
   };
   _create.reverse = dropFunction(mOptions);
   return _create;

--- a/lib/operations/functions.js
+++ b/lib/operations/functions.js
@@ -29,7 +29,12 @@ function createFunction(mOptions) {
       window,
       behavior = 'VOLATILE',
       onNull,
-      parallel
+      strict,
+      security,
+      parallel,
+      cost,
+      rows,
+      support
     } = functionOptions;
     const options = [];
     if (behavior) {
@@ -45,11 +50,23 @@ function createFunction(mOptions) {
     if (window) {
       options.push('WINDOW');
     }
-    if (onNull) {
+    if (onNull === true || onNull === 'NULL' || strict) {
       options.push('RETURNS NULL ON NULL INPUT');
+    }
+    if (security) {
+      options.push(`SECURITY ${security}`);
     }
     if (parallel) {
       options.push(`PARALLEL ${parallel}`);
+    }
+    if (typeof cost !== 'undefined') {
+      options.push(`COST ${cost}`);
+    }
+    if (typeof rows !== 'undefined') {
+      options.push(`ROWS ${rows}`);
+    }
+    if (support) {
+      options.push(`SUPPORT ${support}`);
     }
 
     const replaceStr = replace ? ' OR REPLACE' : '';

--- a/lib/operations/policies.js
+++ b/lib/operations/policies.js
@@ -1,5 +1,5 @@
 const makeClauses = ({ role, using, check }) => {
-  const roles = (Array.isArray(role) ? role : [role]).join(', ');
+  const roles = Array.isArray(role) ? role.join(', ') : role;
   const clauses = [];
   if (roles) {
     clauses.push(`TO ${roles}`);
@@ -30,6 +30,7 @@ function createPolicy(mOptions) {
       role: options.role || 'PUBLIC'
     };
     const clauses = [
+      `AS ${options.restrictive ? 'RESTRICTIVE' : 'PERMISSIVE'}`,
       `FOR ${options.command || 'ALL'}`,
       ...makeClauses(createOptions)
     ];

--- a/lib/operations/policies.js
+++ b/lib/operations/policies.js
@@ -30,10 +30,14 @@ function createPolicy(mOptions) {
       role: options.role || 'PUBLIC'
     };
     const clauses = [
-      `AS ${options.restrictive ? 'RESTRICTIVE' : 'PERMISSIVE'}`,
       `FOR ${options.command || 'ALL'}`,
       ...makeClauses(createOptions)
     ];
+    // by default, don't add the 'PERMISSIVE' clause, for Postgres <10
+    if (typeof options.restrictive === 'boolean')
+      clauses.unshift(
+        `AS ${options.restrictive ? 'RESTRICTIVE' : 'PERMISSIVE'}`
+      );
     const clausesStr = clauses.join(' ');
     const policyNameStr = mOptions.literal(policyName);
     const tableNameStr = mOptions.literal(tableName);

--- a/lib/operations/policies.js
+++ b/lib/operations/policies.js
@@ -1,3 +1,5 @@
+const { comment } = require('../utils');
+
 const makeClauses = ({ role, using, check }) => {
   const roles = Array.isArray(role) ? role.join(', ') : role;
   const clauses = [];
@@ -41,7 +43,14 @@ function createPolicy(mOptions) {
     const clausesStr = clauses.join(' ');
     const policyNameStr = mOptions.literal(policyName);
     const tableNameStr = mOptions.literal(tableName);
-    return `CREATE POLICY ${policyNameStr} ON ${tableNameStr} ${clausesStr};`;
+    const stmts = [
+      `CREATE POLICY ${policyNameStr} ON ${tableNameStr} ${clausesStr};`
+    ];
+    if (options.comment)
+      stmts.push(
+        comment(`POLICY ${policyNameStr} ON`, tableNameStr, options.comment)
+      );
+    return stmts.join('\n');
   };
   _create.reverse = dropPolicy(mOptions);
   return _create;
@@ -49,10 +58,19 @@ function createPolicy(mOptions) {
 
 function alterPolicy(mOptions) {
   const _alter = (tableName, policyName, options = {}) => {
-    const clausesStr = makeClauses(options).join(' ');
+    const clauses = makeClauses(options);
     const policyNameStr = mOptions.literal(policyName);
     const tableNameStr = mOptions.literal(tableName);
-    return `ALTER POLICY ${policyNameStr} ON ${tableNameStr} ${clausesStr};`;
+    const stmts = [];
+    if (clauses.length)
+      stmts.push(
+        `ALTER POLICY ${policyNameStr} ON ${tableNameStr} ${clauses.join(' ')};`
+      );
+    if (typeof options.comment !== 'undefined')
+      stmts.push(
+        comment(`POLICY ${policyNameStr} ON`, tableNameStr, options.comment)
+      );
+    return stmts.join('\n');
   };
   return _alter;
 }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -19,7 +19,7 @@ const idColumn = 'id';
 const nameColumn = 'name';
 const runOnColumn = 'run_on';
 
-const loadMigrations = async (db, options, log) => {
+const loadMigrations = async (db, options, logger) => {
   try {
     let shorthands = {};
     const files = await Migration.loadMigrationFiles(
@@ -43,7 +43,7 @@ const loadMigrations = async (db, options, log) => {
         {
           ...shorthands
         },
-        log
+        logger
       );
     });
   } catch (err) {
@@ -163,9 +163,16 @@ const runMigrations = (toRun, method, direction) =>
     Promise.resolve()
   );
 
+const getLogger = ({ log, logger }) => {
+  if (typeof logger === 'object') return logger;
+  if (typeof log === 'function')
+    return { debug: log, info: log, warn: log, error: log };
+  return console;
+};
+
 const runner = async options => {
-  const log = options.log || console.log;
-  const db = Db(options.dbClient || options.databaseUrl, log);
+  const logger = getLogger(options);
+  const db = Db(options.dbClient || options.databaseUrl, logger);
   try {
     await db.createConnection();
     if (options.schema) {
@@ -194,7 +201,7 @@ const runner = async options => {
     }
 
     const [migrations, runNames] = await Promise.all([
-      loadMigrations(db, options, log),
+      loadMigrations(db, options, logger),
       getRunMigrations(db, options)
     ]);
 
@@ -205,14 +212,14 @@ const runner = async options => {
     const toRun = getMigrationsToRun(options, runNames, migrations);
 
     if (!toRun.length) {
-      log('No migrations to run!');
+      logger.warn('No migrations to run!');
       return [];
     }
 
     // TODO: add some fancy colors to logging
-    log('> Migrating files:');
+    logger.info('> Migrating files:');
     toRun.forEach(m => {
-      log(`> - ${m.name}`);
+      logger.info(`> - ${m.name}`);
     });
 
     if (options.fake) {
@@ -223,7 +230,8 @@ const runner = async options => {
         await runMigrations(toRun, 'apply', options.direction);
         await db.query('COMMIT');
       } catch (err) {
-        log('> Rolling back attempted migration ...');
+        logger.error(err);
+        logger.info('> Rolling back attempted migration ...');
         await db.query('ROLLBACK');
         throw err;
       }

--- a/test/db-test.js
+++ b/test/db-test.js
@@ -44,7 +44,7 @@ describe('lib/db', () => {
     });
 
     it('pg.Client should be called with connection string', () => {
-      sandbox.stub(pgMock, 'Client');
+      sandbox.stub(pgMock, 'Client').returns({ end() {} });
       db = Db('connection_string');
       expect(pgMock.Client).to.be.calledWith('connection_string');
     });

--- a/test/functions-test.js
+++ b/test/functions-test.js
@@ -102,4 +102,79 @@ END;$pg1$
       );
     });
   });
+
+  describe('.rename', () => {
+    it('handles all input formats', () => {
+      {
+        const args = [
+          { schema: 'mySchema', name: 'myF' },
+          ['integer', 'custom'],
+          { schema: 'mySchema', name: 'myG' }
+        ];
+        const sql1 = Functions.renameFunction(options1)(...args);
+        const sql2 = Functions.renameFunction(options2)(...args);
+        expect(sql1).to.equal(
+          'ALTER FUNCTION "mySchema"."myF"(integer, custom) RENAME TO "myG";'
+        );
+        expect(sql2).to.equal(
+          'ALTER FUNCTION "my_schema"."my_f"(integer, custom) RENAME TO "my_g";'
+        );
+      }
+      {
+        const sql = Functions.renameFunction(options2)(
+          { schema: 'my_schema', name: 'my_f' },
+          ['integer', 'custom'],
+          'my_g'
+        );
+        expect(sql).to.equal(
+          'ALTER FUNCTION "my_schema"."my_f"(integer, custom) RENAME TO "my_g";'
+        );
+      }
+      {
+        const args = ['myF', ['integer', 'custom'], 'myG'];
+        const sql1 = Functions.renameFunction(options1)(...args);
+        const sql2 = Functions.renameFunction(options2)(...args);
+        expect(sql1).to.equal(
+          'ALTER FUNCTION "myF"(integer, custom) RENAME TO "myG";'
+        );
+        expect(sql2).to.equal(
+          'ALTER FUNCTION "my_f"(integer, custom) RENAME TO "my_g";'
+        );
+      }
+    });
+
+    it('can change schemas', () => {
+      const args = [
+        { schema: 'oldSchema', name: 'myF' },
+        ['integer', 'custom'],
+        { schema: 'newSchema', name: 'myF' }
+      ];
+      const sql1 = Functions.renameFunction(options1)(...args);
+      const sql2 = Functions.renameFunction(options2)(...args);
+      expect(sql1).to.equal(
+        'ALTER FUNCTION "oldSchema"."myF"(integer, custom) SET SCHEMA "newSchema";'
+      );
+      expect(sql2).to.equal(
+        'ALTER FUNCTION "old_schema"."my_f"(integer, custom) SET SCHEMA "new_schema";'
+      );
+    });
+
+    it('can change both schema and name', () => {
+      const args = [
+        { schema: 'oldSchema', name: 'myF' },
+        ['integer', 'custom'],
+        { schema: 'newSchema', name: 'myG' }
+      ];
+      const sql1 = Functions.renameFunction(options1)(...args);
+      const sql2 = Functions.renameFunction(options2)(...args);
+      expect(sql1).to.equal(
+        `ALTER FUNCTION "oldSchema"."myF"(integer, custom) SET SCHEMA "newSchema";
+ALTER FUNCTION "newSchema"."myF"(integer, custom) RENAME TO "myG";`
+      );
+      expect(sql2).to.equal(
+        `ALTER FUNCTION "old_schema"."my_f"(integer, custom) SET SCHEMA "new_schema";
+ALTER FUNCTION "new_schema"."my_f"(integer, custom) RENAME TO "my_g";`
+      );
+    });
+  });
 });

--- a/test/functions-test.js
+++ b/test/functions-test.js
@@ -5,6 +5,15 @@ const { options1, options2 } = require('./utils');
 describe('lib/operations/functions', () => {
   const params = ['integer', { name: 'arg2', mode: 'in', type: 'integer' }];
   describe('.create', () => {
+    it('throws on missing language', () => {
+      expect(() =>
+        Functions.createFunction(options1)(
+          { schema: 'mySchema', name: 'f' },
+          []
+        )
+      ).to.throw();
+    });
+
     it('check schemas can be used', () => {
       const args = [
         { schema: 'mySchema', name: 'f' },
@@ -23,20 +32,20 @@ END;`
       expect(sql1).to.equal(
         `CREATE FUNCTION "mySchema"."f"(integer, in "arg2" integer)
   RETURNS integer
+  LANGUAGE plpgsql
   AS $pg1$BEGIN
   return $1 + arg2;
 END;$pg1$
-  VOLATILE
-  LANGUAGE plpgsql;`
+  VOLATILE;`
       );
       expect(sql2).to.equal(
         `CREATE FUNCTION "my_schema"."f"(integer, in "arg2" integer)
   RETURNS integer
+  LANGUAGE plpgsql
   AS $pg1$BEGIN
   return $1 + arg2;
 END;$pg1$
-  VOLATILE
-  LANGUAGE plpgsql;`
+  VOLATILE;`
       );
     });
 
@@ -57,17 +66,17 @@ END;$pg1$
       expect(sql1).to.equal(
         `CREATE FUNCTION "mySchema"."f"(integer, IN arg2 integer)
   RETURNS integer
+  LANGUAGE sql
   AS $pg1$SELECT $1 + arg2;$pg1$
   IMMUTABLE
-  LANGUAGE sql
   RETURNS NULL ON NULL INPUT;`
       );
       expect(sql2).to.equal(
         `CREATE FUNCTION "my_schema"."f"(integer, IN arg2 integer)
   RETURNS integer
+  LANGUAGE sql
   AS $pg1$SELECT $1 + arg2;$pg1$
   IMMUTABLE
-  LANGUAGE sql
   RETURNS NULL ON NULL INPUT;`
       );
     });
@@ -91,9 +100,9 @@ END;$pg1$
       expect(sql).to.equal(
         `CREATE FUNCTION "myFunction"(a integer, b real)
   RETURNS integer
+  LANGUAGE plpgsql
   AS $pg1$blah-blubb$pg1$
   STABLE
-  LANGUAGE plpgsql
   RETURNS NULL ON NULL INPUT
   SECURITY DEFINER
   PARALLEL RESTRICTED

--- a/test/functions-test.js
+++ b/test/functions-test.js
@@ -1,0 +1,105 @@
+const { expect } = require('chai');
+const Functions = require('../lib/operations/functions');
+const { options1, options2 } = require('./utils');
+
+describe('lib/operations/functions', () => {
+  const params = ['integer', { name: 'arg2', mode: 'in', type: 'integer' }];
+  describe('.create', () => {
+    it('check schemas can be used', () => {
+      const args = [
+        { schema: 'mySchema', name: 'f' },
+        params,
+        {
+          returns: 'integer',
+          language: 'plpgsql',
+          onNull: 'CALLED'
+        },
+        `BEGIN
+  return $1 + arg2;
+END;`
+      ];
+      const sql1 = Functions.createFunction(options1)(...args);
+      const sql2 = Functions.createFunction(options2)(...args);
+      expect(sql1).to.equal(
+        `CREATE FUNCTION "mySchema"."f"(integer, in "arg2" integer)
+  RETURNS integer
+  AS $pg1$BEGIN
+  return $1 + arg2;
+END;$pg1$
+  VOLATILE
+  LANGUAGE plpgsql;`
+      );
+      expect(sql2).to.equal(
+        `CREATE FUNCTION "my_schema"."f"(integer, in "arg2" integer)
+  RETURNS integer
+  AS $pg1$BEGIN
+  return $1 + arg2;
+END;$pg1$
+  VOLATILE
+  LANGUAGE plpgsql;`
+      );
+    });
+
+    it('check param shorthands work', () => {
+      const args = [
+        { schema: 'mySchema', name: 'f' },
+        ['integer', 'IN arg2 integer'],
+        {
+          returns: 'integer',
+          language: 'sql',
+          behavior: 'IMMUTABLE',
+          strict: true
+        },
+        `SELECT $1 + arg2;`
+      ];
+      const sql1 = Functions.createFunction(options1)(...args);
+      const sql2 = Functions.createFunction(options2)(...args);
+      expect(sql1).to.equal(
+        `CREATE FUNCTION "mySchema"."f"(integer, IN arg2 integer)
+  RETURNS integer
+  AS $pg1$SELECT $1 + arg2;$pg1$
+  IMMUTABLE
+  LANGUAGE sql
+  RETURNS NULL ON NULL INPUT;`
+      );
+      expect(sql2).to.equal(
+        `CREATE FUNCTION "my_schema"."f"(integer, IN arg2 integer)
+  RETURNS integer
+  AS $pg1$SELECT $1 + arg2;$pg1$
+  IMMUTABLE
+  LANGUAGE sql
+  RETURNS NULL ON NULL INPUT;`
+      );
+    });
+
+    it('check all PG12 options are supported', () => {
+      const sql = Functions.createFunction(options1)(
+        'myFunction',
+        ['a integer', 'b real'],
+        {
+          returns: 'integer',
+          language: 'plpgsql',
+          behavior: 'STABLE',
+          onNull: 'NULL',
+          security: 'DEFINER',
+          parallel: 'RESTRICTED',
+          cost: 0,
+          rows: 7
+        },
+        'blah-blubb'
+      );
+      expect(sql).to.equal(
+        `CREATE FUNCTION "myFunction"(a integer, b real)
+  RETURNS integer
+  AS $pg1$blah-blubb$pg1$
+  STABLE
+  LANGUAGE plpgsql
+  RETURNS NULL ON NULL INPUT
+  SECURITY DEFINER
+  PARALLEL RESTRICTED
+  COST 0
+  ROWS 7;`
+      );
+    });
+  });
+});

--- a/test/migration-test.js
+++ b/test/migration-test.js
@@ -14,20 +14,23 @@ describe('lib/migration', () => {
   const dbMock = {};
   const log = () => null;
   const options = { migrationsTable };
+  const typeShorthands = {};
+  const logger = { debug: log, info: log, warn: log, error: log };
   let migration;
 
   beforeEach(() => {
     dbMock.query = sinon.spy();
   });
 
-  describe('self.applyUp', () => {
+  describe('.applyUp', () => {
     it('normal operations: db.query should be called', () => {
       migration = new Migration(
         dbMock,
         callbackMigration,
         actionsCallback,
         options,
-        log
+        typeShorthands,
+        logger
       );
       return migration.apply('up').then(() => {
         expect(dbMock.query).to.be.called;
@@ -40,7 +43,8 @@ describe('lib/migration', () => {
         promiseMigration,
         actionsPromise,
         options,
-        log
+        typeShorthands,
+        logger
       );
       return migration.apply('up').then(() => {
         expect(dbMock.query).to.be.called;
@@ -53,7 +57,8 @@ describe('lib/migration', () => {
         callbackMigration,
         actionsCallback,
         { ...options, dryRun: true },
-        log
+        typeShorthands,
+        logger
       );
       return migration.apply('up').then(() => {
         expect(dbMock.query).to.not.be.called;
@@ -66,7 +71,8 @@ describe('lib/migration', () => {
         promiseMigration,
         actionsCallback,
         options,
-        log
+        typeShorthands,
+        logger
       );
       return migration.apply('up').then(() => {
         expect(dbMock.query).to.have.callCount(4);
@@ -80,14 +86,15 @@ describe('lib/migration', () => {
     });
   });
 
-  describe('self.applyDown', () => {
+  describe('.applyDown', () => {
     it('normal operations: db.query should be called', () => {
       migration = new Migration(
         dbMock,
         callbackMigration,
         actionsCallback,
         options,
-        log
+        typeShorthands,
+        logger
       );
       return migration.apply('down').then(() => {
         expect(dbMock.query).to.be.called;
@@ -100,7 +107,8 @@ describe('lib/migration', () => {
         callbackMigration,
         actionsCallback,
         { ...options, dryRun: true },
-        log
+        typeShorthands,
+        logger
       );
       return migration.apply('down').then(() => {
         expect(dbMock.query).to.not.be.called;
@@ -113,7 +121,8 @@ describe('lib/migration', () => {
         promiseMigration,
         actionsCallback,
         options,
-        log
+        typeShorthands,
+        logger
       );
       return migration.apply('down').then(() => {
         expect(dbMock.query).to.have.callCount(4);

--- a/test/migrations/005_table_test.js
+++ b/test/migrations/005_table_test.js
@@ -3,42 +3,41 @@ const table = require('./004_table');
 const schema = process.env.SCHEMA || 'public';
 
 exports.up = pgm =>
-  new Promise((resolve, reject) =>
-    pgm.db
-      .select(
-        `SELECT obj_description(c.oid) as "comment"
-                FROM pg_class c join pg_namespace n ON (c.relnamespace = n.oid)
-                WHERE c.relname = 't2' and c.relkind = 'r' and n.nspname = '${schema}'`
-      )
-      .then(([{ comment }]) =>
-        comment === table.comment ? null : reject(new Error('Comment not set'))
-      )
-      .then(() =>
-        pgm.db
-          .query('SAVEPOINT sp_reference;')
-          .then(() => pgm.db.query('INSERT INTO t2(id2) VALUES (1);'))
-          .then(() => reject(new Error('Missing reference clause')))
-          .catch(() => pgm.db.query('ROLLBACK TO SAVEPOINT sp_reference;'))
-      )
-      .then(() =>
-        pgm.db
-          .query('SAVEPOINT sp_not_null;')
-          .then(() =>
-            pgm.db.query('INSERT INTO t1(created) VALUES (current_timestamp); ')
-          )
-          .then(() => reject(new Error('Missing not null clause')))
-          .catch(() => pgm.db.query('ROLLBACK TO SAVEPOINT sp_not_null;'))
-      )
-      .then(() =>
-        pgm.db.query(
-          "INSERT INTO t1(string) VALUES ('something') RETURNING id;"
+  pgm.db
+    .select(
+      `SELECT obj_description(c.oid) as "comment"
+              FROM pg_class c join pg_namespace n ON (c.relnamespace = n.oid)
+              WHERE c.relname = 't2' and c.relkind = 'r' and n.nspname = '${schema}'`
+    )
+    .then(([{ comment }]) => {
+      if (comment !== table.comment) throw new Error('Comment not set');
+    })
+    .then(() =>
+      pgm.db
+        .query('SAVEPOINT sp_reference;')
+        .then(() => pgm.db.query('INSERT INTO t2(id2) VALUES (1);'))
+        .then(
+          () => Promise.reject(new Error('Missing reference clause')),
+          () => pgm.db.query('ROLLBACK TO SAVEPOINT sp_reference;')
         )
-      )
-      .then(({ rows: [{ id }] }) =>
-        pgm.db.query(`INSERT INTO t2(id2) VALUES (${id});`)
-      )
-      .then(resolve)
-  );
+    )
+    .then(() =>
+      pgm.db
+        .query('SAVEPOINT sp_not_null;')
+        .then(() =>
+          pgm.db.query('INSERT INTO t1(created) VALUES (current_timestamp);')
+        )
+        .then(
+          () => Promise.reject(new Error('Missing not null clause')),
+          () => pgm.db.query('ROLLBACK TO SAVEPOINT sp_not_null;')
+        )
+    )
+    .then(() =>
+      pgm.db.query("INSERT INTO t1(string) VALUES ('something') RETURNING id;")
+    )
+    .then(({ rows: [{ id }] }) =>
+      pgm.db.query(`INSERT INTO t2(id2) VALUES (${id});`)
+    );
 
 exports.down = pgm => {
   pgm.sql('DELETE from t2');

--- a/test/migrations/010_column_test.js
+++ b/test/migrations/010_column_test.js
@@ -1,22 +1,23 @@
 exports.up = pgm =>
-  new Promise((resolve, reject) =>
-    Promise.resolve()
-      .then(() =>
-        pgm.db
-          .query('SAVEPOINT sp_check;')
-          .then(() => pgm.db.query('INSERT INTO t1(nr) VALUES (1);'))
-          .then(() => reject(new Error('Missing check clause')))
-          .catch(() => pgm.db.query('ROLLBACK TO SAVEPOINT sp_check;'))
-      )
-      .then(() => pgm.db.query('INSERT INTO t1(nr) VALUES (20);'))
-      .then(() =>
-        pgm.db
-          .query('SAVEPOINT sp_unique;')
-          .then(() => pgm.db.query('INSERT INTO t1(nr) VALUES (20);'))
-          .then(() => reject(new Error('Missing not unique clause')))
-          .catch(() => pgm.db.query('ROLLBACK TO SAVEPOINT sp_unique;'))
-      )
-      .then(resolve)
-  );
+  Promise.resolve()
+    .then(() =>
+      pgm.db
+        .query('SAVEPOINT sp_check;')
+        .then(() => pgm.db.query('INSERT INTO t1(nr) VALUES (1);'))
+        .then(
+          () => Promise.reject(new Error('Missing check clause')),
+          () => pgm.db.query('ROLLBACK TO SAVEPOINT sp_check;')
+        )
+    )
+    .then(() => pgm.db.query('INSERT INTO t1(nr) VALUES (20);'))
+    .then(() =>
+      pgm.db
+        .query('SAVEPOINT sp_unique;')
+        .then(() => pgm.db.query('INSERT INTO t1(nr) VALUES (20);'))
+        .then(
+          () => Promise.reject(new Error('Missing not unique clause')),
+          () => pgm.db.query('ROLLBACK TO SAVEPOINT sp_unique;')
+        )
+    );
 
 exports.down = () => null;

--- a/test/migrations/013_column_alter_test.js
+++ b/test/migrations/013_column_alter_test.js
@@ -1,14 +1,10 @@
 exports.up = pgm =>
-  new Promise((resolve, reject) =>
-    Promise.resolve()
-      .then(() =>
-        pgm.db
-          .query('SAVEPOINT sp_smallint;')
-          .then(() => pgm.db.query('INSERT INTO t1(nmbr) VALUES (2147483647);'))
-          .then(() => reject(new Error('Type not updated')))
-          .catch(() => pgm.db.query('ROLLBACK TO SAVEPOINT sp_smallint;'))
-      )
-      .then(resolve)
-  );
+  pgm.db
+    .query('SAVEPOINT sp_smallint;')
+    .then(() => pgm.db.query('INSERT INTO t1(nmbr) VALUES (2147483647);'))
+    .then(
+      () => Promise.reject(new Error('Type not updated')),
+      () => pgm.db.query('ROLLBACK TO SAVEPOINT sp_smallint;')
+    );
 
 exports.down = () => null;

--- a/test/migrations/015_add_constraint_test.js
+++ b/test/migrations/015_add_constraint_test.js
@@ -1,15 +1,11 @@
 exports.up = pgm =>
-  new Promise((resolve, reject) =>
-    Promise.resolve()
-      .then(() =>
-        pgm.db
-          .query('SAVEPOINT sp_check;')
-          .then(() => pgm.db.query('INSERT INTO t1(nmbr) VALUES (30);'))
-          .then(() => reject(new Error('Missing check clause')))
-          .catch(() => pgm.db.query('ROLLBACK TO SAVEPOINT sp_check;'))
-      )
-      .then(() => pgm.db.query('INSERT INTO t1(nmbr) VALUES (21);'))
-      .then(resolve)
-  );
+  pgm.db
+    .query('SAVEPOINT sp_check;')
+    .then(() => pgm.db.query('INSERT INTO t1(nmbr) VALUES (30);'))
+    .then(
+      () => Promise.reject(new Error('Missing check clause')),
+      () => pgm.db.query('ROLLBACK TO SAVEPOINT sp_check;')
+    )
+    .then(() => pgm.db.query('INSERT INTO t1(nmbr) VALUES (21);'));
 
 exports.down = () => null;

--- a/test/migrations/026_set_type_attribute_test.js
+++ b/test/migrations/026_set_type_attribute_test.js
@@ -1,14 +1,10 @@
 exports.up = pgm =>
-  new Promise((resolve, reject) =>
-    Promise.resolve()
-      .then(() =>
-        pgm.db
-          .query('SAVEPOINT sp_smallint;')
-          .then(() => pgm.db.query("select (ROW(2147483647, 'x')::obj).id;"))
-          .then(() => reject(new Error('Type not updated')))
-          .catch(() => pgm.db.query('ROLLBACK TO SAVEPOINT sp_smallint;'))
-      )
-      .then(resolve)
-  );
+  pgm.db
+    .query('SAVEPOINT sp_smallint;')
+    .then(() => pgm.db.query("select (ROW(2147483647, 'x')::obj).id;"))
+    .then(
+      () => Promise.reject(new Error('Type not updated')),
+      () => pgm.db.query('ROLLBACK TO SAVEPOINT sp_smallint;')
+    );
 
 exports.down = () => null;

--- a/test/migrations/032_drop_type_attribute_test.js
+++ b/test/migrations/032_drop_type_attribute_test.js
@@ -1,14 +1,10 @@
 exports.up = pgm =>
-  new Promise((resolve, reject) =>
-    Promise.resolve()
-      .then(() =>
-        pgm.db
-          .query('SAVEPOINT sp_attr;')
-          .then(() => pgm.db.query("select (ROW(1, 'x')::obj).str;"))
-          .then(() => reject(new Error('Attribute was not removed')))
-          .catch(() => pgm.db.query('ROLLBACK TO SAVEPOINT sp_attr;'))
-      )
-      .then(resolve)
-  );
+  pgm.db
+    .query('SAVEPOINT sp_attr;')
+    .then(() => pgm.db.query("select (ROW(1, 'x')::obj).str;"))
+    .then(
+      () => Promise.reject(new Error('Attribute was not removed')),
+      () => pgm.db.query('ROLLBACK TO SAVEPOINT sp_attr;')
+    );
 
 exports.down = () => null;

--- a/test/migrations/034_drop_type_test.js
+++ b/test/migrations/034_drop_type_test.js
@@ -1,16 +1,12 @@
 exports.up = pgm =>
-  new Promise((resolve, reject) =>
-    Promise.resolve()
-      .then(() =>
-        pgm.db
-          .query('SAVEPOINT sp_drop;')
-          .then(() =>
-            pgm.db.query('CREATE TEMPORARY TABLE t_list_3 (l list_for_drop);')
-          )
-          .then(() => reject(new Error('Type was not removed')))
-          .catch(() => pgm.db.query('ROLLBACK TO SAVEPOINT sp_drop;'))
-      )
-      .then(resolve)
-  );
+  pgm.db
+    .query('SAVEPOINT sp_drop;')
+    .then(() =>
+      pgm.db.query('CREATE TEMPORARY TABLE t_list_3 (l list_for_drop);')
+    )
+    .then(
+      () => Promise.reject(new Error('Type was not removed')),
+      () => pgm.db.query('ROLLBACK TO SAVEPOINT sp_drop;')
+    );
 
 exports.down = () => null;

--- a/test/migrations/041_function_test.js
+++ b/test/migrations/041_function_test.js
@@ -1,10 +1,6 @@
 exports.up = pgm =>
-  new Promise((resolve, reject) =>
-    pgm.db
-      .select('SELECT add(1,2) as r')
-      .then(([{ r }]) =>
-        r === 3 ? resolve() : reject(new Error('Function does not work'))
-      )
-  );
+  pgm.db.select('SELECT add(1,2) as r').then(([{ r }]) => {
+    if (r !== 3) throw new Error('Function does not work');
+  });
 
 exports.down = () => null;

--- a/test/migrations/044_trigger_test.js
+++ b/test/migrations/044_trigger_test.js
@@ -1,10 +1,8 @@
 exports.up = pgm =>
-  new Promise((resolve, reject) =>
-    pgm.db
-      .select('INSERT INTO tt (a) VALUES (1) RETURNING a')
-      .then(([{ a }]) =>
-        a === 2 ? resolve() : reject(new Error('Trigger does not work'))
-      )
-  );
+  pgm.db
+    .select('INSERT INTO tt (a) VALUES (1) RETURNING a;')
+    .then(([{ a }]) => {
+      if (a !== 2) throw new Error('Trigger does not work');
+    });
 
 exports.down = () => null;

--- a/test/migrations/047_domain_check.js
+++ b/test/migrations/047_domain_check.js
@@ -1,14 +1,10 @@
 exports.up = pgm =>
-  new Promise((resolve, reject) =>
-    Promise.resolve()
-      .then(() =>
-        pgm.db
-          .query('SAVEPOINT sp_check;')
-          .then(() => pgm.db.query('INSERT INTO td (d) VALUES (11);'))
-          .then(() => reject(new Error('Check on domain was not set')))
-          .catch(() => pgm.db.query('ROLLBACK TO SAVEPOINT sp_check;'))
-      )
-      .then(resolve)
-  );
+  pgm.db
+    .query('SAVEPOINT sp_check;')
+    .then(() => pgm.db.query('INSERT INTO td (d) VALUES (11);'))
+    .then(
+      () => Promise.reject(new Error('Check on domain was not set')),
+      () => pgm.db.query('ROLLBACK TO SAVEPOINT sp_check;')
+    );
 
 exports.down = () => null;

--- a/test/migrations/050_sequence_test.js
+++ b/test/migrations/050_sequence_test.js
@@ -1,10 +1,8 @@
 exports.up = pgm =>
-  new Promise((resolve, reject) =>
-    pgm.db
-      .select('INSERT INTO ts DEFAULT VALUES RETURNING id;')
-      .then(([{ id }]) =>
-        id === 10 ? resolve() : reject(new Error('Bad sequence value'))
-      )
-  );
+  pgm.db
+    .select('INSERT INTO ts DEFAULT VALUES RETURNING id;')
+    .then(([{ id }]) => {
+      if (id !== 10) throw new Error('Bad sequence value');
+    });
 
 exports.down = () => null;

--- a/test/migrations/052_sequence_alter_test.js
+++ b/test/migrations/052_sequence_alter_test.js
@@ -1,10 +1,8 @@
 exports.up = pgm =>
-  new Promise((resolve, reject) =>
-    pgm.db
-      .select('INSERT INTO ts DEFAULT VALUES RETURNING id;')
-      .then(([{ id }]) =>
-        id === 20 ? resolve() : reject(new Error('Bad sequence value'))
-      )
-  );
+  pgm.db
+    .select('INSERT INTO ts DEFAULT VALUES RETURNING id;')
+    .then(([{ id }]) => {
+      if (id !== 20) throw new Error('Bad sequence value');
+    });
 
 exports.down = () => null;

--- a/test/migrations/055_operator_test.js
+++ b/test/migrations/055_operator_test.js
@@ -1,10 +1,8 @@
 exports.up = pgm =>
-  new Promise((resolve, reject) =>
-    pgm.db
-      .select('SELECT ROW(1,2)::complex + ROW(3,4)::complex as sum;')
-      .then(([{ sum }]) =>
-        sum === '(4,6)' ? resolve() : reject(new Error('Bad sequence value'))
-      )
-  );
+  pgm.db
+    .select('SELECT ROW(1,2)::complex + ROW(3,4)::complex as sum;')
+    .then(([{ sum }]) => {
+      if (sum !== '(4,6)') throw new Error('Bad sequence value');
+    });
 
 exports.down = () => null;

--- a/test/migrations/058_policy_test.js
+++ b/test/migrations/058_policy_test.js
@@ -1,24 +1,19 @@
 exports.up = pgm =>
-  new Promise((resolve, reject) =>
-    Promise.all([
-      pgm.db.query("INSERT INTO tp(user_name) VALUES ('admin');"),
-      pgm.db.query("INSERT INTO tp(user_name) VALUES ('alice');"),
-      pgm.db.query("INSERT INTO tp(user_name) VALUES ('bob');")
-    ])
-      .then(() => pgm.db.query('set role admin;'))
-      .then(() => pgm.db.select('SELECT * FROM tp;'))
-      .then(
-        ({ length }) =>
-          length === 3 || reject(new Error('Policy is not enforced'))
-      )
-      .then(() => pgm.db.query('set role alice;'))
-      .then(() => pgm.db.select('SELECT * FROM tp;'))
-      .then(
-        ({ length }) =>
-          length === 1 || reject(new Error('Policy is not enforced'))
-      )
-      .then(() => pgm.db.query('reset role;'))
-      .then(resolve)
-  );
+  Promise.all([
+    pgm.db.query("INSERT INTO tp(user_name) VALUES ('admin');"),
+    pgm.db.query("INSERT INTO tp(user_name) VALUES ('alice');"),
+    pgm.db.query("INSERT INTO tp(user_name) VALUES ('bob');")
+  ])
+    .then(() => pgm.db.query('set role admin;'))
+    .then(() => pgm.db.select('SELECT * FROM tp;'))
+    .then(({ length }) => {
+      if (length !== 3) throw new Error('Policy is not enforced');
+    })
+    .then(() => pgm.db.query('set role alice;'))
+    .then(() => pgm.db.select('SELECT * FROM tp;'))
+    .then(({ length }) => {
+      if (length !== 1) throw new Error('Policy is not enforced');
+    })
+    .then(() => pgm.db.query('reset role;'));
 
 exports.down = () => null;

--- a/test/migrations/061_column_comment_test.js
+++ b/test/migrations/061_column_comment_test.js
@@ -4,20 +4,17 @@ const {
 } = require('./060_column_comment');
 
 exports.up = pgm =>
-  new Promise((resolve, reject) =>
-    pgm.db
-      .select(
-        `SELECT d.description
-            FROM pg_description d
-            join information_schema.columns c on (d.objsubid = c.ordinal_position)
-            join pg_class t ON (t.relname = c.table_name and t.relkind = 'r' and d.objoid = t.oid)
-            join pg_namespace n ON (t.relnamespace = n.oid and n.nspname = c.table_schema)
-            WHERE c.column_name = 'id' and c.table_schema = '${schema}' and c.table_name = '${name}';`
-      )
-      .then(([{ description }]) =>
-        description === comment ? null : reject(new Error('Comment not set'))
-      )
-      .then(resolve)
-  );
+  pgm.db
+    .select(
+      `SELECT d.description
+          FROM pg_description d
+          join information_schema.columns c on (d.objsubid = c.ordinal_position)
+          join pg_class t ON (t.relname = c.table_name and t.relkind = 'r' and d.objoid = t.oid)
+          join pg_namespace n ON (t.relnamespace = n.oid and n.nspname = c.table_schema)
+          WHERE c.column_name = 'id' and c.table_schema = '${schema}' and c.table_name = '${name}';`
+    )
+    .then(([{ description }]) => {
+      if (description !== comment) throw new Error('Comment not set');
+    });
 
 exports.down = () => null;

--- a/test/migrations/073_alter_column_comment_test.js
+++ b/test/migrations/073_alter_column_comment_test.js
@@ -4,20 +4,17 @@ const {
 } = require('./072_alter_column_comment');
 
 exports.up = pgm =>
-  new Promise((resolve, reject) =>
-    pgm.db
-      .select(
-        `SELECT d.description
-            FROM pg_description d
-            join information_schema.columns c on (d.objsubid = c.ordinal_position)
-            join pg_class t ON (t.relname = c.table_name and t.relkind = 'r' and d.objoid = t.oid)
-            join pg_namespace n ON (t.relnamespace = n.oid and n.nspname = c.table_schema)
-            WHERE c.column_name = 'id' and c.table_schema = '${schema}' and c.table_name = '${name}';`
-      )
-      .then(([{ description }]) =>
-        description === comment ? null : reject(new Error('Comment not set'))
-      )
-      .then(resolve)
-  );
+  pgm.db
+    .select(
+      `SELECT d.description
+          FROM pg_description d
+          join information_schema.columns c on (d.objsubid = c.ordinal_position)
+          join pg_class t ON (t.relname = c.table_name and t.relkind = 'r' and d.objoid = t.oid)
+          join pg_namespace n ON (t.relnamespace = n.oid and n.nspname = c.table_schema)
+          WHERE c.column_name = 'id' and c.table_schema = '${schema}' and c.table_name = '${name}';`
+    )
+    .then(([{ description }]) => {
+      if (description !== comment) throw new Error('Comment not set');
+    });
 
 exports.down = () => null;

--- a/test/policies-test.js
+++ b/test/policies-test.js
@@ -1,0 +1,51 @@
+const { expect } = require('chai');
+const Policies = require('../lib/operations/policies');
+const { options1, options2 } = require('./utils');
+
+describe('lib/operations/policies', () => {
+  describe('.create', () => {
+    it('check defaults', () => {
+      const args = [{ schema: 'mySchema', name: 'myTableName' }, 'getIn'];
+      const sql1 = Policies.createPolicy(options1)(...args);
+      const sql2 = Policies.createPolicy(options2)(...args);
+      expect(sql1).to.equal(
+        'CREATE POLICY "getIn" ON "mySchema"."myTableName" AS PERMISSIVE FOR ALL TO PUBLIC;'
+      );
+      expect(sql2).to.equal(
+        'CREATE POLICY "get_in" ON "my_schema"."my_table_name" AS PERMISSIVE FOR ALL TO PUBLIC;'
+      );
+    });
+    it('can be restrictive', () => {
+      const args = [
+        { schema: 'my_schema', name: 'my_tablename' },
+        'get_out',
+        { restrictive: true }
+      ];
+      const sql1 = Policies.createPolicy(options1)(...args);
+      const sql2 = Policies.createPolicy(options2)(...args);
+      expect(sql1).to.equal(
+        'CREATE POLICY "get_out" ON "my_schema"."my_tablename" AS RESTRICTIVE FOR ALL TO PUBLIC;'
+      );
+      expect(sql2).to.equal(
+        'CREATE POLICY "get_out" ON "my_schema"."my_tablename" AS RESTRICTIVE FOR ALL TO PUBLIC;'
+      );
+    });
+    it('supports all options', () => {
+      const args = [
+        'my_tablename',
+        'my_allowance',
+        {
+          restrictive: false,
+          command: 'UPDATE',
+          role: 'the_user',
+          using: 'crazy_expression',
+          check: 'curious.function(column)'
+        }
+      ];
+      const sql = Policies.createPolicy(options1)(...args);
+      expect(sql).to.equal(
+        'CREATE POLICY "my_allowance" ON "my_tablename" AS PERMISSIVE FOR UPDATE TO the_user USING (crazy_expression) WITH CHECK (curious.function(column));'
+      );
+    });
+  });
+});

--- a/test/policies-test.js
+++ b/test/policies-test.js
@@ -9,10 +9,10 @@ describe('lib/operations/policies', () => {
       const sql1 = Policies.createPolicy(options1)(...args);
       const sql2 = Policies.createPolicy(options2)(...args);
       expect(sql1).to.equal(
-        'CREATE POLICY "getIn" ON "mySchema"."myTableName" AS PERMISSIVE FOR ALL TO PUBLIC;'
+        'CREATE POLICY "getIn" ON "mySchema"."myTableName" FOR ALL TO PUBLIC;'
       );
       expect(sql2).to.equal(
-        'CREATE POLICY "get_in" ON "my_schema"."my_table_name" AS PERMISSIVE FOR ALL TO PUBLIC;'
+        'CREATE POLICY "get_in" ON "my_schema"."my_table_name" FOR ALL TO PUBLIC;'
       );
     });
     it('can be restrictive', () => {


### PR DESCRIPTION
…or so :-)
From the commit messages:
* implement more function options
* Fix some promise problems
  * new Promise constructor antipattern around promises
  * unhandled rejection caused by calling `end()` on mocked client
* support creation of RESTRICTIVE policies
* test function renames, support moving to schema
* fix bug when the newFunctionName did contain a schema
* refactor function create options
* support ALTER FUNCTION, including owner change
  possibly breaking changes:
  * VOLATILE is no longer a default
  * CALLED ON NULL INPUT gets emitted as soon as `onNull`/`strict` is specified
  * FunctionOptions type is no longer exported
* support comments on functions
* better (configurable) logging
  also fixes migration-tests that did log stuff they shouldn't have logged
* support comments on constraints