### PR TITLE
Updates to docs - specifying schema for trigger_name

### DIFF
--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -7,7 +7,7 @@
 **Arguments:**
 
 - `table_name` _[[Name](migrations.md#type)]_ - name of the table where the new trigger will live
-- `trigger_name` _[[Name](migrations.md#type)]_ - name of the new trigger
+- `trigger_name` _[string]_ - name of the new trigger
 - `trigger_options` _[object]_ - options:
   - `when` _[string]_ - `BEFORE`, `AFTER`, or `INSTEAD OF`
   - `operation` _[string or array of strings]_ - `INSERT`, `UPDATE[ OF ...]`, `DELETE` or `TRUNCATE`
@@ -31,7 +31,7 @@
 **Arguments:**
 
 - `table_name` _[[Name](migrations.md#type)]_ - name of the table where the trigger lives
-- `trigger_name` _[[Name](migrations.md#type)]_ - name of the trigger to drop
+- `trigger_name` _[string]_ - name of the trigger to drop
 - `drop_options` _[object]_ - options:
   - `ifExists` _[boolean]_ - drops trigger only if it exists
   - `cascade` _[boolean]_ - drops also dependent objects
@@ -45,5 +45,5 @@
 **Arguments:**
 
 - `table_name` _[[Name](migrations.md#type)]_ - name of the table where the trigger lives
-- `old_trigger_name` _[[Name](migrations.md#type)]_ - old name of the trigger
-- `new_trigger_name` _[[Name](migrations.md#type)]_ - new name of the trigger
+- `old_trigger_name` _[string]_ - old name of the trigger
+- `new_trigger_name` _[string]_ - new name of the trigger

--- a/index.d.ts
+++ b/index.d.ts
@@ -470,10 +470,10 @@ export interface MigrationBuilder {
     renameFunction(oldFunctionName: Name, functionParams: FunctionParam[], newFunctionName: Name): void
 
     // Triggers
-    createTrigger(tableName: Name, triggerName: Name, triggerOptions: TriggerOptions): void
-    createTrigger(tableName: Name, triggerName: Name, triggerOptions: TriggerOptions & FunctionOptions, definition: Value): void
-    dropTrigger(tableName: Name, triggerName: Name, dropOptions?: DropOptions): void
-    renameTrigger(tableName: Name, oldTriggerName: Name, newTriggerName: Name): void
+    createTrigger(tableName: Name, triggerName: string, triggerOptions: TriggerOptions): void
+    createTrigger(tableName: Name, triggerName: string, triggerOptions: TriggerOptions & FunctionOptions, definition: Value): void
+    dropTrigger(tableName: Name, triggerName: string, dropOptions?: DropOptions): void
+    renameTrigger(tableName: Name, oldTriggerName: string, newTriggerName: string): void
 
     // Schemas
     createSchema(schemaName: string, schemaOptions?: { ifNotExists?: boolean, authorization?: string }): void


### PR DESCRIPTION
Hi, I just notice the "trigger_name" term of the triggers.md doc probably conflict with postgresql schema-qualified.

> The name cannot be schema-qualified — the trigger inherits the schema of its table.

And here: [Stack Overflow](https://stackoverflow.com/questions/52543430/postgres-create-a-trigger-in-another-schema)

Thank you :)