### PR TITLE
Improve error message in migration.js

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -151,7 +151,9 @@ module.exports = class Migration {
     const action = this[direction];
 
     if (typeof action !== 'function') {
-      throw new Error(`Unknown value for direction: ${direction}`);
+      throw new Error(
+        `Unknown value for direction: ${direction}. Is the migration ${this.name} exporting a '${direction}' function?`
+      );
     }
 
     return action;

--- a/test/migration-test.js
+++ b/test/migration-test.js
@@ -78,6 +78,23 @@ describe('lib/migration', () => {
         expect(dbMock.query.getCall(3).args[0]).to.equal('COMMIT;');
       });
     });
+
+    it('should fail with an error message if the migration is invalid', () => {
+      const invalidMigrationName = 'invalid-migration';
+      migration = new Migration(dbMock, invalidMigrationName, {}, options, log);
+      const direction = 'up';
+      let error;
+      try {
+        migration.apply(direction);
+      } catch (err) {
+        error = err;
+      }
+      // expecting outside the catch block ensures that the test will fail if the
+      // an exception is not caught
+      expect(error.toString()).to.include(
+        `${invalidMigrationName} exporting a '${direction}' function`
+      );
+    });
   });
 
   describe('self.applyDown', () => {


### PR DESCRIPTION
If you have a migration that does not export a function with the same name as the direction (`up` or `down`) then the migration runner will fail with an error. This commit improves the error message to make it easier to diagnose the problem.