### PR TITLE
Another way for transpiling TypeScript

### DIFF
--- a/docs/transpiling.md
+++ b/docs/transpiling.md
@@ -21,3 +21,10 @@ It requires a little setup to use:
 
     Uncomment/Use either babel or typescript hook and adjust your config for compiler.
     You can then use migration as usual via e.g. `npm run migrate up`. :tada:
+
+Another option is to use [ts-node](https://www.npmjs.com/package/ts-node) CLI directly and it needs to be available globally or as a dependency.
+If migrations are in the `/src/migrations` folder then the path can still be referenced with the `-m` CLI option.
+
+```
+"migrate": "ts-node node_modules/.bin/node-pg-migrate -m src/migrations -j ts",
+```


### PR DESCRIPTION
TypeScript can be transpiled without creating a `migrate.js` file.
Also it's worth mentioning again how to manage migrations sitting in a custom folder, since it's very likely to happen when using TypeScript.

I personally like this configuration, what do you think?