### PR TITLE
createIndex doc

### DIFF
--- a/docs/indexes.md
+++ b/docs/indexes.md
@@ -13,7 +13,7 @@
   - `unique` _[boolean]_ - set to true if this is a unique index
   - `where` _[string]_ - raw sql for where clause of index
   - `concurrently` _[boolean]_ - create this index concurrently
-  - `opclass` _[string]_ - name of an operator class to use
+  - `opclass` _[[Name](migrations.md#type)]_ - name of an operator class to use
   - `method` _[string]_ - btree | hash | gist | spgist | gin
 
 **Aliases:** `addIndex`

--- a/index.d.ts
+++ b/index.d.ts
@@ -87,7 +87,7 @@ export interface CreateIndexOptions {
     unique?: boolean
     where?: string
     concurrently?: boolean
-    opclass?: string
+    opclass?: Name
     method?: 'btree' | 'hash' | 'gist' | 'spgist' | 'gin'
 }
 


### PR DESCRIPTION
When I try to do the pmg.createIndex, I can use the `Name` type in the `options -> opclass` to specify the schema namespace which is nice and it's working.

So I change the doc and definition, hope the commits is helpful for the other users.
Thanks :)