### PR TITLE
Allow 'Down' migrations in .sql files

### DIFF
--- a/src/migration.ts
+++ b/src/migration.ts
@@ -83,7 +83,7 @@ export class Migration implements RunMigration {
 
   public readonly timestamp: number
 
-  public readonly up?: MigrationAction
+  public up?: false | MigrationAction
 
   public down?: false | MigrationAction
 
@@ -161,17 +161,15 @@ export class Migration implements RunMigration {
   }
 
   _getAction(direction: MigrationDirection) {
-    if (direction === 'down') {
-      if (this.down === false) {
-        throw new Error(`User has disabled down migration on file: ${this.name}`)
-      }
-
-      if (this.down === undefined) {
-        this.down = this.up
-      }
+    if (direction === 'down' && this.down === undefined) {
+      this.down = this.up
     }
 
     const action: MigrationAction | false | undefined = this[direction]
+
+    if (action === false) {
+      throw new Error(`User has disabled ${direction} migration on file: ${this.name}`)
+    }
 
     if (typeof action !== 'function') {
       throw new Error(

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -16,15 +16,18 @@ const idColumn = 'id'
 const nameColumn = 'name'
 const runOnColumn = 'run_on'
 
-const migrateSqlFile = async (sqlPath: string): Promise<MigrationBuilderActions> => {
-  const sql = await readFile(sqlPath, 'utf-8')
-  const [up, down] = sql.split(/^--+\s*down\smigration/im)
+const migrateSqlFile = (sqlPath: string): MigrationBuilderActions => {
   const actions: MigrationBuilderActions = {}
-  if (up) {
-    actions.up = async pgm => pgm.sql(up)
+  const regex = new RegExp('^--+s*downsmigration', 'im')
+  const getUp = (sql: string) => sql.split(regex)[0] || ''
+  const getDown = (sql: string) => sql.split(regex)[1] || ''
+  actions.up = async pgm => {
+    const up = getUp(await readFile(sqlPath, 'utf-8'))
+    return pgm.sql(up || '')
   }
-  if (down) {
-    actions.down = async pgm => pgm.sql(down)
+  actions.down = async pgm => {
+    const down = getDown(await readFile(sqlPath, 'utf-8'))
+    return pgm.sql(down || '')
   }
   return actions
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -18,9 +18,9 @@ const runOnColumn = 'run_on'
 
 const migrateSqlFile = (sqlPath: string): MigrationBuilderActions => {
   const actions: MigrationBuilderActions = {}
-  const regex = new RegExp('^--+s*downsmigration', 'im')
-  const getUp = (sql: string) => sql.split(regex)[0] || ''
-  const getDown = (sql: string) => sql.split(regex)[1] || ''
+  const migrationCommentRegex = /^--+s*down\smigration/im
+  const getUp = (sql: string) => sql.split(migrationCommentRegex)[0] || ''
+  const getDown = (sql: string) => sql.split(migrationCommentRegex)[1] || ''
   actions.up = async pgm => {
     const up = getUp(await readFile(sqlPath, 'utf-8'))
     return pgm.sql(up || '')

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -18,7 +18,7 @@ const runOnColumn = 'run_on'
 
 const migrateSqlFile = (sqlPath: string): MigrationBuilderActions => {
   const actions: MigrationBuilderActions = {}
-  const migrationCommentRegex = /^--+s*down\smigration/im
+  const migrationCommentRegex = /^--+\s*down\smigration/im
   const getUp = (sql: string) => sql.split(migrationCommentRegex)[0] || ''
   const getDown = (sql: string) => sql.split(migrationCommentRegex)[1] || ''
   actions.up = async pgm => {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -24,8 +24,8 @@ const loadMigrations = async (db: DBConnection, options: RunnerOption, log: type
       const filePath = `${options.dir}/${file}`
       const actions: MigrationBuilderActions =
         path.extname(filePath) === '.sql'
-          ? // eslint-disable-next-line security/detect-non-literal-fs-filename
-            { up: async pgm => pgm.sql(await readFile(filePath, 'utf8')) }
+          ?
+            migrateSqlFile(filePath)
           : // eslint-disable-next-line global-require,import/no-dynamic-require,security/detect-non-literal-require
             require(path.relative(__dirname, filePath))
       shorthands = { ...shorthands, ...actions.shorthands }
@@ -44,6 +44,19 @@ const loadMigrations = async (db: DBConnection, options: RunnerOption, log: type
     throw new Error(`Can't get migration files: ${err.stack}`)
   }
 }
+
+const migrateSqlFile = async (path: string): Promise<MigrationBuilderActions> => {
+  const sql = await readFile(path, 'utf-8');
+  const [up, down] = sql.split(/^--+\s*down\smigration/im);
+  const actions: MigrationBuilderActions = {};
+  if (up) {
+    actions.up = async (pgm) => pgm.sql(up);
+  }
+  if (down) {
+    actions.down = async (pgm) => pgm.sql(down);
+  }
+  return actions;
+};
 
 const lock = async (db: DBConnection): Promise<void> => {
   const [lockObtained] = await db.select(`select pg_try_advisory_lock(${PG_MIGRATE_LOCK_ID}) as "lockObtained"`)

--- a/src/sqlMigration.ts
+++ b/src/sqlMigration.ts
@@ -1,0 +1,35 @@
+import fs from 'fs'
+import { promisify } from 'util'
+import { MigrationBuilderActions } from './types'
+
+const readFile = promisify(fs.readFile) // eslint-disable-line security/detect-non-literal-fs-filename
+
+const createMigrationCommentRegex = (direction: 'up' | 'down') =>
+  new RegExp(`^\\s*--[\\s-]*${direction}\\s+migration`, 'im') // eslint-disable-line security/detect-non-literal-regexp
+
+export const getActions = (content: string): MigrationBuilderActions => {
+  const upMigrationCommentRegex = createMigrationCommentRegex('up')
+  const downMigrationCommentRegex = createMigrationCommentRegex('down')
+
+  const upMigrationStart = content.search(upMigrationCommentRegex)
+  const downMigrationStart = content.search(downMigrationCommentRegex)
+
+  const upSql =
+    upMigrationStart >= 0
+      ? content.substr(upMigrationStart, downMigrationStart < upMigrationStart ? undefined : downMigrationStart)
+      : content
+  const downSql =
+    downMigrationStart >= 0
+      ? content.substr(downMigrationStart, upMigrationStart < downMigrationStart ? undefined : upMigrationStart)
+      : undefined
+
+  return {
+    up: pgm => pgm.sql(upSql),
+    down: downSql === undefined ? false : pgm => pgm.sql(downSql),
+  }
+}
+
+export default async (sqlPath: string) => {
+  const content = await readFile(sqlPath, 'utf-8')
+  return getActions(content)
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,8 +107,8 @@ export type MigrationAction = (pgm: MigrationBuilder, run?: () => void) => Promi
 export type Literal = (v: Name) => string
 
 export interface MigrationBuilderActions {
-  up?: MigrationAction
-  down?: MigrationAction
+  up?: MigrationAction | false
+  down?: MigrationAction | false
   shorthands?: tables.ColumnDefinitions
 }
 

--- a/templates/migration-template.sql
+++ b/templates/migration-template.sql
@@ -1,3 +1,3 @@
--- Up migration
+-- Up Migration
 
 -- Down Migration

--- a/templates/migration-template.sql
+++ b/templates/migration-template.sql
@@ -1,1 +1,3 @@
--- up migration
+-- Up migration
+
+-- Down Migration

--- a/test/sqlMigration-test.ts
+++ b/test/sqlMigration-test.ts
@@ -1,0 +1,105 @@
+import sinon from 'sinon'
+import { expect } from 'chai'
+import { getActions } from '../src/sqlMigration'
+
+/* eslint-disable no-unused-expressions */
+
+describe('lib/sqlMigration', () => {
+  describe('getActions', () => {
+    it('without comments', () => {
+      const content = 'SELECT 1 FROM something'
+      const { up, down } = getActions(content)
+      expect(up).to.exist
+      expect(down).to.be.false
+
+      const sql = sinon.spy()
+      expect(up({ sql })).to.not.exist
+      expect(sql.called).to.be.true
+      expect(sql.lastCall.args[0].trim()).to.eql(content.trim())
+    })
+
+    it('with up comment', () => {
+      const content = `
+-- Up Migration
+SELECT 1 FROM something
+`
+      const { up, down } = getActions(content)
+      expect(up).to.exist
+      expect(down).to.be.false
+
+      const sql = sinon.spy()
+      expect(up({ sql })).to.not.exist
+      expect(sql.called).to.be.true
+      expect(sql.lastCall.args[0].trim()).to.eql(content.trim())
+    })
+
+    it('with both comments', () => {
+      const upMigration = `
+-- Up Migration
+SELECT 1 FROM something`
+      const downMigration = `
+-- Down Migration
+SELECT 2 FROM something`
+      const content = `${upMigration}${downMigration}`
+      const { up, down } = getActions(content)
+      expect(up).to.exist
+      expect(down).to.exist
+
+      const upSql = sinon.spy()
+      expect(up({ sql: upSql })).to.not.exist
+      expect(upSql.called).to.be.true
+      expect(upSql.lastCall.args[0].trim()).to.eql(upMigration.trim())
+
+      const downSql = sinon.spy()
+      expect(down({ sql: downSql })).to.not.exist
+      expect(downSql.called).to.be.true
+      expect(downSql.lastCall.args[0].trim()).to.eql(downMigration.trim())
+    })
+
+    it('with both comments in reverse order', () => {
+      const upMigration = `
+-- Up Migration
+SELECT 1 FROM something`
+      const downMigration = `
+-- Down Migration
+SELECT 2 FROM something`
+      const content = `${downMigration}${upMigration}`
+      const { up, down } = getActions(content)
+      expect(up).to.exist
+      expect(down).to.exist
+
+      const upSql = sinon.spy()
+      expect(up({ sql: upSql })).to.not.exist
+      expect(upSql.called).to.be.true
+      expect(upSql.lastCall.args[0].trim()).to.eql(upMigration.trim())
+
+      const downSql = sinon.spy()
+      expect(down({ sql: downSql })).to.not.exist
+      expect(downSql.called).to.be.true
+      expect(downSql.lastCall.args[0].trim()).to.eql(downMigration.trim())
+    })
+
+    it('with both comments with some chars added', () => {
+      const upMigration = `
+ -- - up Migration to do Up migration
+SELECT 1 FROM something`
+      const downMigration = `
+  -- -- -- Down    migration to bring DB down
+SELECT 2 FROM something`
+      const content = `${upMigration}${downMigration}`
+      const { up, down } = getActions(content)
+      expect(up).to.exist
+      expect(down).to.exist
+
+      const upSql = sinon.spy()
+      expect(up({ sql: upSql })).to.not.exist
+      expect(upSql.called).to.be.true
+      expect(upSql.lastCall.args[0].trim()).to.eql(upMigration.trim())
+
+      const downSql = sinon.spy()
+      expect(down({ sql: downSql })).to.not.exist
+      expect(downSql.called).to.be.true
+      expect(downSql.lastCall.args[0].trim()).to.eql(downMigration.trim())
+    })
+  })
+})


### PR DESCRIPTION
This commit allows SQL files to have down migrations via comments.

Anything below `-- Up migration` will be treated as `up`, anything
below a `-- Down migration` will be treated as `down`.

A migration file can have either or both.