### PR TITLE
Fix locking

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -51,8 +51,8 @@ const loadMigrations = async (db: DBConnection, options: RunnerOption, logger: L
 }
 
 const lock = async (db: DBConnection): Promise<void> => {
-  const [lockObtained] = await db.select(`select pg_try_advisory_lock(${PG_MIGRATE_LOCK_ID}) as "lockObtained"`)
-  if (!lockObtained) {
+  const [result] = await db.select(`select pg_try_advisory_lock(${PG_MIGRATE_LOCK_ID}) as "lockObtained"`)
+  if (!result.lockObtained) {
     throw new Error('Another migration is already running')
   }
 }


### PR DESCRIPTION
```js
await db.select(`select pg_try_advisory_lock(${PG_MIGRATE_LOCK_ID}) as "lockObtained"`)
```

This does not return just an array with a boolean, but an array containing an object with a `lockObtained` property. With the existing implementation every caller would think that it acquired the lock and proceed with migrations. Easily reproducible by just programmatically calling the runner multiple times in a `Promise.all`, and having the migrations add something with a unique constraint (and index name for example):

```js
await Promise.all([runner(...), runner(...),])
```
This PR also makes sure that the lock is released. When testing this, I found that once the first runner ran, the next ones never managed to acquire the lock on subsequent retries.
