### PR TITLE
Use ClientConfig from pg

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,8 @@ import * as views from './operations/viewsTypes'
 import * as mViews from './operations/viewsMaterializedTypes'
 import PgLiteral from './operations/PgLiteral'
 
+export { ClientConfig, ConnectionConfig } from 'pg'
+
 // see ClientBase in @types/pg
 export interface DB {
   /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 import { ClientBase, ClientConfig, QueryArrayResult, QueryResult, QueryArrayConfig, QueryConfig } from 'pg'
-import { TlsOptions } from 'tls'
 import { Name } from './operations/generalTypes'
 
 import * as domains from './operations/domainsTypes'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { ClientBase, QueryArrayResult, QueryResult, QueryArrayConfig, QueryConfig } from 'pg'
+import { ClientBase, ClientConfig, QueryArrayResult, QueryResult, QueryArrayConfig, QueryConfig } from 'pg'
 import { TlsOptions } from 'tls'
 import { Name } from './operations/generalTypes'
 
@@ -218,19 +218,6 @@ export interface RunnerOptionConfig {
   log?: LogFn
   logger?: Logger
   verbose?: boolean
-}
-
-export interface ConnectionConfig {
-  user?: string
-  database?: string
-  password?: string
-  port?: number
-  host?: string
-  connectionString?: string
-}
-
-export interface ClientConfig extends ConnectionConfig {
-  ssl?: boolean | TlsOptions
 }
 
 export interface RunnerOptionUrl {


### PR DESCRIPTION
Just use `ClientConfig` from `pg` instead of defining it explicitly. Getting a type error, since the `ssl` field in `ClientConfig` from `pg` is slightly different from the `ssl` field in here.
```
Type 'ClientConfig' is not assignable to type 'string | ClientConfig'.
  Type 'import(".../node_modules/@types/pg/index").ClientConfig' is not assignable to type 'import(".../node_modules/node-pg-migrate/dist/types").ClientConfig'.
    Types of property 'ssl' are incompatible.
      Type 'boolean | ConnectionOptions | undefined' is not assignable to type 'boolean | TlsOptions | undefined'.
        Type 'ConnectionOptions' is not assignable to type 'boolean | TlsOptions | undefined'.
          Type 'ConnectionOptions' is not assignable to type 'TlsOptions'.
            Types of property 'pskCallback' are incompatible.
              Type '((hint: string | null) => PSKCallbackNegotation | null) | undefined' is not assignable to type '((socket: TLSSocket, identity: string) => Uint8Array | DataView | Uint8ClampedArray | Uint16Array | Uint32Array | ... 5 more ... | null) | undefined'.
                Type '(hint: string | null) => PSKCallbackNegotation | null' is not assignable to type '(socket: TLSSocket, identity: string) => Uint8Array | DataView | Uint8ClampedArray | Uint16Array | Uint32Array | ... 5 more ... | null'.
                  Types of parameters 'hint' and 'socket' are incompatible.
                    Type 'TLSSocket' is not assignable to type 'string'.
```