### PR TITLE
display additional details when logging errors

### DIFF
--- a/bin/node-pg-migrate
+++ b/bin/node-pg-migrate
@@ -11,7 +11,7 @@ const ConnectionParameters = require('pg/lib/connection-parameters')
 const { default: migrationRunner, Migration } = require('../dist')
 
 process.on('uncaughtException', (err) => {
-  console.error(err.stack)
+  console.error(err)
   process.exit(1)
 })
 
@@ -240,13 +240,13 @@ function readTsconfig() {
       // eslint-disable-next-line global-require,import/no-dynamic-require,security/detect-non-literal-require,import/no-extraneous-dependencies
       tsconfig = require('json5').parse(config)
     } catch (err) {
-      console.error(`Can't load tsconfig.json: ${err.stack}`)
+      console.error("Can't load tsconfig.json:", err)
     }
     try {
       // eslint-disable-next-line global-require,import/no-extraneous-dependencies
       tsnode = require('ts-node')
     } catch (err) {
-      console.error(`Can't load ts-node: ${err.stack}`)
+      console.error("Can't load ts-node:", err)
     }
     if (tsconfig && tsnode) {
       tsnode.register(tsconfig)
@@ -359,7 +359,7 @@ if (action === 'create') {
       process.exit(0)
     })
     .catch((err) => {
-      console.error(err.stack)
+      console.error(err)
       process.exit(1)
     })
 } else if (action === 'up' || action === 'down' || action === 'redo') {
@@ -439,7 +439,7 @@ if (action === 'create') {
       process.exit(0)
     })
     .catch((err) => {
-      console.error(err.stack)
+      console.error(err)
       process.exit(1)
     })
 } else {


### PR DESCRIPTION
`bin/node-pg-migrate`'s current method for displaying error messages does not display the additional properties an error object may have for debugging. Specifically for "node-postgres" errors, the `detail` property turns the error message available in the stack into something actionable by the user. By switching from `console.error(err.stack)` to `console.error(err)`, these additional properties can be displayed by NodeJS`s default error message inspection (see [console.error](https://nodejs.org/api/console.html#console_console_error_data_args), [util.inspect](https://nodejs.org/api/util.html#util_util_inspect_object_options)).

The existing functionality seems related to how logging an error, `console.log(error)` would only show the `error.message` instead of including the stack. [This was the case in NodeJS versions before v6.0.0, but in newer versions, the stack and additional properties are included](https://stackoverflow.com/a/42538065/2933249).

The below examples are from node v12.18.2.

Here is an error message before the changes in this pull request:
```
Error executing:
ALTER TABLE "account_locker_roles"
  ADD CONSTRAINT "account_locker_roles_unique" UNIQUE ("account", "locker");
error: could not create unique index "account_locker_roles_unique"

> Rolling back attempted migration ...
error: could not create unique index "account_locker_roles_unique"
    at Connection.parseE (/home/joel/WebstormProjects/lsa/node_modules/pg/lib/connection.js:614:13)
    at Connection.parseMessage (/home/joel/WebstormProjects/lsa/node_modules/pg/lib/connection.js:413:19)
    at Socket.<anonymous> (/home/joel/WebstormProjects/lsa/node_modules/pg/lib/connection.js:129:22)
    at Socket.emit (events.js:315:20)
    at addChunk (_stream_readable.js:295:12)
    at readableAddChunk (_stream_readable.js:271:9)
    at Socket.Readable.push (_stream_readable.js:212:10)
    at TCP.onStreamRead (internal/stream_base_commons.js:186:23)
```

Here is the same error message after applying the changes in this pull request, with the `detail` property displayed:
```
Error executing:
ALTER TABLE "account_locker_roles"
  ADD CONSTRAINT "account_locker_roles_unique" UNIQUE ("account", "locker");
error: could not create unique index "account_locker_roles_unique"

> Rolling back attempted migration ...
error: could not create unique index "account_locker_roles_unique"
    at Parser.parseErrorMessage (/home/joel/WebstormProjects/node-pg-migrate/node_modules/pg-protocol/dist/parser.js:241:15)
    at Parser.handlePacket (/home/joel/WebstormProjects/node-pg-migrate/node_modules/pg-protocol/dist/parser.js:89:29)
    at Parser.parse (/home/joel/WebstormProjects/node-pg-migrate/node_modules/pg-protocol/dist/parser.js:41:38)
    at Socket.<anonymous> (/home/joel/WebstormProjects/node-pg-migrate/node_modules/pg-protocol/dist/index.js:8:42)
    at Socket.emit (events.js:315:20)
    at addChunk (_stream_readable.js:295:12)
    at readableAddChunk (_stream_readable.js:271:9)
    at Socket.Readable.push (_stream_readable.js:212:10)
    at TCP.onStreamRead (internal/stream_base_commons.js:186:23) {
  length: 258,
  severity: 'ERROR',
  code: '23505',
  detail: 'Key (account, locker)=(zndmlD5J, fake_locker_hash_1) is duplicated.',
  hint: undefined,
  position: undefined,
  internalPosition: undefined,
  internalQuery: undefined,
  where: undefined,
  schema: 'public',
  table: 'account_locker_roles',
  column: undefined,
  dataType: undefined,
  constraint: 'account_locker_roles_unique',
  file: 'tuplesort.c',
  line: '4049',
  routine: 'comparetup_index_btree'
}
```