### PR TITLE
Provide format script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ save: &save
     key: code-{{ .Revision }}
     paths:
       - .
-      - "~/.npm-global"
+      - '~/.npm-global'
 
 restore: &restore
   restore_cache:
@@ -333,16 +333,16 @@ jobs:
       - <<: *test-postgres
   test-env-vars:
     docker:
-    - <<: *node-image
-      environment:
-        - PGUSER=ubuntu
-        - PGPASSWORD=123456abcdefghABCDEFGH~\`\!@#$%^\&*-_=+{}[]\(\)\<\>,.\;:\"\'?\|/\\
-        - PGDATABASE=circle_test
-    - image: postgres:13.2-alpine
-      environment:
-        - POSTGRES_USER=ubuntu
-        - POSTGRES_PASSWORD=123456abcdefghABCDEFGH~\`\!@#$%^\&*-_=+{}[]\(\)\<\>,.\;:\"\'?\|/\\
-        - POSTGRES_DB=circle_test
+      - <<: *node-image
+        environment:
+          - PGUSER=ubuntu
+          - PGPASSWORD=123456abcdefghABCDEFGH~\`\!@#$%^\&*-_=+{}[]\(\)\<\>,.\;:\"\'?\|/\\
+          - PGDATABASE=circle_test
+      - image: postgres:13.2-alpine
+        environment:
+          - POSTGRES_USER=ubuntu
+          - POSTGRES_PASSWORD=123456abcdefghABCDEFGH~\`\!@#$%^\&*-_=+{}[]\(\)\<\>,.\;:\"\'?\|/\\
+          - POSTGRES_DB=circle_test
     steps:
       - <<: *restore
       - <<: *postgres-wait
@@ -509,22 +509,22 @@ workflows:
             - install
       - test-env-vars:
           requires:
-          - install
+            - install
       - test-schema:
           requires:
-          - install
+            - install
       - test-schemas:
           requires:
-          - install
+            - install
       - test-typescript-migration:
           requires:
-          - install
+            - install
       - test-typescript-customrunner-url:
           requires:
-          - install
+            - install
       - test-typescript-customrunner-client:
           requires:
-          - install
+            - install
       - test-create-migration:
           requires:
-          - install
+            - install

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,7 +3,7 @@
 #
 # You may wish to alter this file to override the set of languages analyzed,
 # or to provide custom queries or build logic.
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
   push:
@@ -29,43 +29,43 @@ jobs:
         # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          # We must fetch at least the immediate parents so that if this is
+          # a pull request then we can checkout the head.
+          fetch-depth: 2
 
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
+      # If this run was triggered by a pull request event, then checkout
+      # the head of the pull request instead of the merge commit.
+      - run: git checkout HEAD^2
+        if: ${{ github.event_name == 'pull_request' }}
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file. 
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+      #- run: |
+      #   make bootstrap
+      #   make release
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,2 @@
 dist
 templates
-
-# Ignore strange semicolon
-test/ts/customRunnerDBClient.ts
-test/ts/customRunnerDBUrl.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,6 @@
+dist
 templates
+
+# Ignore strange semicolon
+test/ts/customRunnerDBClient.ts
+test/ts/customRunnerDBUrl.ts

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,22 +1,25 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>node-pg-migrate - Postgresql database migration management tool for node.js</title>
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-  <meta name="description" content="Postgresql database migration management tool for node.js">
-  <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-  <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
-</head>
-<body>
-  <div id="app"></div>
-  <script>
-    window.$docsify = {
-      name: 'node-pg-migrate',
-      repo: 'https://github.com/salsita/node-pg-migrate',
-      loadSidebar: true,
-    }
-  </script>
-  <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>node-pg-migrate - Postgresql database migration management tool for node.js</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta name="description" content="Postgresql database migration management tool for node.js" />
+    <meta
+      name="viewport"
+      content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
+    />
+    <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script>
+      window.$docsify = {
+        name: 'node-pg-migrate',
+        repo: 'https://github.com/salsita/node-pg-migrate',
+        loadSidebar: true,
+      }
+    </script>
+    <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "build": "tsc --removeComments && tsc --declaration --emitDeclarationOnly",
     "test": "cross-env NODE_ENV=test mocha --require ./mocha.bootstrap.js \"test/*.ts\"",
     "migrate": "node bin/node-pg-migrate",
+    "format": "prettier --write .",
     "lint": "eslint . bin/* --ext .js,.ts",
     "lintfix": "npm run lint -- --fix && prettier --write *.json *.md docs/*.md",
     "prepare": "npm run build",

--- a/test/ts/customRunnerDBClient.ts
+++ b/test/ts/customRunnerDBClient.ts
@@ -1,12 +1,13 @@
 import { Client } from 'pg'
 import { run } from './customRunner'
 
-// eslint-disable-next-line prettier/prettier
-(async () => {
+async function start() {
   process.exitCode = 1
   const dbClient = new Client(process.env.DATABASE_URL)
   await dbClient.connect()
   const result = await run({ dbClient })
   // dbClient.end()
   process.exit(result === true ? 0 : 1)
-})()
+}
+
+start()

--- a/test/ts/customRunnerDBUrl.ts
+++ b/test/ts/customRunnerDBUrl.ts
@@ -1,8 +1,9 @@
 import { run } from './customRunner'
 
-// eslint-disable-next-line prettier/prettier
-(async () => {
+async function start() {
   process.exitCode = 1
   const result = await run({ databaseUrl: String(process.env.DATABASE_URL) })
   process.exit(result === true ? 0 : 1)
-})()
+}
+
+start()


### PR DESCRIPTION
This adds a format script to `package.json`'s `scripts` block, so you can run `npm run format` and all supported files in the project will be formatted.

Folders like `dist` needs to be excluded because they are auto-generated.

The both other ignored files have a strange semicolon before the first brace in front of the `async`, so I just ignored these both files for now.