### PR TITLE
Add custom env file path

### DIFF
--- a/bin/node-pg-migrate
+++ b/bin/node-pg-migrate
@@ -15,21 +15,6 @@ process.on('uncaughtException', (err) => {
   process.exit(1)
 })
 
-try {
-  const myEnv = require('dotenv').config({ silent: true }) // eslint-disable-line global-require,import/no-extraneous-dependencies
-  try {
-    require('dotenv-expand')(myEnv) // eslint-disable-line global-require,import/no-extraneous-dependencies
-  } catch (err) {
-    if (err.code !== 'MODULE_NOT_FOUND') {
-      throw err
-    }
-  }
-} catch (err) {
-  if (err.code !== 'MODULE_NOT_FOUND') {
-    throw err
-  }
-}
-
 const schemaArg = 'schema'
 const createSchemaArg = 'create-schema'
 const databaseUrlVarArg = 'database-url-var'
@@ -53,6 +38,7 @@ const decamelizeArg = 'decamelize'
 const tsconfigArg = 'tsconfig'
 const verboseArg = 'verbose'
 const rejectUnauthorizedArg = 'reject-unauthorized'
+const envPathArg = 'envPath'
 
 const { argv } = yargs
   .usage('Usage: $0 [up|down|create|redo] [migrationName] [options]')
@@ -165,6 +151,11 @@ const { argv } = yargs
     type: 'string',
   })
 
+  .option(envPathArg, {
+    describe: 'path to the .env file that should be used for configuration',
+    type: 'string',
+  })
+
   .option(dryRunArg, {
     default: false,
     describe: "Prints the SQL but doesn't run it",
@@ -236,6 +227,22 @@ let CHECK_ORDER = argv[checkOrderArg]
 let VERBOSE = argv[verboseArg]
 let DECAMELIZE = argv[decamelizeArg]
 let tsconfigPath = argv[tsconfigArg]
+let envPath = argv[envPathArg] || './.env'
+
+try {
+  const myEnv = require('dotenv').config({ silent: true, path: envPath }) // eslint-disable-line global-require,import/no-extraneous-dependencies
+  try {
+    require('dotenv-expand')(myEnv) // eslint-disable-line global-require,import/no-extraneous-dependencies
+  } catch (err) {
+    if (err.code !== 'MODULE_NOT_FOUND') {
+      throw err
+    }
+  }
+} catch (err) {
+  if (err.code !== 'MODULE_NOT_FOUND') {
+    throw err
+  }
+}
 
 function readTsconfig() {
   if (tsconfigPath) {

--- a/bin/node-pg-migrate
+++ b/bin/node-pg-migrate
@@ -227,15 +227,15 @@ let CHECK_ORDER = argv[checkOrderArg]
 let VERBOSE = argv[verboseArg]
 let DECAMELIZE = argv[decamelizeArg]
 let tsconfigPath = argv[tsconfigArg]
-let envPath = argv[envPathArg]
+const envPath = argv[envPathArg]
 
 try {
   // Create default dotenv config
-  const dotenvConfig = { silent: true };
+  const dotenvConfig = { silent: true }
 
   // If the path has been configured, add it to the config, otherwise don't change the default dotenv path
   if (envPath) {
-    dotenvConfig.path = envPath;
+    dotenvConfig.path = envPath
   }
 
   const myEnv = require('dotenv').config(dotenvConfig) // eslint-disable-line global-require,import/no-extraneous-dependencies

--- a/bin/node-pg-migrate
+++ b/bin/node-pg-migrate
@@ -226,7 +226,7 @@ if (envPath) {
 try {
   // Load config from ".env" file
   const myEnv = require('dotenv').config(dotenvConfig) // eslint-disable-line global-require,import/no-extraneous-dependencies
-  
+
   require('dotenv-expand')(myEnv) // eslint-disable-line global-require,import/no-extraneous-dependencies
 } catch (err) {
   if (err.code !== 'MODULE_NOT_FOUND') {

--- a/bin/node-pg-migrate
+++ b/bin/node-pg-migrate
@@ -147,12 +147,12 @@ const { argv } = yargs
   })
 
   .option(tsconfigArg, {
-    describe: 'path to tsconfig.json file',
+    describe: 'Path to tsconfig.json file',
     type: 'string',
   })
 
   .option(envPathArg, {
-    describe: 'path to the .env file that should be used for configuration',
+    describe: 'Path to the .env file that should be used for configuration',
     type: 'string',
   })
 
@@ -215,23 +215,19 @@ if (argv.help || argv._.length === 0) {
 /* Load env before accessing process.env */
 const envPath = argv[envPathArg]
 
+// Create default dotenv config
+const dotenvConfig = { silent: true }
+
+// If the path has been configured, add it to the config, otherwise don't change the default dotenv path
+if (envPath) {
+  dotenvConfig.path = envPath
+}
+
 try {
-  // Create default dotenv config
-  const dotenvConfig = { silent: true }
-
-  // If the path has been configured, add it to the config, otherwise don't change the default dotenv path
-  if (envPath) {
-    dotenvConfig.path = envPath
-  }
-
+  // Load config from ".env" file
   const myEnv = require('dotenv').config(dotenvConfig) // eslint-disable-line global-require,import/no-extraneous-dependencies
-  try {
-    require('dotenv-expand')(myEnv) // eslint-disable-line global-require,import/no-extraneous-dependencies
-  } catch (err) {
-    if (err.code !== 'MODULE_NOT_FOUND') {
-      throw err
-    }
-  }
+  
+  require('dotenv-expand')(myEnv) // eslint-disable-line global-require,import/no-extraneous-dependencies
 } catch (err) {
   if (err.code !== 'MODULE_NOT_FOUND') {
     throw err

--- a/bin/node-pg-migrate
+++ b/bin/node-pg-migrate
@@ -227,10 +227,18 @@ let CHECK_ORDER = argv[checkOrderArg]
 let VERBOSE = argv[verboseArg]
 let DECAMELIZE = argv[decamelizeArg]
 let tsconfigPath = argv[tsconfigArg]
-let envPath = argv[envPathArg] || './.env'
+let envPath = argv[envPathArg]
 
 try {
-  const myEnv = require('dotenv').config({ silent: true, path: envPath }) // eslint-disable-line global-require,import/no-extraneous-dependencies
+  // Create default dotenv config
+  const dotenvConfig = { silent: true };
+
+  // If the path has been configured, add it to the config, otherwise don't change the default dotenv path
+  if (envPath) {
+    dotenvConfig.path = envPath;
+  }
+
+  const myEnv = require('dotenv').config(dotenvConfig) // eslint-disable-line global-require,import/no-extraneous-dependencies
   try {
     require('dotenv-expand')(myEnv) // eslint-disable-line global-require,import/no-extraneous-dependencies
   } catch (err) {

--- a/bin/node-pg-migrate
+++ b/bin/node-pg-migrate
@@ -212,21 +212,7 @@ if (argv.help || argv._.length === 0) {
   process.exit(1)
 }
 
-let MIGRATIONS_DIR = argv[migrationsDirArg]
-let DB_CONNECTION = process.env[argv[databaseUrlVarArg]]
-let IGNORE_PATTERN = argv[ignorePatternArg]
-let SCHEMA = argv[schemaArg]
-let CREATE_SCHEMA = argv[createSchemaArg]
-let MIGRATIONS_SCHEMA = argv[migrationsSchemaArg]
-let CREATE_MIGRATIONS_SCHEMA = argv[createMigrationsSchemaArg]
-let MIGRATIONS_TABLE = argv[migrationsTableArg]
-let MIGRATIONS_FILE_LANGUAGE = argv[migrationFileLanguageArg]
-let MIGRATIONS_FILENAME_FORMAT = argv[migrationFilenameFormatArg]
-let TEMPLATE_FILE_NAME = argv[templateFileNameArg]
-let CHECK_ORDER = argv[checkOrderArg]
-let VERBOSE = argv[verboseArg]
-let DECAMELIZE = argv[decamelizeArg]
-let tsconfigPath = argv[tsconfigArg]
+/* Load env before accessing process.env */
 const envPath = argv[envPathArg]
 
 try {
@@ -251,6 +237,22 @@ try {
     throw err
   }
 }
+
+let MIGRATIONS_DIR = argv[migrationsDirArg]
+let DB_CONNECTION = process.env[argv[databaseUrlVarArg]]
+let IGNORE_PATTERN = argv[ignorePatternArg]
+let SCHEMA = argv[schemaArg]
+let CREATE_SCHEMA = argv[createSchemaArg]
+let MIGRATIONS_SCHEMA = argv[migrationsSchemaArg]
+let CREATE_MIGRATIONS_SCHEMA = argv[createMigrationsSchemaArg]
+let MIGRATIONS_TABLE = argv[migrationsTableArg]
+let MIGRATIONS_FILE_LANGUAGE = argv[migrationFileLanguageArg]
+let MIGRATIONS_FILENAME_FORMAT = argv[migrationFilenameFormatArg]
+let TEMPLATE_FILE_NAME = argv[templateFileNameArg]
+let CHECK_ORDER = argv[checkOrderArg]
+let VERBOSE = argv[verboseArg]
+let DECAMELIZE = argv[decamelizeArg]
+let tsconfigPath = argv[tsconfigArg]
 
 function readTsconfig() {
   if (tsconfigPath) {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -45,7 +45,7 @@ You can specify custom JSON file with config (format is same as for `db` entry o
 }
 ```
 
-If a .env file exists, it will be loaded using [dotenv](https://www.npmjs.com/package/dotenv) (if installed) when running the node-pg-migrate binary.
+If a .env file exists, it will be loaded using [dotenv](https://www.npmjs.com/package/dotenv) (if installed) when running the node-pg-migrate binary. If the .env file is not on the same level where the command has been called, you can use the `--envPath` option to point to the location of your .env file.
 
 Depending on your project's setup, it may make sense to write some custom grunt/gulp/whatever tasks that set this env var and run your migration commands. More on that below.
 
@@ -77,6 +77,7 @@ You can adjust defaults by passing arguments to `node-pg-migrate`:
 - `migration-file-language` (`j`) - Language of the migration file to create (`js` or `ts`)
 - `template-file-name` - Use your own template file for migrations (language will be determined from the extension of the template). The file must export the `up` method accepting `MigrationBuilder` instance.
 - `tsconfig` - Path to tsconfig.json. Used to setup transpiling of TS migration files. (Also sets `migration-file-language` to typescript, if not overridden)
+- `envPath` - Path to a .env file. The default finds the file on the same level where the command has been called. It might be useful if you have nested projects, but a global .env file that you need to point to.
 - `timestamp` - Treats number argument to up/down migration as timestamp (running up migrations less or equal to timestamp or down migrations greater or equal to timestamp)
 - `check-order` - Check order of migrations before running them (defaults to `true`, to switch it off supply `--no-check-order` on the command line).
   (There should be no migration with timestamp lesser than last run migration.)


### PR DESCRIPTION
Loads the "env" file from a custom path if your file containing environment variables is located elsewhere.

- added a new commandline argument, `envPathArg`.
- Add the config to the dotenv config **only** if it has been set, otherwise don't change anything. ([link to dotenv path option](https://github.com/motdotla/dotenv#path))