### PR TITLE
CURRENT_TIMESTAMP instead of NOW() (redshift support)

### DIFF
--- a/src/migration.ts
+++ b/src/migration.ts
@@ -184,7 +184,7 @@ export class Migration implements RunMigration {
         return `DELETE FROM "${schema}"."${migrationsTable}" WHERE name='${name}';`
       case this.up:
         this.logger.info(`### MIGRATION ${this.name} (UP) ###`)
-        return `INSERT INTO "${schema}"."${migrationsTable}" (name, run_on) VALUES ('${name}', NOW());`
+        return `INSERT INTO "${schema}"."${migrationsTable}" (name, run_on) VALUES ('${name}', CURRENT_TIMESTAMP);`
       default:
         throw new Error('Unknown direction')
     }


### PR DESCRIPTION
* update insert into migrations table to use CURRENT_TIMESTAMP instead of NOW() to better support redshift.

with this and turning off locks (and dealing with the issues creating the migration table, that is another pull request) this makes migrations work in redshift and postgres.