### PR TITLE
Add node 15 test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 
 node-image: &node-image
-  image: circleci/node:14
+  image: circleci/node:16
 
 set-npm-global: &set-npm-global
   run:
@@ -212,6 +212,20 @@ jobs:
   test-node-12:
     docker:
       - image: circleci/node:12
+        environment:
+          - DATABASE_URL=postgres://ubuntu:ubuntu@localhost:5432/circle_test
+      - image: postgres:13.3-alpine
+        environment:
+          - POSTGRES_USER=ubuntu
+          - POSTGRES_PASSWORD=ubuntu
+          - POSTGRES_DB=circle_test
+    steps:
+      - <<: *restore
+      - <<: *postgres-wait
+      - <<: *test-postgres
+  test-node-14:
+    docker:
+      - image: circleci/node:14
         environment:
           - DATABASE_URL=postgres://ubuntu:ubuntu@localhost:5432/circle_test
       - image: postgres:13.3-alpine
@@ -490,6 +504,9 @@ workflows:
           requires:
             - install
       - test-node-12:
+          requires:
+            - install
+      - test-node-14:
           requires:
             - install
       - test-config:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 
 node-image: &node-image
-  image: circleci/node:16
+  image: circleci/node:15
 
 set-npm-global: &set-npm-global
   run:


### PR DESCRIPTION
replaces #781 

---

```node
Starting container circleci/node:16
Warning: No authentication provided, using CircleCI credentials for pulls from Docker Hub.
  image cache not found on this host, downloading circleci/node:16

Error response from daemon: manifest for circleci/node:16 not found: manifest unknown: manifest unknown
```

Seems there is an issue :thinking: 

---

Nevermind :facepalm: ... Node 16 isn't a thing yet :sweat_smile: 