### PR TITLE
Update migration-template.ts

### DIFF
--- a/templates/migration-template.ts
+++ b/templates/migration-template.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/camelcase */
+/* eslint-disable @typescript-eslint/naming-convention */
 import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
 
 export const shorthands: ColumnDefinitions | undefined = undefined;


### PR DESCRIPTION
eslint rule `@typescript-eslint/camelcase` has been deprecated and removed in favor of `@typescript-eslint/naming-convention`

also eslint emits an error if a referenced rule does not exist