### PR TITLE
fix: change from require to dynamic import

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -32,7 +32,7 @@ const loadMigrations = async (db: DBConnection, options: RunnerOption, logger: L
             path.extname(filePath) === '.sql'
               ? await migrateSqlFile(filePath)
               : // eslint-disable-next-line global-require,import/no-dynamic-require,security/detect-non-literal-require
-                require(path.relative(__dirname, filePath))
+                await import(path.relative(__dirname, filePath))
           shorthands = { ...shorthands, ...actions.shorthands }
           return new Migration(
             db,


### PR DESCRIPTION
## Summary 

Change the way the migrations files are being loaded in the `loadMigrations` function. Replace from `require` to a dynamic import `await import` in order to support ESM projects.

## Known issues

In a pure ESM project the node-pg-migrate module is not usable because the `loadMigrations` function uses `require` instead of `await import`. 

Current project characteristics:

- Typescript
- package.json : `"type" : "module"`


tsconfig.json content:

```
{
  "extends": "@tsconfig/node16/tsconfig.json",
  "compilerOptions": {
    "lib": ["es2021"],
    "module": "es2022",
    "target": "es2022",
    "esModuleInterop": true,
    "skipLibCheck": true,
    "moduleResolution": "node",
    "forceConsistentCasingInFileNames": true,
    "baseUrl": "./src",
    "outDir": "dist",
  },
  "ts-node": {
    "esm": true
  },
  "include": ["./src", "./migrations"]
}
```


Script used to run the migrations:

` "migrate:build" : "./node_modules/.bin/node-pg-migrate -m ./dist/migrations"`

## Logs

```
Error: Can't get migration files: Error [ERR_REQUIRE_ESM]: require() of ES Module .../dist/migrations/1652421258856_add-tweets-table.js from .../node_modules/node-pg-migrate/dist/runner.js not supported.
Instead change the require of 1652421258856_add-tweets-table.js in ..../node_modules/node-pg-migrate/dist/runner.js to a dynamic import() which is available in all CommonJS modules.
```