### PR TITLE
feat: allow to provide migrations manually

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import runner from './runner'
 import { Migration } from './migration'
-import { RunnerOption, MigrationBuilder, PgType } from './types'
+import { RunnerOption, MigrationBuilder, MigrationBuilderActions, PgType } from './types'
 import PgLiteral from './operations/PgLiteral'
 import {
   PgLiteralValue,
@@ -119,10 +119,11 @@ import {
 } from './operations/viewsMaterializedTypes'
 
 export {
+  PgType,
   PgLiteral,
   Migration,
-  PgType,
   MigrationBuilder,
+  MigrationBuilderActions,
   RunnerOption,
   PgLiteralValue,
   Value,

--- a/src/types.ts
+++ b/src/types.ts
@@ -216,10 +216,6 @@ export interface RunnerOptionConfig {
    */
   schema?: string | string[]
   /**
-   * The directory containing your migration files.
-   */
-  dir: string
-  /**
    * Check order of migrations before running them.
    */
   checkOrder?: boolean
@@ -235,10 +231,6 @@ export interface RunnerOptionConfig {
    * Treats `count` as timestamp.
    */
   timestamp?: boolean
-  /**
-   * Regex pattern for file names to ignore (ignores files starting with `.` by default).
-   */
-  ignorePattern?: string
   /**
    * Run only migration with this name.
    */
@@ -284,6 +276,29 @@ export interface RunnerOptionConfig {
   verbose?: boolean
 }
 
+export interface RunnerOptionDir {
+  /**
+   * The directory containing your migration files.
+   */
+  dir: string
+  /**
+   * Regex pattern for file names to ignore (ignores files starting with `.` by default).
+   */
+  ignorePattern?: string
+}
+
+export interface RunnerOptionMigrations {
+  /**
+   * A dictionary containing migrations to run.
+   *
+   * The object can follow th
+   */
+  migrations: Record<
+    string,
+    string | MigrationBuilderActions | (() => MigrationBuilderActions | Promise<MigrationBuilderActions>)
+  >
+}
+
 export interface RunnerOptionUrl {
   /**
    * Connection string or client config which is passed to [new pg.Client](https://node-postgres.com/api/client#constructor)
@@ -300,4 +315,6 @@ export interface RunnerOptionClient {
   dbClient: ClientBase
 }
 
-export type RunnerOption = RunnerOptionConfig & (RunnerOptionClient | RunnerOptionUrl)
+export type RunnerOption = RunnerOptionConfig &
+  (RunnerOptionClient | RunnerOptionUrl) &
+  (RunnerOptionDir | RunnerOptionMigrations)

--- a/test/ts/customRunner.ts
+++ b/test/ts/customRunner.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'path'
 import { Client } from 'pg'
 import runner, { RunnerOption } from '../../dist'
+import { RunnerOptionDir, RunnerOptionMigrations } from '../../dist/types'
 
 type TestOptions = {
   count?: number
@@ -13,7 +14,7 @@ type Options = ({ databaseUrl: string } & TestOptions) | ({ dbClient: Client } &
 /* eslint-disable no-console */
 // eslint-disable-next-line import/prefer-default-export
 export const run = async (options: Options): Promise<boolean> => {
-  const opts: Omit<RunnerOption, 'direction'> & Options = {
+  const opts: Omit<RunnerOption, 'direction'> & Options & (RunnerOptionDir | RunnerOptionMigrations) = {
     migrationsTable: 'migrations',
     dir: resolve(__dirname, 'migrations'),
     expectedUpLength: 2,


### PR DESCRIPTION
Hello,

Thank you for providing this very useful library.

This PR aims to allow to provide migrations manually instead of looking in a specified folder.

It's particularly useful when working with bundlers. It allows to bundle migrations and provide them as an object of mapped modules.

Usage:
```js
const migrations = {
  // you can specify a path directly (will be imported using require)
  "1663367180464_base.ts": "../../src/migrations/1663367180464_base.js",

  // you can specify a module directly
  "1663367180464_base.ts": require("../../src/migrations/1663367180464_base.js"),

  // you can specify a synchronous function
  "1663367180464_base.ts": () => require("../../src/migrations/1663367180464_base.js"),

  // you can specify an asynchronous function
  "1663367180464_base.ts": () => import("../../src/migrations/1663367180464_base.js")
};

await migration({
    dbClient,
    migrations,
    direction: "up",
    count: Infinity,
    migrationsTable: "migrations"
});
```

Vite exemple:
```js
const migrations = import.meta.glob("../../../migrations/*.ts");

await migration({
    dbClient,
    migrations,
    direction: "up",
    count: Infinity,
    migrationsTable: "migrations"
});
```