### PR TITLE
Support noTransaction in raw SQL files

### DIFF
--- a/src/sqlMigration.ts
+++ b/src/sqlMigration.ts
@@ -6,25 +6,40 @@ const { readFile } = fs.promises
 const createMigrationCommentRegex = (direction: 'up' | 'down') =>
   new RegExp(`^\\s*--[\\s-]*${direction}\\s+migration`, 'im') // eslint-disable-line security/detect-non-literal-regexp
 
+const noTransactionCommentRegex = /^\s*--[\s-]*no\s*transaction/i
+
 export const getActions = (content: string): MigrationBuilderActions => {
   const upMigrationCommentRegex = createMigrationCommentRegex('up')
   const downMigrationCommentRegex = createMigrationCommentRegex('down')
 
+  const noTransaction = content.search(noTransactionCommentRegex) >= 0
   const upMigrationStart = content.search(upMigrationCommentRegex)
   const downMigrationStart = content.search(downMigrationCommentRegex)
 
   const upSql =
     upMigrationStart >= 0
-      ? content.substr(upMigrationStart, downMigrationStart < upMigrationStart ? undefined : downMigrationStart)
+      ? content.substring(upMigrationStart, downMigrationStart < upMigrationStart ? undefined : downMigrationStart)
       : content
   const downSql =
     downMigrationStart >= 0
-      ? content.substr(downMigrationStart, upMigrationStart < downMigrationStart ? undefined : upMigrationStart)
+      ? content.substring(downMigrationStart, upMigrationStart < downMigrationStart ? undefined : upMigrationStart)
       : undefined
-
   return {
-    up: (pgm) => pgm.sql(upSql),
-    down: downSql === undefined ? false : (pgm) => pgm.sql(downSql),
+    up: (pgm) => {
+      if (noTransaction) {
+        pgm.noTransaction()
+      }
+      pgm.sql(upSql)
+    },
+    down:
+      downSql === undefined
+        ? false
+        : (pgm) => {
+            if (noTransaction) {
+              pgm.noTransaction()
+            }
+            pgm.sql(downSql)
+          },
   }
 }
 

--- a/test/sqlMigration-test.ts
+++ b/test/sqlMigration-test.ts
@@ -13,9 +13,11 @@ describe('lib/sqlMigration', () => {
       expect(down).to.be.false
 
       const sql = sinon.spy()
-      expect(up({ sql })).to.not.exist
+      const noTransaction = sinon.spy()
+      expect(up({ sql, noTransaction })).to.not.exist
       expect(sql.called).to.be.true
       expect(sql.lastCall.args[0].trim()).to.eql(content.trim())
+      expect(noTransaction.called).to.be.false
     })
 
     it('with up comment', () => {
@@ -28,12 +30,14 @@ SELECT 1 FROM something
       expect(down).to.be.false
 
       const sql = sinon.spy()
-      expect(up({ sql })).to.not.exist
+      const noTransaction = sinon.spy()
+      expect(up({ sql, noTransaction })).to.not.exist
       expect(sql.called).to.be.true
       expect(sql.lastCall.args[0].trim()).to.eql(content.trim())
+      expect(noTransaction.called).to.be.false
     })
 
-    it('with both comments', () => {
+    it('with both up & down comments', () => {
       const upMigration = `
 -- Up Migration
 SELECT 1 FROM something`
@@ -46,17 +50,21 @@ SELECT 2 FROM something`
       expect(down).to.exist
 
       const upSql = sinon.spy()
-      expect(up({ sql: upSql })).to.not.exist
+      const upNoTransaction = sinon.spy()
+      expect(up({ sql: upSql, noTransaction: upNoTransaction })).to.not.exist
       expect(upSql.called).to.be.true
       expect(upSql.lastCall.args[0].trim()).to.eql(upMigration.trim())
+      expect(upNoTransaction.called).to.be.false
 
       const downSql = sinon.spy()
-      expect(down({ sql: downSql })).to.not.exist
+      const downNoTransaction = sinon.spy()
+      expect(down({ sql: downSql, noTransaction: downNoTransaction })).to.not.exist
       expect(downSql.called).to.be.true
       expect(downSql.lastCall.args[0].trim()).to.eql(downMigration.trim())
+      expect(downNoTransaction.called).to.be.false
     })
 
-    it('with both comments in reverse order', () => {
+    it('with both up & down comments in reverse order', () => {
       const upMigration = `
 -- Up Migration
 SELECT 1 FROM something`
@@ -69,17 +77,21 @@ SELECT 2 FROM something`
       expect(down).to.exist
 
       const upSql = sinon.spy()
-      expect(up({ sql: upSql })).to.not.exist
+      const upNoTransaction = sinon.spy()
+      expect(up({ sql: upSql, noTransaction: upNoTransaction })).to.not.exist
       expect(upSql.called).to.be.true
       expect(upSql.lastCall.args[0].trim()).to.eql(upMigration.trim())
+      expect(upNoTransaction.called).to.be.false
 
       const downSql = sinon.spy()
-      expect(down({ sql: downSql })).to.not.exist
+      const downNoTransaction = sinon.spy()
+      expect(down({ sql: downSql, noTransaction: downNoTransaction })).to.not.exist
       expect(downSql.called).to.be.true
       expect(downSql.lastCall.args[0].trim()).to.eql(downMigration.trim())
+      expect(downNoTransaction.called).to.be.false
     })
 
-    it('with both comments with some chars added', () => {
+    it('with both up & down comments with some chars added', () => {
       const upMigration = `
  -- - up Migration to do Up migration
 SELECT 1 FROM something`
@@ -92,14 +104,64 @@ SELECT 2 FROM something`
       expect(down).to.exist
 
       const upSql = sinon.spy()
-      expect(up({ sql: upSql })).to.not.exist
+      const upNoTransaction = sinon.spy()
+      expect(up({ sql: upSql, noTransaction: upNoTransaction })).to.not.exist
       expect(upSql.called).to.be.true
       expect(upSql.lastCall.args[0].trim()).to.eql(upMigration.trim())
+      expect(upNoTransaction.called).to.be.false
 
       const downSql = sinon.spy()
-      expect(down({ sql: downSql })).to.not.exist
+      const downNoTransaction = sinon.spy()
+      expect(down({ sql: downSql, noTransaction: downNoTransaction })).to.not.exist
       expect(downSql.called).to.be.true
       expect(downSql.lastCall.args[0].trim()).to.eql(downMigration.trim())
+      expect(downNoTransaction.called).to.be.false
+    })
+
+    it('with noTransaction comment', () => {
+      const content = `
+-- no transaction
+SELECT 1 FROM something
+`
+      const { up, down } = getActions(content)
+      expect(up).to.exist
+      expect(down).to.be.false
+
+      const sql = sinon.spy()
+      const noTransaction = sinon.spy()
+      expect(up({ sql, noTransaction })).to.not.exist
+      expect(sql.called).to.be.true
+      expect(sql.lastCall.args[0].trim()).to.eql(content.trim())
+      expect(noTransaction.called).to.be.true
+    })
+
+    it('with all comments', () => {
+      const noTransaction = `
+-- No Transaction`
+      const upMigration = `
+-- Up Migration
+SELECT 1 FROM something`
+      const downMigration = `
+-- Down Migration
+SELECT 2 FROM something`
+      const content = `${noTransaction}${upMigration}${downMigration}`
+      const { up, down } = getActions(content)
+      expect(up).to.exist
+      expect(down).to.exist
+
+      const upSql = sinon.spy()
+      const upNoTransaction = sinon.spy()
+      expect(up({ sql: upSql, noTransaction: upNoTransaction })).to.not.exist
+      expect(upSql.called).to.be.true
+      expect(upSql.lastCall.args[0].trim()).to.eql(upMigration.trim())
+      expect(upNoTransaction.called).to.be.true
+
+      const downSql = sinon.spy()
+      const downNoTransaction = sinon.spy()
+      expect(down({ sql: downSql, noTransaction: downNoTransaction })).to.not.exist
+      expect(downSql.called).to.be.true
+      expect(downSql.lastCall.args[0].trim()).to.eql(downMigration.trim())
+      expect(downNoTransaction.called).to.be.true
     })
   })
 })


### PR DESCRIPTION
## Summary
This PR introduces support for a `-- noTransaction`/`-- no transaction` comment syntax in raw SQL migration files. This configures the SQL in the file to be run outside a transaction.

This PR also fixes a subtle bug that appears to have existed for a while with the up/down comment syntax. Whereby using `substr` (which accepts a starting index, and length), was accidentally used instead of `substring`. The impact being that having text before a `-- up migration` comment would result in the up migration extending into the `-- down migration` by `text.length`.

## Background
My team was hoping to write our migrations using `.sql` files, since it's easier to run our linter over them.

However, we've ran into an issue where there's no way to specify a `.sql` migration that runs outside of a transaction - which [as per the docs is very useful](https://salsita.github.io/node-pg-migrate/#/misc?id=pgmnotransaction), e.g. creating concurrent indexes.

Hopefully we can get this merged! Let me know if you want to see anything else here :) 