### PR TITLE
docs(template): add JSDoc to js migration template

### DIFF
--- a/templates/migration-template.js
+++ b/templates/migration-template.js
@@ -1,5 +1,15 @@
 exports.shorthands = undefined;
 
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
 exports.up = (pgm) => {};
 
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
 exports.down = (pgm) => {};

--- a/templates/migration-template.js
+++ b/templates/migration-template.js
@@ -1,3 +1,6 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
 exports.shorthands = undefined;
 
 /**


### PR DESCRIPTION
# 📝 Description

This PR add JSDoc to this template file [`./templates/migration-template.js`](https://github.com/salsita/node-pg-migrate/blob/master/templates/migration-template.js).

## 🔎 Evidence that this works

![evidence](https://github.com/salsita/node-pg-migrate/assets/12430365/2e47183f-ecdd-4f38-a8e2-3f6b9dedb8c0)

## 🔀 Related Pull Requests

- #949 

## 🏷️ Related Issues

- #948 

### 🗃️ Changes

On branch:

> **feat/gh-948-add-js-doc-comment-to-template**


Changes to be committed:

> modified:   templates/migration-template.js