### PR TITLE
fix: restore support url as an object in configuration

### DIFF
--- a/.github/workflows/postgres-test.yml
+++ b/.github/workflows/postgres-test.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [18, 20]
-        postgres_version: [12.18, 13.14, 14.11, 15.6, 16.2]
+        node_version: [ 18, 20 ]
+        postgres_version: [ 12.18, 13.14, 14.11, 15.6, 16.2 ]
       fail-fast: false
     timeout-minutes: 10
 
@@ -65,8 +65,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [20]
-        postgres_version: [16.2]
+        node_version: [ 20 ]
+        postgres_version: [ 16.2 ]
       fail-fast: false
     timeout-minutes: 10
 
@@ -123,6 +123,68 @@ jobs:
           EOF
 
       - name: Integration Test
+        run: pnpm run migrate up -m test/migrations && pnpm run migrate down 0 -m test/migrations --timestamps
+
+  config-url-object-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node_version: [ 20 ]
+        postgres_version: [ 16.2 ]
+      fail-fast: false
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:${{ matrix.postgres_version }}-alpine
+        env:
+          POSTGRES_USER: ubuntu
+          POSTGRES_PASSWORD: ubuntu
+          POSTGRES_DB: integration_test
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+
+    name: 'Config Test: pg-${{ matrix.postgres_version }}, node-${{ matrix.node_version }}, ubuntu-latest'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
+
+      - name: Set node version to ${{ matrix.node_version }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ matrix.node_version }}
+          cache: 'pnpm'
+
+      - name: Install deps
+        run: pnpm install
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Write URL object config
+        run: |
+          mkdir -p config
+          cat > config/default.json << 'EOF'
+          {
+            "db": {
+              "url": {
+                "connectionString": "postgres://ubuntu:ubuntu@localhost:5432/integration_test"
+              }
+            }
+          }
+          EOF
+
+      - name: Integration Test for URL object config
         run: pnpm run migrate up -m test/migrations && pnpm run migrate down 0 -m test/migrations --timestamps
 
   dotenv-test:
@@ -242,8 +304,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [20]
-        postgres_version: [16.2]
+        node_version: [ 20 ]
+        postgres_version: [ 16.2 ]
       fail-fast: false
     timeout-minutes: 10
 

--- a/.github/workflows/postgres-test.yml
+++ b/.github/workflows/postgres-test.yml
@@ -61,7 +61,7 @@ jobs:
         env:
           DATABASE_URL: postgres://ubuntu:ubuntu@localhost:5432/integration_test
 
-  config-test:
+  config-1-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -87,7 +87,7 @@ jobs:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
 
-    name: 'Config Test: pg-${{ matrix.postgres_version }}, node-${{ matrix.node_version }}, ubuntu-latest'
+    name: 'Config 1 Test: pg-${{ matrix.postgres_version }}, node-${{ matrix.node_version }}, ubuntu-latest'
     steps:
       - name: Checkout
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -125,7 +125,7 @@ jobs:
       - name: Integration Test
         run: pnpm run migrate up -m test/migrations && pnpm run migrate down 0 -m test/migrations --timestamps
 
-  config-url-object-test:
+  config-2-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -151,7 +151,7 @@ jobs:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
 
-    name: 'Config Test: pg-${{ matrix.postgres_version }}, node-${{ matrix.node_version }}, ubuntu-latest'
+    name: 'Config 2 Test: pg-${{ matrix.postgres_version }}, node-${{ matrix.node_version }}, ubuntu-latest'
     steps:
       - name: Checkout
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4

--- a/.github/workflows/postgres-test.yml
+++ b/.github/workflows/postgres-test.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [ 18, 20 ]
-        postgres_version: [ 12.18, 13.14, 14.11, 15.6, 16.2 ]
+        node_version: [18, 20]
+        postgres_version: [12.18, 13.14, 14.11, 15.6, 16.2]
       fail-fast: false
     timeout-minutes: 10
 
@@ -65,8 +65,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [ 20 ]
-        postgres_version: [ 16.2 ]
+        node_version: [20]
+        postgres_version: [16.2]
       fail-fast: false
     timeout-minutes: 10
 
@@ -129,8 +129,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [ 20 ]
-        postgres_version: [ 16.2 ]
+        node_version: [20]
+        postgres_version: [16.2]
       fail-fast: false
     timeout-minutes: 10
 
@@ -304,8 +304,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [ 20 ]
-        postgres_version: [ 16.2 ]
+        node_version: [20]
+        postgres_version: [16.2]
       fail-fast: false
     timeout-minutes: 10
 

--- a/bin/node-pg-migrate.ts
+++ b/bin/node-pg-migrate.ts
@@ -391,7 +391,7 @@ function readJson(json: unknown): void {
     tsconfigPath = applyIf(tsconfigPath, tsconfigArg, json, isString);
 
     // @ts-expect-error: this is a TS 4.8 bug
-    if ('url' in json && json.url && isString(json.url)) {
+    if ('url' in json && json.url) {
       // @ts-expect-error: this is a TS 4.8 bug
       DB_CONNECTION ??= json.url;
     } else if (isClientConfig(json)) {


### PR DESCRIPTION
This PR fixes a regression introduced in `v7.0.0` where it was not possible to use the defined configured `url` as an object anymore (cf. https://salsita.github.io/node-pg-migrate/#/cli?id=json-configuration).

For reference, it typically looks like that:

```json
{
  "url": {
    "connectionString": "postgres://postgres:password@localhost:5432/postgres",
    "ssl": false
  }
}
```

This was caused by a lack of unit testing around this behaviour, so I introduced a spec for the CLI to cover this case. I never had to write tests for CLIs @Shinigami92, so I had to improvise a little. I think it is a good base to extend the CLI tests if you ever want to. Let me know what you think.

Closes https://github.com/salsita/node-pg-migrate/issues/1112