### PR TITLE
chore: reduce statement return type

### DIFF
--- a/src/operations/domains/alterDomain.ts
+++ b/src/operations/domains/alterDomain.ts
@@ -10,7 +10,7 @@ export interface DomainOptionsAlter extends DomainOptions {
 export type AlterDomain = (
   domainName: Name,
   domainOptions: DomainOptionsAlter
-) => string | string[];
+) => string;
 
 export function alterDomain(mOptions: MigrationOptions): AlterDomain {
   const _alter: AlterDomain = (domainName, options) => {

--- a/src/operations/domains/createDomain.ts
+++ b/src/operations/domains/createDomain.ts
@@ -12,7 +12,7 @@ export type CreateDomainFn = (
   domainName: Name,
   type: Type,
   domainOptions?: DomainOptionsCreate & DropOptions
-) => string | string[];
+) => string;
 
 export type CreateDomain = Reversible<CreateDomainFn>;
 

--- a/src/operations/domains/dropDomain.ts
+++ b/src/operations/domains/dropDomain.ts
@@ -4,7 +4,7 @@ import type { DropOptions, Name } from '../generalTypes';
 export type DropDomain = (
   domainName: Name,
   dropOptions?: DropOptions
-) => string | string[];
+) => string;
 
 export function dropDomain(mOptions: MigrationOptions): DropDomain {
   const _drop: DropDomain = (domainName, options = {}) => {

--- a/src/operations/domains/renameDomain.ts
+++ b/src/operations/domains/renameDomain.ts
@@ -4,7 +4,7 @@ import type { Name, Reversible } from '../generalTypes';
 export type RenameDomainFn = (
   oldDomainName: Name,
   newDomainName: Name
-) => string | string[];
+) => string;
 
 export type RenameDomain = Reversible<RenameDomainFn>;
 

--- a/src/operations/functions/createFunction.ts
+++ b/src/operations/functions/createFunction.ts
@@ -9,7 +9,7 @@ export type CreateFunctionFn = (
   functionParams: FunctionParam[],
   functionOptions: FunctionOptions & DropOptions,
   definition: Value
-) => string | string[];
+) => string;
 
 export type CreateFunction = Reversible<CreateFunctionFn>;
 

--- a/src/operations/functions/dropFunction.ts
+++ b/src/operations/functions/dropFunction.ts
@@ -7,7 +7,7 @@ export type DropFunction = (
   functionName: Name,
   functionParams: FunctionParam[],
   dropOptions?: DropOptions
-) => string | string[];
+) => string;
 
 export function dropFunction(mOptions: MigrationOptions): DropFunction {
   const _drop: DropFunction = (

--- a/src/operations/functions/renameFunction.ts
+++ b/src/operations/functions/renameFunction.ts
@@ -7,7 +7,7 @@ export type RenameFunctionFn = (
   oldFunctionName: Name,
   functionParams: FunctionParam[],
   newFunctionName: Name
-) => string | string[];
+) => string;
 
 export type RenameFunction = Reversible<RenameFunctionFn>;
 

--- a/src/operations/grants/grantOnSchemas.ts
+++ b/src/operations/grants/grantOnSchemas.ts
@@ -19,9 +19,7 @@ export type GrantOnSchemasOptions = OnlyGrantOnSchemasOptions &
   WithGrantOption &
   RevokeOnObjectsOptions;
 
-export type GrantOnSchemasFn = (
-  options: GrantOnSchemasOptions
-) => string | string[];
+export type GrantOnSchemasFn = (options: GrantOnSchemasOptions) => string;
 
 export type GrantOnSchemas = Reversible<GrantOnSchemasFn>;
 

--- a/src/operations/grants/grantOnTables.ts
+++ b/src/operations/grants/grantOnTables.ts
@@ -22,7 +22,7 @@ export type GrantOnTablesOptions =
 
 export type GrantOnTablesFn = (
   options: GrantOnTablesOptions & RevokeOnObjectsOptions
-) => string | string[];
+) => string;
 
 export type GrantOnTables = Reversible<GrantOnTablesFn>;
 

--- a/src/operations/grants/grantRoles.ts
+++ b/src/operations/grants/grantRoles.ts
@@ -11,7 +11,7 @@ export type GrantRolesFn = (
   rolesFrom: Name | Name[],
   rolesTo: Name | Name[],
   grantRolesOptions?: GrantRolesOptions
-) => string | string[];
+) => string;
 
 export type GrantRoles = GrantRolesFn & { reverse: GrantRolesFn };
 

--- a/src/operations/grants/revokeOnSchemas.ts
+++ b/src/operations/grants/revokeOnSchemas.ts
@@ -7,9 +7,7 @@ import { asRolesStr } from './shared';
 export type RevokeOnSchemasOptions = OnlyGrantOnSchemasOptions &
   RevokeOnObjectsOptions;
 
-export type RevokeOnSchemas = (
-  options: RevokeOnSchemasOptions
-) => string | string[];
+export type RevokeOnSchemas = (options: RevokeOnSchemasOptions) => string;
 
 export function revokeOnSchemas(mOptions: MigrationOptions): RevokeOnSchemas {
   const _revokeOnSchemas: RevokeOnSchemas = ({

--- a/src/operations/grants/revokeOnTables.ts
+++ b/src/operations/grants/revokeOnTables.ts
@@ -12,9 +12,7 @@ export type RevokeOnTablesOptions = CommonOnTablesOptions &
   (AllTablesOptions | SomeTablesOptions) &
   RevokeOnObjectsOptions;
 
-export type RevokeOnTables = (
-  options: RevokeOnTablesOptions
-) => string | string[];
+export type RevokeOnTables = (options: RevokeOnTablesOptions) => string;
 
 export function revokeOnTables(mOptions: MigrationOptions): RevokeOnTables {
   const _revokeOnTables: RevokeOnTables = (options) => {

--- a/src/operations/grants/revokeRoles.ts
+++ b/src/operations/grants/revokeRoles.ts
@@ -9,7 +9,7 @@ export type RevokeRoles = (
   roles: Name | Name[],
   rolesFrom: Name | Name[],
   revokeRolesOptions?: RevokeRolesOptions
-) => string | string[];
+) => string;
 
 export function revokeRoles(mOptions: MigrationOptions): RevokeRoles {
   const _revokeRoles: RevokeRoles = (roles, rolesFrom, options) => {

--- a/src/operations/indexes/createIndex.ts
+++ b/src/operations/indexes/createIndex.ts
@@ -31,7 +31,7 @@ export type CreateIndexFn = (
   tableName: Name,
   columns: string | Array<string | IndexColumn>,
   options?: CreateIndexOptions & DropIndexOptions
-) => string | string[];
+) => string;
 
 export type CreateIndex = Reversible<CreateIndexFn>;
 

--- a/src/operations/indexes/dropIndex.ts
+++ b/src/operations/indexes/dropIndex.ts
@@ -16,7 +16,7 @@ export type DropIndex = (
   tableName: Name,
   columns: string | Array<string | IndexColumn>,
   options?: DropIndexOptions
-) => string | string[];
+) => string;
 
 export function dropIndex(mOptions: MigrationOptions): DropIndex {
   const _drop: DropIndex = (tableName, rawColumns, options = {}) => {

--- a/src/operations/materializedViews/alterMaterializedView.ts
+++ b/src/operations/materializedViews/alterMaterializedView.ts
@@ -15,7 +15,7 @@ export interface AlterMaterializedViewOptions {
 export type AlterMaterializedView = (
   viewName: Name,
   options: AlterMaterializedViewOptions
-) => string | string[];
+) => string;
 
 export function alterMaterializedView(
   mOptions: MigrationOptions

--- a/src/operations/materializedViews/createMaterializedView.ts
+++ b/src/operations/materializedViews/createMaterializedView.ts
@@ -24,7 +24,7 @@ export type CreateMaterializedViewFn = (
   viewName: Name,
   options: CreateMaterializedViewOptions & DropOptions,
   definition: string
-) => string | string[];
+) => string;
 
 export type CreateMaterializedView = Reversible<CreateMaterializedViewFn>;
 

--- a/src/operations/materializedViews/dropMaterializedView.ts
+++ b/src/operations/materializedViews/dropMaterializedView.ts
@@ -4,7 +4,7 @@ import type { DropOptions, Name } from '../generalTypes';
 export type DropMaterializedView = (
   viewName: Name,
   options?: DropOptions
-) => string | string[];
+) => string;
 
 export function dropMaterializedView(
   mOptions: MigrationOptions

--- a/src/operations/materializedViews/refreshMaterializedView.ts
+++ b/src/operations/materializedViews/refreshMaterializedView.ts
@@ -11,7 +11,7 @@ export interface RefreshMaterializedViewOptions {
 export type RefreshMaterializedViewFn = (
   viewName: Name,
   options?: RefreshMaterializedViewOptions
-) => string | string[];
+) => string;
 
 export type RefreshMaterializedView = Reversible<RefreshMaterializedViewFn>;
 

--- a/src/operations/materializedViews/renameMaterializedView.ts
+++ b/src/operations/materializedViews/renameMaterializedView.ts
@@ -4,7 +4,7 @@ import type { Name, Reversible } from '../generalTypes';
 export type RenameMaterializedViewFn = (
   viewName: Name,
   newViewName: Name
-) => string | string[];
+) => string;
 
 export type RenameMaterializedView = Reversible<RenameMaterializedViewFn>;
 

--- a/src/operations/materializedViews/renameMaterializedViewColumn.ts
+++ b/src/operations/materializedViews/renameMaterializedViewColumn.ts
@@ -5,7 +5,7 @@ export type RenameMaterializedViewColumnFn = (
   viewName: Name,
   columnName: string,
   newColumnName: string
-) => string | string[];
+) => string;
 
 export type RenameMaterializedViewColumn =
   Reversible<RenameMaterializedViewColumnFn>;

--- a/src/operations/operators/addToOperatorFamily.ts
+++ b/src/operations/operators/addToOperatorFamily.ts
@@ -8,7 +8,7 @@ export type AddToOperatorFamilyFn = (
   operatorFamilyName: Name,
   indexMethod: Name,
   operatorList: OperatorListDefinition[]
-) => string | string[];
+) => string;
 
 export type AddToOperatorFamily = Reversible<AddToOperatorFamilyFn>;
 

--- a/src/operations/operators/createOperator.ts
+++ b/src/operations/operators/createOperator.ts
@@ -26,7 +26,7 @@ export interface CreateOperatorOptions {
 export type CreateOperatorFn = (
   operatorName: Name,
   options: CreateOperatorOptions & DropOperatorOptions
-) => string | string[];
+) => string;
 
 export type CreateOperator = Reversible<CreateOperatorFn>;
 

--- a/src/operations/operators/createOperatorClass.ts
+++ b/src/operations/operators/createOperatorClass.ts
@@ -17,7 +17,7 @@ export type CreateOperatorClassFn = (
   indexMethod: Name,
   operatorList: OperatorListDefinition[],
   options: CreateOperatorClassOptions & DropOptions
-) => string | string[];
+) => string;
 
 export type CreateOperatorClass = Reversible<CreateOperatorClassFn>;
 

--- a/src/operations/operators/createOperatorFamily.ts
+++ b/src/operations/operators/createOperatorFamily.ts
@@ -6,7 +6,7 @@ export type CreateOperatorFamilyFn = (
   operatorFamilyName: Name,
   indexMethod: Name,
   options?: DropOptions
-) => string | string[];
+) => string;
 
 export type CreateOperatorFamily = Reversible<CreateOperatorFamilyFn>;
 

--- a/src/operations/operators/dropOperator.ts
+++ b/src/operations/operators/dropOperator.ts
@@ -10,7 +10,7 @@ export interface DropOperatorOptions extends DropOptions {
 export type DropOperator = (
   operatorName: Name,
   dropOptions?: DropOperatorOptions
-) => string | string[];
+) => string;
 
 export function dropOperator(mOptions: MigrationOptions): DropOperator {
   const _drop: DropOperator = (operatorName, options = {}) => {

--- a/src/operations/operators/dropOperatorClass.ts
+++ b/src/operations/operators/dropOperatorClass.ts
@@ -5,7 +5,7 @@ export type DropOperatorClass = (
   operatorClassName: Name,
   indexMethod: Name,
   dropOptions?: DropOptions
-) => string | string[];
+) => string;
 
 export function dropOperatorClass(
   mOptions: MigrationOptions

--- a/src/operations/operators/dropOperatorFamily.ts
+++ b/src/operations/operators/dropOperatorFamily.ts
@@ -5,7 +5,7 @@ export type DropOperatorFamily = (
   operatorFamilyName: Name,
   newSchemaName: Name,
   dropOptions?: DropOptions
-) => string | string[];
+) => string;
 
 export function dropOperatorFamily(
   mOptions: MigrationOptions

--- a/src/operations/operators/removeFromOperatorFamily.ts
+++ b/src/operations/operators/removeFromOperatorFamily.ts
@@ -7,7 +7,7 @@ export type RemoveFromOperatorFamily = (
   operatorFamilyName: Name,
   indexMethod: Name,
   operatorList: OperatorListDefinition[]
-) => string | string[];
+) => string;
 
 export const removeFromOperatorFamily = (
   mOptions: MigrationOptions

--- a/src/operations/operators/renameOperatorClass.ts
+++ b/src/operations/operators/renameOperatorClass.ts
@@ -5,7 +5,7 @@ export type RenameOperatorClassFn = (
   oldOperatorClassName: Name,
   indexMethod: Name,
   newOperatorClassName: Name
-) => string | string[];
+) => string;
 
 export type RenameOperatorClass = Reversible<RenameOperatorClassFn>;
 

--- a/src/operations/operators/renameOperatorFamily.ts
+++ b/src/operations/operators/renameOperatorFamily.ts
@@ -5,7 +5,7 @@ export type RenameOperatorFamilyFn = (
   oldOperatorFamilyName: Name,
   indexMethod: Name,
   newOperatorFamilyName: Name
-) => string | string[];
+) => string;
 
 export type RenameOperatorFamily = Reversible<RenameOperatorFamilyFn>;
 

--- a/src/operations/policies/alterPolicy.ts
+++ b/src/operations/policies/alterPolicy.ts
@@ -7,7 +7,7 @@ export type AlterPolicy = (
   tableName: Name,
   policyName: string,
   options: PolicyOptions
-) => string | string[];
+) => string;
 
 export function alterPolicy(mOptions: MigrationOptions): AlterPolicy {
   const _alter: AlterPolicy = (tableName, policyName, options = {}) => {

--- a/src/operations/policies/createPolicy.ts
+++ b/src/operations/policies/createPolicy.ts
@@ -14,7 +14,7 @@ type CreatePolicyFn = (
   tableName: Name,
   policyName: string,
   options?: CreatePolicyOptions & IfExistsOption
-) => string | string[];
+) => string;
 
 export type CreatePolicy = Reversible<CreatePolicyFn>;
 

--- a/src/operations/policies/dropPolicy.ts
+++ b/src/operations/policies/dropPolicy.ts
@@ -5,7 +5,7 @@ export type DropPolicy = (
   tableName: Name,
   policyName: string,
   options?: IfExistsOption
-) => string | string[];
+) => string;
 
 export function dropPolicy(mOptions: MigrationOptions): DropPolicy {
   const _drop: DropPolicy = (tableName, policyName, options = {}) => {

--- a/src/operations/policies/renamePolicy.ts
+++ b/src/operations/policies/renamePolicy.ts
@@ -5,7 +5,7 @@ export type RenamePolicyFn = (
   tableName: Name,
   policyName: string,
   newPolicyName: string
-) => string | string[];
+) => string;
 
 export type RenamePolicy = Reversible<RenamePolicyFn>;
 

--- a/src/operations/roles/alterRole.ts
+++ b/src/operations/roles/alterRole.ts
@@ -3,10 +3,7 @@ import type { Name } from '../generalTypes';
 import type { RoleOptions } from './shared';
 import { formatRoleOptions } from './shared';
 
-export type AlterRole = (
-  roleName: Name,
-  roleOptions: RoleOptions
-) => string | string[];
+export type AlterRole = (roleName: Name, roleOptions: RoleOptions) => string;
 
 export function alterRole(mOptions: MigrationOptions): AlterRole {
   const _alter: AlterRole = (roleName, roleOptions = {}) => {

--- a/src/operations/roles/createRole.ts
+++ b/src/operations/roles/createRole.ts
@@ -7,7 +7,7 @@ import { formatRoleOptions } from './shared';
 export type CreateRoleFn = (
   roleName: Name,
   roleOptions?: RoleOptions & IfExistsOption
-) => string | string[];
+) => string;
 
 export type CreateRole = Reversible<CreateRoleFn>;
 

--- a/src/operations/roles/dropRole.ts
+++ b/src/operations/roles/dropRole.ts
@@ -1,10 +1,7 @@
 import type { MigrationOptions } from '../../types';
 import type { IfExistsOption, Name } from '../generalTypes';
 
-export type DropRole = (
-  roleName: Name,
-  options?: IfExistsOption
-) => string | string[];
+export type DropRole = (roleName: Name, options?: IfExistsOption) => string;
 
 export function dropRole(mOptions: MigrationOptions): DropRole {
   const _drop: DropRole = (roleName, options = {}) => {

--- a/src/operations/roles/renameRole.ts
+++ b/src/operations/roles/renameRole.ts
@@ -1,10 +1,7 @@
 import type { MigrationOptions } from '../../types';
 import type { Name, Reversible } from '../generalTypes';
 
-export type RenameRoleFn = (
-  oldRoleName: Name,
-  newRoleName: Name
-) => string | string[];
+export type RenameRoleFn = (oldRoleName: Name, newRoleName: Name) => string;
 
 export type RenameRole = Reversible<RenameRoleFn>;
 

--- a/src/operations/schemas/createSchema.ts
+++ b/src/operations/schemas/createSchema.ts
@@ -13,7 +13,7 @@ export interface CreateSchemaOptions extends IfNotExistsOption {
 export type CreateSchemaFn = (
   schemaName: string,
   schemaOptions?: CreateSchemaOptions & DropOptions
-) => string | string[];
+) => string;
 
 export type CreateSchema = Reversible<CreateSchemaFn>;
 

--- a/src/operations/schemas/dropSchema.ts
+++ b/src/operations/schemas/dropSchema.ts
@@ -4,7 +4,7 @@ import type { DropOptions } from '../generalTypes';
 export type DropSchema = (
   schemaName: string,
   dropOptions?: DropOptions
-) => string | string[];
+) => string;
 
 export function dropSchema(mOptions: MigrationOptions): DropSchema {
   const _drop: DropSchema = (schemaName, options = {}) => {

--- a/src/operations/schemas/renameSchema.ts
+++ b/src/operations/schemas/renameSchema.ts
@@ -4,7 +4,7 @@ import type { Reversible } from '../generalTypes';
 export type RenameSchemaFn = (
   oldSchemaName: string,
   newSchemaName: string
-) => string | string[];
+) => string;
 
 export type RenameSchema = Reversible<RenameSchemaFn>;
 

--- a/src/operations/sequences/alterSequence.ts
+++ b/src/operations/sequences/alterSequence.ts
@@ -10,7 +10,7 @@ export interface SequenceOptionsAlter extends SequenceOptions {
 export type AlterSequence = (
   sequenceName: Name,
   sequenceOptions: SequenceOptionsAlter
-) => string | string[];
+) => string;
 
 export function alterSequence(mOptions: MigrationOptions): AlterSequence {
   return (sequenceName, options) => {

--- a/src/operations/sequences/createSequence.ts
+++ b/src/operations/sequences/createSequence.ts
@@ -18,7 +18,7 @@ export interface SequenceOptionsCreate
 export type CreateSequenceFn = (
   sequenceName: Name,
   sequenceOptions?: SequenceOptionsCreate & DropOptions
-) => string | string[];
+) => string;
 
 export type CreateSequence = Reversible<CreateSequenceFn>;
 

--- a/src/operations/sequences/dropSequence.ts
+++ b/src/operations/sequences/dropSequence.ts
@@ -4,7 +4,7 @@ import type { DropOptions, Name } from '../generalTypes';
 export type DropSequence = (
   sequenceName: Name,
   dropOptions?: DropOptions
-) => string | string[];
+) => string;
 
 export function dropSequence(mOptions: MigrationOptions): DropSequence {
   const _drop: DropSequence = (sequenceName, options = {}) => {

--- a/src/operations/sequences/renameSequence.ts
+++ b/src/operations/sequences/renameSequence.ts
@@ -4,7 +4,7 @@ import type { Name, Reversible } from '../generalTypes';
 export type RenameSequenceFn = (
   oldSequenceName: Name,
   newSequenceName: Name
-) => string | string[];
+) => string;
 
 export type RenameSequence = Reversible<RenameSequenceFn>;
 

--- a/src/operations/sql.ts
+++ b/src/operations/sql.ts
@@ -5,7 +5,7 @@ import type { Name, Value } from './generalTypes';
 export type Sql = (
   sqlStr: string,
   args?: { [key: string]: Name | Value }
-) => string | string[];
+) => string;
 
 export function sql(mOptions: MigrationOptions): Sql {
   const t = createTransformer(mOptions.literal);

--- a/src/operations/tables/addColumns.ts
+++ b/src/operations/tables/addColumns.ts
@@ -14,7 +14,7 @@ export type AddColumnsFn = (
   tableName: Name,
   newColumns: ColumnDefinitions,
   addOptions?: IfNotExistsOption & DropOptions
-) => string | string[];
+) => string;
 
 export type AddColumns = Reversible<AddColumnsFn>;
 

--- a/src/operations/tables/addConstraint.ts
+++ b/src/operations/tables/addConstraint.ts
@@ -9,7 +9,7 @@ export type CreateConstraintFn = (
   tableName: Name,
   constraintName: string | null,
   expression: string | (ConstraintOptions & DropOptions)
-) => string | string[];
+) => string;
 
 export type CreateConstraint = Reversible<CreateConstraintFn>;
 

--- a/src/operations/tables/alterColumn.ts
+++ b/src/operations/tables/alterColumn.ts
@@ -36,7 +36,7 @@ export type AlterColumn = (
   tableName: Name,
   columnName: string,
   options: AlterColumnOptions
-) => string | string[];
+) => string;
 
 export function alterColumn(mOptions: MigrationOptions): AlterColumn {
   return (tableName, columnName, options) => {

--- a/src/operations/tables/alterTable.ts
+++ b/src/operations/tables/alterTable.ts
@@ -9,7 +9,7 @@ export interface AlterTableOptions {
 export type AlterTable = (
   tableName: Name,
   alterOptions: AlterTableOptions
-) => string | string[];
+) => string;
 
 export function alterTable(mOptions: MigrationOptions): AlterTable {
   const _alter: AlterTable = (tableName, options) => {

--- a/src/operations/tables/createTable.ts
+++ b/src/operations/tables/createTable.ts
@@ -13,7 +13,7 @@ export type CreateTableFn = (
   tableName: Name,
   columns: ColumnDefinitions,
   options?: TableOptions & DropOptions
-) => string | string[];
+) => string;
 
 export type CreateTable = Reversible<CreateTableFn>;
 

--- a/src/operations/tables/dropColumns.ts
+++ b/src/operations/tables/dropColumns.ts
@@ -6,7 +6,7 @@ export type DropColumns = (
   tableName: Name,
   columns: string | string[] | { [name: string]: unknown },
   dropOptions?: DropOptions
-) => string | string[];
+) => string;
 
 export function dropColumns(mOptions: MigrationOptions): DropColumns {
   const _drop: DropColumns = (tableName, columns, options = {}) => {

--- a/src/operations/tables/dropConstraint.ts
+++ b/src/operations/tables/dropConstraint.ts
@@ -5,7 +5,7 @@ export type DropConstraint = (
   tableName: Name,
   constraintName: string,
   options?: DropOptions
-) => string | string[];
+) => string;
 
 export function dropConstraint(mOptions: MigrationOptions): DropConstraint {
   const _drop: DropConstraint = (tableName, constraintName, options = {}) => {

--- a/src/operations/tables/dropTable.ts
+++ b/src/operations/tables/dropTable.ts
@@ -1,10 +1,7 @@
 import type { MigrationOptions } from '../../types';
 import type { DropOptions, Name } from '../generalTypes';
 
-export type DropTable = (
-  tableName: Name,
-  dropOptions?: DropOptions
-) => string | string[];
+export type DropTable = (tableName: Name, dropOptions?: DropOptions) => string;
 
 export function dropTable(mOptions: MigrationOptions): DropTable {
   const _drop: DropTable = (tableName, options = {}) => {

--- a/src/operations/tables/renameColumn.ts
+++ b/src/operations/tables/renameColumn.ts
@@ -5,7 +5,7 @@ export type RenameColumnFn = (
   tableName: Name,
   oldColumnName: string,
   newColumnName: string
-) => string | string[];
+) => string;
 
 export type RenameColumn = Reversible<RenameColumnFn>;
 

--- a/src/operations/tables/renameConstraint.ts
+++ b/src/operations/tables/renameConstraint.ts
@@ -5,7 +5,7 @@ export type RenameConstraintFn = (
   tableName: Name,
   oldConstraintName: string,
   newConstraintName: string
-) => string | string[];
+) => string;
 
 export type RenameConstraint = Reversible<RenameConstraintFn>;
 

--- a/src/operations/tables/renameTable.ts
+++ b/src/operations/tables/renameTable.ts
@@ -1,10 +1,7 @@
 import type { MigrationOptions } from '../../types';
 import type { Name, Reversible } from '../generalTypes';
 
-export type RenameTableFn = (
-  tableName: Name,
-  newtableName: Name
-) => string | string[];
+export type RenameTableFn = (tableName: Name, newtableName: Name) => string;
 
 export type RenameTable = Reversible<RenameTableFn>;
 

--- a/src/operations/triggers/createTrigger.ts
+++ b/src/operations/triggers/createTrigger.ts
@@ -10,14 +10,14 @@ export type CreateTriggerFn1 = (
   tableName: Name,
   triggerName: string,
   triggerOptions: TriggerOptions & DropOptions
-) => string | string[];
+) => string;
 
 export type CreateTriggerFn2 = (
   tableName: Name,
   triggerName: string,
   triggerOptions: TriggerOptions & FunctionOptions & DropOptions,
   definition: Value
-) => string | string[];
+) => string;
 
 export type CreateTriggerFn = CreateTriggerFn1 | CreateTriggerFn2;
 

--- a/src/operations/triggers/dropTrigger.ts
+++ b/src/operations/triggers/dropTrigger.ts
@@ -5,7 +5,7 @@ export type DropTrigger = (
   tableName: Name,
   triggerName: string,
   dropOptions?: DropOptions
-) => string | string[];
+) => string;
 
 export function dropTrigger(mOptions: MigrationOptions): DropTrigger {
   const _drop: DropTrigger = (tableName, triggerName, options = {}) => {

--- a/src/operations/triggers/renameTrigger.ts
+++ b/src/operations/triggers/renameTrigger.ts
@@ -5,7 +5,7 @@ export type RenameTriggerFn = (
   tableName: Name,
   oldTriggerName: string,
   newTriggerName: string
-) => string | string[];
+) => string;
 
 export type RenameTrigger = Reversible<RenameTriggerFn>;
 

--- a/src/operations/types/addTypeAttribute.ts
+++ b/src/operations/types/addTypeAttribute.ts
@@ -7,7 +7,7 @@ export type AddTypeAttributeFn = (
   typeName: Name,
   attributeName: string,
   attributeType: Type & IfExistsOption
-) => string | string[];
+) => string;
 
 export type AddTypeAttribute = Reversible<AddTypeAttributeFn>;
 

--- a/src/operations/types/addTypeValue.ts
+++ b/src/operations/types/addTypeValue.ts
@@ -12,7 +12,7 @@ export type AddTypeValue = (
   typeName: Name,
   value: Value,
   options?: AddTypeValueOptions
-) => string | string[];
+) => string;
 
 export function addTypeValue(mOptions: MigrationOptions): AddTypeValue {
   const _add: AddTypeValue = (typeName, value, options = {}) => {

--- a/src/operations/types/createType.ts
+++ b/src/operations/types/createType.ts
@@ -12,7 +12,7 @@ import { dropType } from './dropType';
 export type CreateTypeFn = (
   typeName: Name,
   values: (Value[] | { [name: string]: Type }) & DropOptions
-) => string | string[];
+) => string;
 
 export type CreateType = Reversible<CreateTypeFn>;
 

--- a/src/operations/types/dropType.ts
+++ b/src/operations/types/dropType.ts
@@ -1,10 +1,7 @@
 import type { MigrationOptions } from '../../types';
 import type { DropOptions, Name } from '../generalTypes';
 
-export type DropType = (
-  typeName: Name,
-  dropOptions?: DropOptions
-) => string | string[];
+export type DropType = (typeName: Name, dropOptions?: DropOptions) => string;
 
 export function dropType(mOptions: MigrationOptions): DropType {
   const _drop: DropType = (typeName, options = {}) => {

--- a/src/operations/types/dropTypeAttribute.ts
+++ b/src/operations/types/dropTypeAttribute.ts
@@ -5,7 +5,7 @@ export type DropTypeAttribute = (
   typeName: Name,
   attributeName: string,
   options: IfExistsOption
-) => string | string[];
+) => string;
 
 export function dropTypeAttribute(
   mOptions: MigrationOptions

--- a/src/operations/types/renameType.ts
+++ b/src/operations/types/renameType.ts
@@ -1,10 +1,7 @@
 import type { MigrationOptions } from '../../types';
 import type { Name, Reversible } from '../generalTypes';
 
-export type RenameTypeFn = (
-  typeName: Name,
-  newTypeName: Name
-) => string | string[];
+export type RenameTypeFn = (typeName: Name, newTypeName: Name) => string;
 
 export type RenameType = Reversible<RenameTypeFn>;
 

--- a/src/operations/types/renameTypeAttribute.ts
+++ b/src/operations/types/renameTypeAttribute.ts
@@ -5,7 +5,7 @@ export type RenameTypeAttributeFn = (
   typeName: Name,
   attributeName: string,
   newAttributeName: string
-) => string | string[];
+) => string;
 
 export type RenameTypeAttribute = Reversible<RenameTypeAttributeFn>;
 

--- a/src/operations/types/renameTypeValue.ts
+++ b/src/operations/types/renameTypeValue.ts
@@ -6,7 +6,7 @@ export type RenameTypeValueFn = (
   typeName: Name,
   value: string,
   newValue: string
-) => string | string[];
+) => string;
 
 export type RenameTypeValue = Reversible<RenameTypeValueFn>;
 

--- a/src/operations/types/setTypeAttribute.ts
+++ b/src/operations/types/setTypeAttribute.ts
@@ -6,7 +6,7 @@ export type SetTypeAttribute = (
   typeName: Name,
   attributeName: string,
   attributeType: Type
-) => string | string[];
+) => string;
 
 export function setTypeAttribute(mOptions: MigrationOptions): SetTypeAttribute {
   return (typeName, attributeName, attributeType) => {

--- a/src/operations/views/alterView.ts
+++ b/src/operations/views/alterView.ts
@@ -3,10 +3,7 @@ import type { Name, Nullable } from '../generalTypes';
 import type { ViewOptions } from './shared';
 import { viewOptionStr } from './shared';
 
-export type AlterView = (
-  viewName: Name,
-  options: AlterViewOptions
-) => string | string[];
+export type AlterView = (viewName: Name, options: AlterViewOptions) => string;
 
 export interface AlterViewOptions {
   checkOption?: null | 'CASCADED' | 'LOCAL';

--- a/src/operations/views/alterViewColumn.ts
+++ b/src/operations/views/alterViewColumn.ts
@@ -10,7 +10,7 @@ export type AlterViewColumn = (
   viewName: Name,
   columnName: string,
   options: AlterViewColumnOptions
-) => string | string[];
+) => string;
 
 export function alterViewColumn(mOptions: MigrationOptions): AlterViewColumn {
   const _alter: AlterViewColumn = (viewName, columnName, options) => {

--- a/src/operations/views/createView.ts
+++ b/src/operations/views/createView.ts
@@ -23,7 +23,7 @@ export type CreateViewFn = (
   viewName: Name,
   options: CreateViewOptions & DropOptions,
   definition: string
-) => string | string[];
+) => string;
 
 export type CreateView = Reversible<CreateViewFn>;
 

--- a/src/operations/views/dropView.ts
+++ b/src/operations/views/dropView.ts
@@ -1,10 +1,7 @@
 import type { MigrationOptions } from '../../types';
 import type { DropOptions, Name } from '../generalTypes';
 
-export type DropView = (
-  viewName: Name,
-  options?: DropOptions
-) => string | string[];
+export type DropView = (viewName: Name, options?: DropOptions) => string;
 
 export function dropView(mOptions: MigrationOptions): DropView {
   const _drop: DropView = (viewName, options = {}) => {

--- a/src/operations/views/renameView.ts
+++ b/src/operations/views/renameView.ts
@@ -1,10 +1,7 @@
 import type { MigrationOptions } from '../../types';
 import type { Name, Reversible } from '../generalTypes';
 
-export type RenameViewFn = (
-  viewName: Name,
-  newViewName: Name
-) => string | string[];
+export type RenameViewFn = (viewName: Name, newViewName: Name) => string;
 
 export type RenameView = Reversible<RenameViewFn>;
 


### PR DESCRIPTION
This reduces the statement return type from `string | string[]` to just `string` in all cases where only a flat string is returned.
An `OperationFn` can still return a `string | string[]` and wrapped in `wrap` call, but this helps a bit to simplify the return type when using programmatically and/or in (vi)test cases.