### PR TITLE
chore: normalize package.json repository.url

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   "homepage": "https://github.com/salsita/node-pg-migrate",
   "repository": {
     "type": "git",
-    "url": "https://github.com/salsita/node-pg-migrate.git"
+    "url": "git+https://github.com/salsita/node-pg-migrate.git"
   },
   "dependencies": {
     "yargs": "~17.7.0"


### PR DESCRIPTION
when publishing, npm complains to run `npm pkg fix`, so I did

<img width="1173" alt="image" src="https://github.com/salsita/node-pg-migrate/assets/7195563/4760bee6-d91f-4f13-8012-3c1df9b6831b">
