### PR TITLE
Export `runner` for ESM programatic usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ versions.json
 /migrations
 /bin/*.js
 /bin/*.mjs
+/bin/esm
 
 TAGS
 REVISION

--- a/bin/node-pg-migrate.ts
+++ b/bin/node-pg-migrate.ts
@@ -3,6 +3,8 @@
 import type { DotenvConfigOptions } from 'dotenv';
 // Import as node-pg-migrate, so tsup does not self-reference as '../dist'
 // otherwise this could not be imported by esm
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
+// @ts-ignore: when a clean was made, the types are not present in the first run
 import { default as migrationRunner, Migration } from 'node-pg-migrate';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -464,10 +466,16 @@ if (action === 'create') {
           ignorePattern: IGNORE_PATTERN,
         }),
   })
-    .then((migrationPath) => {
-      console.log(format('Created migration -- %s', migrationPath));
-      process.exit(0);
-    })
+    .then(
+      (
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
+        // @ts-ignore: when a clean was made, the types are not present in the first run
+        migrationPath
+      ) => {
+        console.log(format('Created migration -- %s', migrationPath));
+        process.exit(0);
+      }
+    )
     .catch((error: unknown) => {
       console.error(error);
       process.exit(1);

--- a/bin/node-pg-migrate.ts
+++ b/bin/node-pg-migrate.ts
@@ -1,13 +1,16 @@
 #!/usr/bin/env node
 
 import type { DotenvConfigOptions } from 'dotenv';
+// Import as node-pg-migrate, so tsup does not self-reference as '../dist'
+// otherwise this could not be imported by esm
+import { default as migrationRunner, Migration } from 'node-pg-migrate';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { format } from 'node:util';
 import type { ClientConfig } from 'pg';
-import ConnectionParameters from 'pg/lib/connection-parameters';
+// This needs to be imported with .js extension, otherwise it will fail in esm
+import ConnectionParameters from 'pg/lib/connection-parameters.js';
 import yargs from 'yargs/yargs';
-import { default as migrationRunner, Migration } from '../dist';
 import type { RunnerOption } from '../src';
 import type { FilenameFormat } from '../src/migration';
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "PostgreSQL database migration management tool for node.js",
   "scripts": {
     "clean": "rimraf .eslintcache dist pnpm-lock.yaml node_modules",
-    "build:bin": "tsup-node ./bin/node-pg-migrate.ts --clean false --out-dir ./bin",
+    "build:bin": "tsup-node --config tsup-bin.config.ts",
     "build:clean": "rimraf dist",
     "build:code": "tsup-node",
     "build:types": "tsc --project tsconfig.build.json",
@@ -28,31 +28,29 @@
   },
   "type": "commonjs",
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
     "./dist/*": {
       "types": "./dist/*.d.ts",
       "require": "./dist/*.js",
-      "import": "./dist/*.mjs",
+      "import": "./dist/esm/*.mjs",
       "default": "./dist/*.js"
     },
-    "./bin/node-pg-migrate": {
-      "require": "./bin/node-pg-migrate.js",
-      "import": "./bin/node-pg-migrate.mjs",
-      "default": "./bin/node-pg-migrate.js"
+    "./bin/*": {
+      "require": "./bin/*.js",
+      "import": "./bin/*.mjs",
+      "default": "./bin/*.js"
     },
     ".": {
       "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
+      "import": "./dist/esm/index.mjs",
       "default": "./dist/index.js"
     },
     "./*": {
       "types": "./dist/*.d.ts",
-      "require": "./dist/*.js",
-      "import": "./dist/*.mjs",
-      "default": "./dist/*.js"
+      "require": "./dist/*.js"
     },
     "./package.json": "./package.json"
   },
@@ -122,6 +120,7 @@
     "eslint-plugin-prettier": "5.1.3",
     "eslint-plugin-unicorn": "52.0.0",
     "json5": "2.2.3",
+    "node-pg-migrate": "file:.",
     "npm-run-all2": "6.1.2",
     "pg": "8.11.5",
     "prettier": "3.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       json5:
         specifier: 2.2.3
         version: 2.2.3
+      node-pg-migrate:
+        specifier: file:.
+        version: file:(@types/pg@8.11.5(patch_hash=pmqk2fidwgscfur66ieqtztttq))(pg@8.11.5)
       npm-run-all2:
         specifier: 6.1.2
         version: 6.1.2
@@ -1039,8 +1042,8 @@ packages:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
     engines: {node: '>=6'}
 
-  bundle-require@4.0.3:
-    resolution: {integrity: sha512-2iscZ3fcthP2vka4Y7j277YJevwmsby/FpFDwjgw34Nl7dtCpt7zz/4TexmHMzY6KZEih7En9ImlbbgUNNQGtA==}
+  bundle-require@4.1.0:
+    resolution: {integrity: sha512-FeArRFM+ziGkRViKRnSTbHZc35dgmR9yNog05Kn0+ItI59pOAISGvnnIwW1WgFZQW59IxD9QpJnUPkdIPfZuXg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: '>=0.17'
@@ -1844,6 +1847,17 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  'node-pg-migrate@file:':
+    resolution: {directory: '', type: directory}
+    engines: {node: '>=16.18.0'}
+    hasBin: true
+    peerDependencies:
+      '@types/pg': '>=6.0.0 <9.0.0'
+      pg: '>=4.3.0 <9.0.0'
+    peerDependenciesMeta:
+      '@types/pg':
+        optional: true
+
   node-releases@2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
 
@@ -2530,8 +2544,8 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
-  vite@5.2.10:
-    resolution: {integrity: sha512-PAzgUZbP7msvQvqdSD+ErD5qGnSFiGOoWmV5yAKUEI0kdhjbH6nMWVyZQC/hSc4aXwc0oJ9aEdIiF9Oje0JFCw==}
+  vite@5.2.11:
+    resolution: {integrity: sha512-HndV31LWW05i1BLPMUCE1B9E9GFbOu1MbenhS58FuK6owSO5qHm7GiCotrNY1YE5rMeQSFBGmT5ZaLEjFizgiQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -3279,9 +3293,9 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vitejs/plugin-vue@5.0.4(vite@5.2.10(@types/node@18.19.31))(vue@3.4.26(typescript@4.8.4))':
+  '@vitejs/plugin-vue@5.0.4(vite@5.2.11(@types/node@18.19.31))(vue@3.4.26(typescript@4.8.4))':
     dependencies:
-      vite: 5.2.10(@types/node@18.19.31)
+      vite: 5.2.11(@types/node@18.19.31)
       vue: 3.4.26(typescript@4.8.4)
 
   '@vitest/coverage-v8@1.5.3(vitest@1.5.3(@types/node@18.19.31)(@vitest/ui@1.5.3))':
@@ -3562,7 +3576,7 @@ snapshots:
 
   builtin-modules@3.3.0: {}
 
-  bundle-require@4.0.3(esbuild@0.19.12):
+  bundle-require@4.1.0(esbuild@0.19.12):
     dependencies:
       esbuild: 0.19.12
       load-tsconfig: 0.2.5
@@ -4477,6 +4491,13 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  node-pg-migrate@file:(@types/pg@8.11.5(patch_hash=pmqk2fidwgscfur66ieqtztttq))(pg@8.11.5):
+    dependencies:
+      pg: 8.11.5
+      yargs: 17.7.2
+    optionalDependencies:
+      '@types/pg': 8.11.5(patch_hash=pmqk2fidwgscfur66ieqtztttq)
+
   node-releases@2.0.14: {}
 
   normalize-package-data@2.5.0:
@@ -5055,7 +5076,7 @@ snapshots:
 
   tsup@8.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@18.19.31)(typescript@4.8.4))(typescript@4.8.4):
     dependencies:
-      bundle-require: 4.0.3(esbuild@0.19.12)
+      bundle-require: 4.1.0(esbuild@0.19.12)
       cac: 6.7.14
       chokidar: 3.6.0
       debug: 4.3.4
@@ -5156,7 +5177,7 @@ snapshots:
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.2.10(@types/node@18.19.31)
+      vite: 5.2.11(@types/node@18.19.31)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -5167,7 +5188,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.2.10(@types/node@18.19.31):
+  vite@5.2.11(@types/node@18.19.31):
     dependencies:
       esbuild: 0.20.2
       postcss: 8.4.38
@@ -5183,7 +5204,7 @@ snapshots:
       '@shikijs/core': 1.4.0
       '@shikijs/transformers': 1.4.0
       '@types/markdown-it': 14.1.1
-      '@vitejs/plugin-vue': 5.0.4(vite@5.2.10(@types/node@18.19.31))(vue@3.4.26(typescript@4.8.4))
+      '@vitejs/plugin-vue': 5.0.4(vite@5.2.11(@types/node@18.19.31))(vue@3.4.26(typescript@4.8.4))
       '@vue/devtools-api': 7.1.3(vue@3.4.26(typescript@4.8.4))
       '@vueuse/core': 10.9.0(vue@3.4.26(typescript@4.8.4))
       '@vueuse/integrations': 10.9.0(focus-trap@7.5.4)(vue@3.4.26(typescript@4.8.4))
@@ -5191,7 +5212,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 6.3.0
       shiki: 1.4.0
-      vite: 5.2.10(@types/node@18.19.31)
+      vite: 5.2.11(@types/node@18.19.31)
       vue: 3.4.26(typescript@4.8.4)
     optionalDependencies:
       postcss: 8.4.38
@@ -5241,7 +5262,7 @@ snapshots:
       strip-literal: 2.1.0
       tinybench: 2.8.0
       tinypool: 0.8.4
-      vite: 5.2.10(@types/node@18.19.31)
+      vite: 5.2.11(@types/node@18.19.31)
       vite-node: 1.5.3(@types/node@18.19.31)
       why-is-node-running: 2.2.2
     optionalDependencies:

--- a/src/db.ts
+++ b/src/db.ts
@@ -3,6 +3,7 @@
  */
 import { inspect } from 'node:util';
 import type {
+  Client,
   ClientBase,
   ClientConfig,
   QueryArrayConfig,
@@ -10,7 +11,8 @@ import type {
   QueryConfig,
   QueryResult,
 } from 'pg';
-import { Client } from 'pg';
+// This needs to be imported as `*`, otherwise it will fail in esm
+import * as pg from 'pg';
 import type { DB, Logger } from './types';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -54,7 +56,7 @@ function db(
 
   const client: Client = isExternalClient
     ? (connection as Client)
-    : new Client(connection as string | ClientConfig);
+    : new pg.Client(connection as string | ClientConfig);
 
   const beforeCloseListeners: any[] = [];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -269,5 +269,6 @@ export { isPgLiteral, PgLiteral } from './utils';
 export type { PgLiteralValue } from './utils';
 
 import runner from './runner';
+export {runner} from './runner';
 // eslint-disable-next-line unicorn/prefer-export-from
 export default runner;

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -254,7 +254,7 @@ function getLogger(options: RunnerOption): Logger {
       };
 }
 
-async function runner(options: RunnerOption): Promise<RunMigration[]> {
+export async function runner(options: RunnerOption): Promise<RunMigration[]> {
   const logger = getLogger(options);
   const db = Db(
     (options as RunnerOptionClient).dbClient ||

--- a/tsup-bin.config.ts
+++ b/tsup-bin.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['bin/node-pg-migrate.ts'],
+  outDir: 'bin',
+  clean: false,
+  format: ['esm', 'cjs'],
+  target: ['es2020', 'node16'],
+  dts: false,
+  minify: false,
+  sourcemap: false,
+  bundle: false,
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,13 +1,29 @@
 import { defineConfig } from 'tsup';
 
-export default defineConfig({
-  entry: ['src/**/*.ts'],
-  outDir: 'dist',
-  clean: true,
-  format: ['esm', 'cjs'],
-  target: ['es2020', 'node16'],
-  dts: false,
-  minify: false,
-  splitting: true,
-  bundle: false,
-});
+export default defineConfig([
+  // src esm
+  {
+    entry: ['src/index.ts'],
+    outDir: 'dist/esm',
+    clean: true,
+    format: 'esm',
+    target: ['es2020', 'node16'],
+    dts: false,
+    minify: false,
+    sourcemap: false,
+    bundle: true,
+    outExtension: () => ({ js: '.mjs' }),
+  },
+  // src cjs
+  {
+    entry: ['src/**/*.ts'],
+    outDir: 'dist',
+    clean: false,
+    format: 'cjs',
+    target: ['es2020', 'node16'],
+    dts: false,
+    minify: false,
+    sourcemap: false,
+    bundle: false,
+  },
+]);


### PR DESCRIPTION
With the new ESM import, I cannot use `nodePgMigrate.default` anymore.
I have `TypeError: nodePgMigrate.default is not a function`.

It should fix the error so that we can import runner directy.
