### PR TITLE
fix: export runner as named for better esm usage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -263,11 +263,8 @@ export type {
   RenameViewFn,
   ViewOptions,
 } from './operations/views';
+export { runner as default, runner } from './runner';
 export { PgType } from './types';
 export type { MigrationBuilder, RunnerOption } from './types';
 export { isPgLiteral, PgLiteral } from './utils';
 export type { PgLiteralValue } from './utils';
-
-import runner from './runner';
-// eslint-disable-next-line unicorn/prefer-export-from
-export default runner;

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -254,7 +254,7 @@ function getLogger(options: RunnerOption): Logger {
       };
 }
 
-async function runner(options: RunnerOption): Promise<RunMigration[]> {
+export async function runner(options: RunnerOption): Promise<RunMigration[]> {
   const logger = getLogger(options);
   const db = Db(
     (options as RunnerOptionClient).dbClient ||

--- a/test/runner.spec.ts
+++ b/test/runner.spec.ts
@@ -1,6 +1,6 @@
 import type { ClientBase } from 'pg';
 import { describe, expect, it, vi } from 'vitest';
-import { default as runner } from '../src';
+import { runner } from '../src';
 
 describe('runner', () => {
   it('should return a function', () => {

--- a/test/ts/customRunner.ts
+++ b/test/ts/customRunner.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path';
 import type { Client } from 'pg';
 import type { RunnerOption } from '../../dist';
-import runner from '../../dist';
+import { runner } from '../../dist';
 
 type TestOptions = {
   count?: number;


### PR DESCRIPTION
recreation of #1150 

With the new ESM import, I cannot use `nodePgMigrate.default` anymore.
I have `TypeError: nodePgMigrate.default is not a function`.

It should fix the error so that we can import runner directy.
