### PR TITLE
fix: await db.close() in runner

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -349,7 +349,7 @@ export async function runner(options: RunnerOption): Promise<RunMigration[]> {
         });
       }
 
-      db.close();
+      await db.close();
     }
   }
 }


### PR DESCRIPTION
Fix #1159 