### PR TITLE
fix: Do not reference __dirname if it does not exist

### DIFF
--- a/src/migration.ts
+++ b/src/migration.ts
@@ -8,7 +8,8 @@
 
 import { createReadStream, createWriteStream } from 'node:fs';
 import { mkdir, readdir } from 'node:fs/promises';
-import { basename, extname, resolve } from 'node:path';
+import { basename, dirname, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { QueryResult } from 'pg';
 import type { DBConnection } from './db';
 import MigrationBuilder from './migrationBuilder';
@@ -47,6 +48,9 @@ export type CreateOptions = {
 } & (CreateOptionsTemplate | CreateOptionsDefault);
 
 const SEPARATOR = '_';
+const _dirname = typeof __dirname !== 'undefined'
+  ? __dirname
+  : dirname(fileURLToPath(import.meta.url));
 
 export async function loadMigrationFiles(
   dir: string,
@@ -138,7 +142,7 @@ export class Migration implements RunMigration {
       'templateFileName' in options
         ? resolve(process.cwd(), options.templateFileName)
         : resolve(
-            __dirname,
+            _dirname,
             `../templates/migration-template.${await resolveSuffix(directory, options)}`
           );
     const suffix = getSuffixFromFileName(templateFileName);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,4 +1,5 @@
-import { extname, relative } from 'node:path';
+import { dirname, extname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { DBConnection } from './db';
 import Db from './db';
 import type { RunMigration } from './migration';
@@ -23,6 +24,9 @@ const PG_MIGRATE_LOCK_ID = 7_241_865_325_823_964;
 const idColumn = 'id';
 const nameColumn = 'name';
 const runOnColumn = 'run_on';
+const _dirname = typeof __dirname !== 'undefined'
+  ? __dirname
+  : dirname(fileURLToPath(import.meta.url));
 
 async function loadMigrations(
   db: DBConnection,
@@ -39,7 +43,7 @@ async function loadMigrations(
         const actions: MigrationBuilderActions =
           extname(filePath) === '.sql'
             ? await migrateSqlFile(filePath)
-            : require(relative(__dirname, filePath));
+            : require(relative(_dirname, filePath));
         shorthands = { ...shorthands, ...actions.shorthands };
 
         return new Migration(


### PR DESCRIPTION
The purpose of this is to fix issue #1167 

For esmodules, it doesn't use `__dirname` to get the current module directory location, as this is not available.