### PR TITLE
fix(columns): handle column with cascade option in dropColumns

### DIFF
--- a/src/operations/tables/dropColumns.ts
+++ b/src/operations/tables/dropColumns.ts
@@ -22,14 +22,13 @@ export function dropColumns(mOptions: MigrationOptions): DropColumns {
 
     const ifExistsStr = ifExists ? 'IF EXISTS ' : '';
     const cascadeStr = cascade ? ' CASCADE' : '';
-    const columnsStr = formatLines(
-      columns.map(mOptions.literal),
-      `  DROP ${ifExistsStr}`,
-      `${cascadeStr},`
-    );
+
+    const lines = columns
+      .map(mOptions.literal)
+      .map((column) => `DROP ${ifExistsStr}${column}${cascadeStr}`);
 
     return `ALTER TABLE ${mOptions.literal(tableName)}
-${columnsStr};`;
+${formatLines(lines)};`;
   };
 
   return _drop;

--- a/test/operations/columns/dropColumns.spec.ts
+++ b/test/operations/columns/dropColumns.spec.ts
@@ -35,7 +35,7 @@ describe('operations', () => {
 
         expect(statement).toBeTypeOf('string');
         expect(statement).toBe(`ALTER TABLE "distributors"
-  DROP IF EXISTS "address";`);
+  DROP IF EXISTS "address" CASCADE;`);
       });
 
       it('should return sql statement with schema', () => {


### PR DESCRIPTION
fixes #868 

## Description
The issue was caused by the `join` operation in the `formatLines` method, which does not append `CASCADE` to the SQL `DROP` statement when processing a single index array