### PR TITLE
fix(esm): `__dirname` and `pg.Client`

### DIFF
--- a/bin/node-pg-migrate.ts
+++ b/bin/node-pg-migrate.ts
@@ -21,10 +21,7 @@ process.on('uncaughtException', (err) => {
   process.exit(1);
 });
 
-const crossRequire = createRequire(
-  // @ts-expect-error: ignore until esm only
-  import.meta.url || __dirname
-);
+const crossRequire = createRequire(resolve('noop.js'));
 
 function tryRequire<TModule = unknown>(moduleName: string): TModule | null {
   try {

--- a/src/db.ts
+++ b/src/db.ts
@@ -11,8 +11,7 @@ import type {
   QueryConfig,
   QueryResult,
 } from 'pg';
-// This needs to be imported as `*`, otherwise it will fail in esm
-import * as pg from 'pg';
+import pg from 'pg';
 import type { DB, Logger } from './types';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -8,8 +8,7 @@
 
 import { createReadStream, createWriteStream } from 'node:fs';
 import { mkdir, readdir } from 'node:fs/promises';
-import { createRequire } from 'node:module';
-import { basename, dirname, extname, join, resolve } from 'node:path';
+import { basename, extname, resolve } from 'node:path';
 import type { QueryResult } from 'pg';
 import type { DBConnection } from './db';
 import MigrationBuilder from './migrationBuilder';
@@ -135,23 +134,12 @@ export class Migration implements RunMigration {
         ? now.toISOString().replace(/\D/g, '')
         : now.valueOf();
 
-    const crossRequire = createRequire(
-      // @ts-expect-error: ignore until esm only
-      import.meta.url || __dirname
-    );
-    const moduleDir = dirname(
-      crossRequire.resolve('node-pg-migrate/package.json')
-    );
-
     const templateFileName =
       'templateFileName' in options
         ? resolve(process.cwd(), options.templateFileName)
         : resolve(
-            moduleDir,
-            join(
-              'templates',
-              `migration-template.${await resolveSuffix(directory, options)}`
-            )
+            'node_modules/node-pg-migrate/templates',
+            `migration-template.${await resolveSuffix(directory, options)}`
           );
     const suffix = getSuffixFromFileName(templateFileName);
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,4 +1,5 @@
-import { extname, relative } from 'node:path';
+import { createRequire } from 'node:module';
+import { extname, resolve } from 'node:path';
 import type { DBConnection } from './db';
 import Db from './db';
 import type { RunMigration } from './migration';
@@ -35,11 +36,11 @@ async function loadMigrations(
 
     const migrations = await Promise.all(
       files.map(async (file) => {
-        const filePath = `${options.dir}/${file}`;
+        const filePath = resolve(options.dir, file);
         const actions: MigrationBuilderActions =
           extname(filePath) === '.sql'
             ? await migrateSqlFile(filePath)
-            : require(relative(__dirname, filePath));
+            : createRequire(resolve('noop.js'))(filePath);
         shorthands = { ...shorthands, ...actions.shorthands };
 
         return new Migration(

--- a/test/db.spec.ts
+++ b/test/db.spec.ts
@@ -1,4 +1,4 @@
-import { Client } from 'pg';
+import pg, { Client } from 'pg';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DBConnection } from '../src/db';
 import Db from '../src/db';
@@ -13,6 +13,9 @@ const hoisted = vi.hoisted(() => ({
 }));
 
 vi.mock('pg', () => ({
+  default: {
+    Client: vi.fn().mockImplementation(() => hoisted.client),
+  },
   Client: vi.fn().mockImplementation(() => hoisted.client),
 }));
 
@@ -36,7 +39,7 @@ describe('db', () => {
     it('should call pg.Client with connection string', () => {
       db = Db('connection_string');
 
-      expect(Client).toBeCalledWith('connection_string');
+      expect(pg.Client).toBeCalledWith('connection_string');
     });
 
     it('should use external client', async () => {

--- a/test/ts/customRunner.ts
+++ b/test/ts/customRunner.ts
@@ -16,7 +16,7 @@ type Options =
 export const run = async (options: Options): Promise<boolean> => {
   const opts: Omit<RunnerOption, 'direction'> & Options = {
     migrationsTable: 'migrations',
-    dir: resolve(__dirname, 'migrations'),
+    dir: resolve('test', 'ts', 'migrations'),
     expectedUpLength: 2,
     expectedDownLength: 2,
     ...options,


### PR DESCRIPTION
Resolve #1167  : `__dirname is not defined`
Resolve #1190 : `pg.Client is not a constructor`

It is possible to test with [`node-pg-migrate-exp@7.4.0-experimental-1189-13`](https://www.npmjs.com/package/node-pg-migrate-exp/v/7.4.0-experimental-1189-13):

`npm i node-pg-migrate-exp`
