### PR TITLE
feat: allow specifying SET in createFunction

### DIFF
--- a/src/operations/functions/createFunction.ts
+++ b/src/operations/functions/createFunction.ts
@@ -68,9 +68,13 @@ export function createFunction(mOptions: MigrationOptions): CreateFunction {
     if (set) {
       for (const { configurationParameter, value } of set) {
         if (value === 'FROM CURRENT') {
-          options.push(`SET ${configurationParameter} FROM CURRENT`);
+          options.push(
+            `SET ${mOptions.literal(configurationParameter)} FROM CURRENT`
+          );
         } else {
-          options.push(`SET ${configurationParameter} TO ${value}`);
+          options.push(
+            `SET ${mOptions.literal(configurationParameter)} TO ${value}`
+          );
         }
       }
     }

--- a/src/operations/functions/createFunction.ts
+++ b/src/operations/functions/createFunction.ts
@@ -66,11 +66,11 @@ export function createFunction(mOptions: MigrationOptions): CreateFunction {
     }
 
     if (set) {
-      for (const { name, value } of set) {
+      for (const { configurationParameter, value } of set) {
         if (value === 'FROM CURRENT') {
-          options.push(`SET ${name} FROM CURRENT`);
+          options.push(`SET ${configurationParameter} FROM CURRENT`);
         } else {
-          options.push(`SET ${name} TO ${value}`);
+          options.push(`SET ${configurationParameter} TO ${value}`);
         }
       }
     }

--- a/src/operations/functions/createFunction.ts
+++ b/src/operations/functions/createFunction.ts
@@ -32,6 +32,7 @@ export function createFunction(mOptions: MigrationOptions): CreateFunction {
       security = 'INVOKER',
       onNull = false,
       parallel,
+      set,
     } = functionOptions;
 
     const options: string[] = [];
@@ -62,6 +63,16 @@ export function createFunction(mOptions: MigrationOptions): CreateFunction {
 
     if (parallel) {
       options.push(`PARALLEL ${parallel}`);
+    }
+
+    if (set) {
+      for (const { name, value } of set) {
+        if (value === 'FROM CURRENT') {
+          options.push(`SET ${name} FROM CURRENT`);
+        } else {
+          options.push(`SET ${name} TO ${value}`);
+        }
+      }
     }
 
     const replaceStr = replace ? ' OR REPLACE' : '';

--- a/src/operations/functions/shared.ts
+++ b/src/operations/functions/shared.ts
@@ -30,7 +30,7 @@ export interface FunctionOptions {
   parallel?: 'UNSAFE' | 'RESTRICTED' | 'SAFE';
 
   set?: Array<{
-    name: string;
+    configurationParameter: string;
     value: LiteralUnion<'FROM CURRENT'>;
   }>;
 }

--- a/src/operations/functions/shared.ts
+++ b/src/operations/functions/shared.ts
@@ -31,6 +31,6 @@ export interface FunctionOptions {
 
   set?: Array<{
     name: string;
-    value: 'FROM CURRENT' | string;
+    value: LiteralUnion<'FROM CURRENT'>;
   }>;
 }

--- a/src/operations/functions/shared.ts
+++ b/src/operations/functions/shared.ts
@@ -28,4 +28,9 @@ export interface FunctionOptions {
   onNull?: boolean;
 
   parallel?: 'UNSAFE' | 'RESTRICTED' | 'SAFE';
+
+  set?: Array<{
+    name: string;
+    value: 'FROM CURRENT' | string;
+  }>;
 }

--- a/src/operations/functions/shared.ts
+++ b/src/operations/functions/shared.ts
@@ -1,4 +1,4 @@
-import type { Value } from '../generalTypes';
+import type { LiteralUnion, Value } from '../generalTypes';
 
 export interface FunctionParamType {
   mode?: 'IN' | 'OUT' | 'INOUT' | 'VARIADIC';

--- a/test/migrations/091_function_set.js
+++ b/test/migrations/091_function_set.js
@@ -1,0 +1,30 @@
+exports.up = (pgm) => {
+  pgm.createFunction(
+    'check_password',
+    [
+      { name: 'uname', type: 'text' },
+      { name: 'pass', type: 'text' },
+    ],
+    {
+      replace: true,
+      returns: 'boolean',
+      language: 'plpgsql',
+      security: 'DEFINER',
+      set: [
+        {
+          name: 'search_path',
+          value: "''",
+        },
+      ],
+    },
+    `
+DECLARE passed BOOLEAN;
+BEGIN
+  SELECT (pwd = $2) INTO passed
+  FROM pwds
+  WHERE username = $1;
+  RETURN passed;
+END;
+`
+  );
+};

--- a/test/migrations/091_function_set.js
+++ b/test/migrations/091_function_set.js
@@ -12,7 +12,7 @@ exports.up = (pgm) => {
       security: 'DEFINER',
       set: [
         {
-          name: 'search_path',
+          configurationParameter: 'search_path',
           value: "''",
         },
       ],

--- a/test/operations/functions/createFunction.spec.ts
+++ b/test/operations/functions/createFunction.spec.ts
@@ -110,7 +110,7 @@ $pga$
             language: 'plpgsql',
             set: [
               {
-                name: 'search_path',
+                configurationParameter: 'search_path',
                 value: "''",
               },
             ],

--- a/test/operations/functions/createFunction.spec.ts
+++ b/test/operations/functions/createFunction.spec.ts
@@ -102,6 +102,37 @@ $pga$
         );
       });
 
+      it('should return sql statement with set', () => {
+        const statement = createFunctionFn(
+          'example_function',
+          [],
+          {
+            language: 'plpgsql',
+            set: [
+              {
+                name: 'search_path',
+                value: "''",
+              },
+            ],
+          },
+          `
+-- SQL here
+`
+        );
+
+        expect(statement).toBeTypeOf('string');
+        expect(statement).toBe(
+          `CREATE FUNCTION "example_function"()
+  RETURNS void
+  AS $pga$
+-- SQL here
+$pga$
+  VOLATILE
+  LANGUAGE plpgsql
+  SET search_path TO '';`
+        );
+      });
+
       it('should throw if no language provided', () => {
         expect(() =>
           createFunctionFn(

--- a/test/operations/functions/createFunction.spec.ts
+++ b/test/operations/functions/createFunction.spec.ts
@@ -129,7 +129,7 @@ $pga$
 $pga$
   VOLATILE
   LANGUAGE plpgsql
-  SET search_path TO '';`
+  SET "search_path" TO '';`
         );
       });
 


### PR DESCRIPTION
This PR introduces a change to the `createFunction` function.

It will allow specifiying `SET` statements to change configuration parameters as stated in the [official specification](https://www.postgresql.org/docs/current/sql-createfunction.html).

---

I encountered this while using Supabase: https://supabase.com/docs/guides/database/database-advisors?queryGroups=lint&lint=0011_function_search_path_mutable#how-to-resolve