### PR TITLE
fix: treat external connection as open

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -146,7 +146,8 @@ ${error}
     select,
     column,
 
-    connected: () => connectionStatus === ConnectionStatus.CONNECTED || isExternalClient,
+    connected: () =>
+      connectionStatus === ConnectionStatus.CONNECTED || isExternalClient,
     addBeforeCloseListener: (listener) => beforeCloseListeners.push(listener),
     close: async () => {
       await beforeCloseListeners.reduce(

--- a/src/db.ts
+++ b/src/db.ts
@@ -146,7 +146,7 @@ ${error}
     select,
     column,
 
-    connected: () => connectionStatus === ConnectionStatus.CONNECTED,
+    connected: () => connectionStatus === ConnectionStatus.CONNECTED || isExternalClient,
     addBeforeCloseListener: (listener) => beforeCloseListeners.push(listener),
     close: async () => {
       await beforeCloseListeners.reduce(

--- a/src/db.ts
+++ b/src/db.ts
@@ -41,6 +41,7 @@ enum ConnectionStatus {
   DISCONNECTED = 'DISCONNECTED',
   CONNECTED = 'CONNECTED',
   ERROR = 'ERROR',
+  EXTERNAL = 'EXTERNAL',
 }
 
 function db(
@@ -51,17 +52,24 @@ function db(
     typeof connection === 'object' &&
     'query' in connection &&
     typeof connection.query === 'function';
-  let connectionStatus = ConnectionStatus.DISCONNECTED;
 
   const client: Client = isExternalClient
     ? (connection as Client)
     : new pg.Client(connection as string | ClientConfig);
 
+  let connectionStatus = isExternalClient
+    ? ConnectionStatus.EXTERNAL
+    : ConnectionStatus.DISCONNECTED;
+
   const beforeCloseListeners: any[] = [];
+
+  const connected: DBConnection['connected'] = () =>
+    connectionStatus === ConnectionStatus.CONNECTED ||
+    connectionStatus === ConnectionStatus.EXTERNAL;
 
   const createConnection: DBConnection['createConnection'] = () =>
     new Promise((resolve, reject) => {
-      if (isExternalClient || connectionStatus === ConnectionStatus.CONNECTED) {
+      if (connected()) {
         resolve();
       } else if (connectionStatus === ConnectionStatus.ERROR) {
         reject(
@@ -146,8 +154,7 @@ ${error}
     select,
     column,
 
-    connected: () =>
-      connectionStatus === ConnectionStatus.CONNECTED || isExternalClient,
+    connected,
     addBeforeCloseListener: (listener) => beforeCloseListeners.push(listener),
     close: async () => {
       await beforeCloseListeners.reduce(

--- a/test/db.spec.ts
+++ b/test/db.spec.ts
@@ -134,4 +134,12 @@ describe('db', () => {
       expect(hoisted.client.end).toHaveBeenCalled();
     });
   });
+
+  describe('connected', () => {
+    it('should treat external connection as conencted', () => {
+      const mockClient = new Client();
+      const db = Db(mockClient, log);
+      expect(db.connected()).toBeTruthy();
+    });
+  });
 });


### PR DESCRIPTION
This addresses: https://github.com/salsita/node-pg-migrate/issues/885

Here is the resulting "check trace" on why advisory lock is never released for external Client

exhibit A: It checks that the connection is connected and only if it is connected -- releases the lock
```js

if (db.connected()) {
      if (!options.noLock) {
        await unlock(db).catch((error: unknown) => {
          logger.warn((error as Error).message);
        });
      }

      await db.close();
    }
```

exhibit B: Connection status is decided by this variable
```js
    connected: () => connectionStatus === ConnectionStatus.CONNECTED,
```

exhibit C: When the client is created the connection status is not updated
```js
const createConnection: DBConnection['createConnection'] = () =>
    new Promise((resolve, reject) => {
      if (isExternalClient || connectionStatus === ConnectionStatus.CONNECTED) {
        resolve();
```

exhibit D: The initial value is "DISCONNECTED"
```js
let connectionStatus = ConnectionStatus.DISCONNECTED;
```


Alternatively, this can be fixed by:
* Setting the `connectionStatus` variable to `ConnectionStatus.CONNECTED`
* Rewriting the lock check to acknowledge the external client n some way

The provded solution seems more like the most one.
If any maintainer can advise on a better solution -- I would be glad to update the PR.