### PR TITLE
chore!: drop node v18 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node_version: [18, 20]
+        node_version: [20, 22]
       fail-fast: false
     timeout-minutes: 10
 

--- a/.github/workflows/postgres-test.yml
+++ b/.github/workflows/postgres-test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [18, 20]
+        node_version: [20, 22]
         postgres_version: [13.18, 14.15, 15.10, 16.6, 17.2]
       fail-fast: false
     timeout-minutes: 10

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Started by [Theo Ephraim](https://github.com/theoephraim/), then handed over to 
 
 ## Preconditions
 
-- Node.js 18 or higher
+- Node.js 20.11 or higher
 - PostgreSQL 12.8 or higher (lower versions may work but are not supported officially)
 
 If you don't already have the [`pg`](https://node-postgres.com/) library installed, you will need to add pg as either a direct or dev dependency

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Preconditions
 
-- Node.js 18 or higher
+- Node.js 20.11 or higher
 - PostgreSQL 12.8 or higher (lower versions may work but are not supported officially)
 
 If you don't already have the [`pg`](https://node-postgres.com/) library installed, you will need to add pg as either a direct or dev dependency

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@stylistic/eslint-plugin": "3.0.1",
     "@types/config": "3.3.5",
     "@types/eslint__js": "8.42.3",
-    "@types/node": "22.13.1",
+    "@types/node": "20.17.17",
     "@types/pg": "8.11.11",
     "@types/yargs": "17.0.33",
     "@vitest/coverage-v8": "3.0.5",
@@ -150,6 +150,6 @@
   },
   "packageManager": "pnpm@10.2.1",
   "engines": {
-    "node": ">=18.19.0"
+    "node": ">=20.11.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: 8.42.3
         version: 8.42.3
       '@types/node':
-        specifier: 22.13.1
-        version: 22.13.1
+        specifier: 20.17.17
+        version: 20.17.17
       '@types/pg':
         specifier: 8.11.11
         version: 8.11.11
@@ -107,7 +107,7 @@ importers:
         version: 6.0.1
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@22.13.1)(typescript@5.7.3)
+        version: 10.9.2(@types/node@20.17.17)(typescript@5.7.3)
       tsup:
         specifier: 8.3.6
         version: 8.3.6(jiti@2.4.2)(postcss@8.5.1)(tsx@4.19.2)(typescript@5.7.3)
@@ -122,10 +122,10 @@ importers:
         version: 8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
       vitepress:
         specifier: 1.6.3
-        version: 1.6.3(@algolia/client-search@5.20.1)(@types/node@22.13.1)(postcss@8.5.1)(search-insights@2.17.3)(typescript@5.7.3)
+        version: 1.6.3(@algolia/client-search@5.20.1)(@types/node@20.17.17)(postcss@8.5.1)(search-insights@2.17.3)(typescript@5.7.3)
       vitest:
         specifier: 3.0.5
-        version: 3.0.5(@types/node@22.13.1)(@vitest/ui@3.0.5)(jiti@2.4.2)(tsx@4.19.2)
+        version: 3.0.5(@types/node@20.17.17)(@vitest/ui@3.0.5)(jiti@2.4.2)(tsx@4.19.2)
 
 packages:
 
@@ -977,8 +977,8 @@ packages:
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
-  '@types/node@22.13.1':
-    resolution: {integrity: sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==}
+  '@types/node@20.17.17':
+    resolution: {integrity: sha512-/WndGO4kIfMicEQLTi/mDANUu/iVUhT7KboZPdEqqHQ4aTS+3qT3U5gIqWDFV+XouorjfgGqvKILJeHhuQgFYg==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -2177,7 +2177,7 @@ packages:
 
   'node-pg-migrate@file:':
     resolution: {directory: '', type: directory}
-    engines: {node: '>=18.19.0'}
+    engines: {node: '>=20.11.0'}
     hasBin: true
     peerDependencies:
       '@types/pg': '>=6.0.0 <9.0.0'
@@ -2873,8 +2873,8 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@6.20.0:
-    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   unist-util-is@6.0.0:
     resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
@@ -3755,15 +3755,15 @@ snapshots:
 
   '@types/mdurl@2.0.0': {}
 
-  '@types/node@22.13.1':
+  '@types/node@20.17.17':
     dependencies:
-      undici-types: 6.20.0
+      undici-types: 6.19.8
 
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/pg@8.11.11':
     dependencies:
-      '@types/node': 22.13.1
+      '@types/node': 20.17.17
       pg-protocol: 1.7.0
       pg-types: 4.0.2
 
@@ -3856,9 +3856,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-vue@5.2.1(vite@5.4.14(@types/node@22.13.1))(vue@3.5.13(typescript@5.7.3))':
+  '@vitejs/plugin-vue@5.2.1(vite@5.4.14(@types/node@20.17.17))(vue@3.5.13(typescript@5.7.3))':
     dependencies:
-      vite: 5.4.14(@types/node@22.13.1)
+      vite: 5.4.14(@types/node@20.17.17)
       vue: 3.5.13(typescript@5.7.3)
 
   '@vitest/coverage-v8@3.0.5(vitest@3.0.5)':
@@ -3875,7 +3875,7 @@ snapshots:
       std-env: 3.8.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.5(@types/node@22.13.1)(@vitest/ui@3.0.5)(jiti@2.4.2)(tsx@4.19.2)
+      vitest: 3.0.5(@types/node@20.17.17)(@vitest/ui@3.0.5)(jiti@2.4.2)(tsx@4.19.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -3885,7 +3885,7 @@ snapshots:
       eslint: 9.19.0(jiti@2.4.2)
     optionalDependencies:
       typescript: 5.7.3
-      vitest: 3.0.5(@types/node@22.13.1)(@vitest/ui@3.0.5)(jiti@2.4.2)(tsx@4.19.2)
+      vitest: 3.0.5(@types/node@20.17.17)(@vitest/ui@3.0.5)(jiti@2.4.2)(tsx@4.19.2)
 
   '@vitest/expect@3.0.5':
     dependencies:
@@ -3894,13 +3894,13 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.5(vite@6.1.0(@types/node@22.13.1)(jiti@2.4.2)(tsx@4.19.2))':
+  '@vitest/mocker@3.0.5(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(tsx@4.19.2))':
     dependencies:
       '@vitest/spy': 3.0.5
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.1.0(@types/node@22.13.1)(jiti@2.4.2)(tsx@4.19.2)
+      vite: 6.1.0(@types/node@20.17.17)(jiti@2.4.2)(tsx@4.19.2)
 
   '@vitest/pretty-format@3.0.5':
     dependencies:
@@ -3930,7 +3930,7 @@ snapshots:
       sirv: 3.0.0
       tinyglobby: 0.2.10
       tinyrainbow: 2.0.0
-      vitest: 3.0.5(@types/node@22.13.1)(@vitest/ui@3.0.5)(jiti@2.4.2)(tsx@4.19.2)
+      vitest: 3.0.5(@types/node@20.17.17)(@vitest/ui@3.0.5)(jiti@2.4.2)(tsx@4.19.2)
 
   '@vitest/utils@3.0.5':
     dependencies:
@@ -5768,14 +5768,14 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.2(@types/node@22.13.1)(typescript@5.7.3):
+  ts-node@10.9.2(@types/node@20.17.17)(typescript@5.7.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.13.1
+      '@types/node': 20.17.17
       acorn: 8.14.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -5882,7 +5882,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@6.20.0: {}
+  undici-types@6.19.8: {}
 
   unist-util-is@6.0.0:
     dependencies:
@@ -5934,13 +5934,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@3.0.5(@types/node@22.13.1)(jiti@2.4.2)(tsx@4.19.2):
+  vite-node@3.0.5(@types/node@20.17.17)(jiti@2.4.2)(tsx@4.19.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.2
-      vite: 6.1.0(@types/node@22.13.1)(jiti@2.4.2)(tsx@4.19.2)
+      vite: 6.1.0(@types/node@20.17.17)(jiti@2.4.2)(tsx@4.19.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5955,27 +5955,27 @@ snapshots:
       - tsx
       - yaml
 
-  vite@5.4.14(@types/node@22.13.1):
+  vite@5.4.14(@types/node@20.17.17):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.1
       rollup: 4.34.6
     optionalDependencies:
-      '@types/node': 22.13.1
+      '@types/node': 20.17.17
       fsevents: 2.3.3
 
-  vite@6.1.0(@types/node@22.13.1)(jiti@2.4.2)(tsx@4.19.2):
+  vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(tsx@4.19.2):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.1
       rollup: 4.34.6
     optionalDependencies:
-      '@types/node': 22.13.1
+      '@types/node': 20.17.17
       fsevents: 2.3.3
       jiti: 2.4.2
       tsx: 4.19.2
 
-  vitepress@1.6.3(@algolia/client-search@5.20.1)(@types/node@22.13.1)(postcss@8.5.1)(search-insights@2.17.3)(typescript@5.7.3):
+  vitepress@1.6.3(@algolia/client-search@5.20.1)(@types/node@20.17.17)(postcss@8.5.1)(search-insights@2.17.3)(typescript@5.7.3):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.20.1)(search-insights@2.17.3)
@@ -5984,7 +5984,7 @@ snapshots:
       '@shikijs/transformers': 2.3.2
       '@shikijs/types': 2.3.2
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.1(vite@5.4.14(@types/node@22.13.1))(vue@3.5.13(typescript@5.7.3))
+      '@vitejs/plugin-vue': 5.2.1(vite@5.4.14(@types/node@20.17.17))(vue@3.5.13(typescript@5.7.3))
       '@vue/devtools-api': 7.7.1
       '@vue/shared': 3.5.13
       '@vueuse/core': 12.5.0(typescript@5.7.3)
@@ -5993,7 +5993,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.1.1
       shiki: 2.3.2
-      vite: 5.4.14(@types/node@22.13.1)
+      vite: 5.4.14(@types/node@20.17.17)
       vue: 3.5.13(typescript@5.7.3)
     optionalDependencies:
       postcss: 8.5.1
@@ -6024,10 +6024,10 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest@3.0.5(@types/node@22.13.1)(@vitest/ui@3.0.5)(jiti@2.4.2)(tsx@4.19.2):
+  vitest@3.0.5(@types/node@20.17.17)(@vitest/ui@3.0.5)(jiti@2.4.2)(tsx@4.19.2):
     dependencies:
       '@vitest/expect': 3.0.5
-      '@vitest/mocker': 3.0.5(vite@6.1.0(@types/node@22.13.1)(jiti@2.4.2)(tsx@4.19.2))
+      '@vitest/mocker': 3.0.5(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(tsx@4.19.2))
       '@vitest/pretty-format': 3.0.5
       '@vitest/runner': 3.0.5
       '@vitest/snapshot': 3.0.5
@@ -6043,11 +6043,11 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.1.0(@types/node@22.13.1)(jiti@2.4.2)(tsx@4.19.2)
-      vite-node: 3.0.5(@types/node@22.13.1)(jiti@2.4.2)(tsx@4.19.2)
+      vite: 6.1.0(@types/node@20.17.17)(jiti@2.4.2)(tsx@4.19.2)
+      vite-node: 3.0.5(@types/node@20.17.17)(jiti@2.4.2)(tsx@4.19.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.13.1
+      '@types/node': 20.17.17
       '@vitest/ui': 3.0.5(vitest@3.0.5)
     transitivePeerDependencies:
       - jiti

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2023",
     "module": "CommonJS",
     "moduleResolution": "Node",
-    "lib": ["ES2022", "DOM"],
+    "lib": ["ES2023", "DOM"],
     "noEmit": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2023",
     "moduleResolution": "Node",
     "module": "CommonJS",
     "strict": true,
     "noEmit": true,
-    "lib": ["ES2020"],
+    "lib": ["ES2023"],
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": true,

--- a/tsup-bin.config.ts
+++ b/tsup-bin.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   outDir: 'bin',
   clean: false,
   format: ['esm', 'cjs'],
-  target: ['es2022', 'node18'],
+  target: ['es2023', 'node20'],
   dts: false,
   minify: false,
   sourcemap: false,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,7 +7,7 @@ export default defineConfig([
     outDir: 'dist/esm',
     clean: true,
     format: 'esm',
-    target: ['es2022', 'node18'],
+    target: ['es2023', 'node20'],
     dts: false,
     minify: false,
     sourcemap: false,


### PR DESCRIPTION
also setting es2023 as target based on https://node.green/#ES2023