### PR TITLE
feat: add support for partitioning

### DIFF
--- a/src/operations/tables/createTable.ts
+++ b/src/operations/tables/createTable.ts
@@ -1,5 +1,10 @@
 import type { MigrationOptions } from '../../types';
-import { formatLines, formatPartitionColumns, intersection, makeComment } from '../../utils';
+import {
+  formatLines,
+  formatPartitionColumns,
+  intersection,
+  makeComment,
+} from '../../utils';
 import type { Name, Reversible } from '../generalTypes';
 import type { DropTableOptions } from './dropTable';
 import { dropTable } from './dropTable';

--- a/src/operations/tables/createTable.ts
+++ b/src/operations/tables/createTable.ts
@@ -1,5 +1,5 @@
 import type { MigrationOptions } from '../../types';
-import { formatLines, intersection, makeComment } from '../../utils';
+import { formatLines, formatPartitionColumns, intersection, makeComment } from '../../utils';
 import type { Name, Reversible } from '../generalTypes';
 import type { DropTableOptions } from './dropTable';
 import { dropTable } from './dropTable';
@@ -27,6 +27,7 @@ export function createTable(mOptions: MigrationOptions): CreateTable {
       like,
       constraints: optionsConstraints = {},
       comment,
+      partition,
     } = options;
 
     const {
@@ -64,11 +65,16 @@ export function createTable(mOptions: MigrationOptions): CreateTable {
     const inheritsStr = inherits
       ? ` INHERITS (${mOptions.literal(inherits)})`
       : '';
+
+    const partitionStr = partition
+      ? ` PARTITION BY ${partition.strategy} (${formatPartitionColumns(partition, mOptions.literal)})`
+      : '';
+
     const tableNameStr = mOptions.literal(tableName);
 
     const createTableQuery = `CREATE${temporaryStr} TABLE${ifNotExistsStr} ${tableNameStr} (
 ${formatLines(tableDefinition)}
-)${inheritsStr};`;
+)${inheritsStr}${partitionStr};`;
     const comments = [...columnComments, ...constraintComments];
 
     if (comment !== undefined) {

--- a/src/operations/tables/shared.ts
+++ b/src/operations/tables/shared.ts
@@ -102,6 +102,22 @@ export interface ConstraintOptions {
   comment?: string;
 }
 
+export type PartitionStrategy = 'RANGE' | 'LIST' | 'HASH';
+
+export interface PartitionColumnOptions {
+  name: string;
+  collate?: string;
+  opclass?: string;
+}
+
+export interface PartitionOptions {
+  strategy: PartitionStrategy;
+  columns:
+    | Array<string | PartitionColumnOptions>
+    | string
+    | PartitionColumnOptions;
+}
+
 export interface TableOptions extends IfNotExistsOption {
   temporary?: boolean;
 
@@ -112,6 +128,8 @@ export interface TableOptions extends IfNotExistsOption {
   constraints?: ConstraintOptions;
 
   comment?: string | null;
+
+  partition?: PartitionOptions;
 }
 
 export function parseReferences(

--- a/src/utils/formatPartitionColumns.ts
+++ b/src/utils/formatPartitionColumns.ts
@@ -1,4 +1,7 @@
-import type { PartitionColumnOptions, PartitionOptions } from '../operations/tables';
+import type {
+  PartitionColumnOptions,
+  PartitionOptions,
+} from '../operations/tables';
 import { toArray } from './toArray';
 
 function formatPartitionColumn(

--- a/src/utils/formatPartitionColumns.ts
+++ b/src/utils/formatPartitionColumns.ts
@@ -1,5 +1,4 @@
-
-import { PartitionColumnOptions, PartitionOptions } from '../operations/tables';
+import type { PartitionColumnOptions, PartitionOptions } from '../operations/tables';
 import { toArray } from './toArray';
 
 function formatPartitionColumn(
@@ -15,6 +14,7 @@ function formatPartitionColumn(
   if (column.collate) {
     formatted += ` COLLATE ${column.collate}`;
   }
+
   if (column.opclass) {
     formatted += ` ${column.opclass}`;
   }

--- a/src/utils/formatPartitionColumns.ts
+++ b/src/utils/formatPartitionColumns.ts
@@ -1,0 +1,32 @@
+
+import { PartitionColumnOptions, PartitionOptions } from '../operations/tables';
+import { toArray } from './toArray';
+
+function formatPartitionColumn(
+  column: string | PartitionColumnOptions,
+  literal: (value: string) => string
+): string {
+  if (typeof column === 'string') {
+    return literal(column);
+  }
+
+  let formatted = literal(column.name);
+
+  if (column.collate) {
+    formatted += ` COLLATE ${column.collate}`;
+  }
+  if (column.opclass) {
+    formatted += ` ${column.opclass}`;
+  }
+
+  return formatted;
+}
+
+// Helper function to format all partition columns
+export function formatPartitionColumns(
+  partition: PartitionOptions,
+  literal: (value: string) => string
+): string {
+  const columns = toArray(partition.columns);
+  return columns.map((col) => formatPartitionColumn(col, literal)).join(', ');
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,6 +4,7 @@ export { decamelize } from './decamelize';
 export { escapeValue } from './escapeValue';
 export { formatLines } from './formatLines';
 export { formatParams } from './formatParams';
+export { formatPartitionColumns } from './formatPartitionColumns';
 export { getMigrationTableSchema } from './getMigrationTableSchema';
 export { getSchemas } from './getSchemas';
 export { identity } from './identity';

--- a/test/migration.spec.ts
+++ b/test/migration.spec.ts
@@ -57,7 +57,7 @@ describe('migration', () => {
       const filePaths = await getMigrationFilePaths(dir, { logger });
 
       expect(Array.isArray(filePaths)).toBeTruthy();
-      expect(filePaths).toHaveLength(91);
+      expect(filePaths).toHaveLength(92);
       expect(filePaths).not.toContainEqual(expect.stringContaining('nested'));
 
       for (const filePath of filePaths) {
@@ -78,7 +78,7 @@ describe('migration', () => {
       });
 
       expect(Array.isArray(filePaths)).toBeTruthy();
-      expect(filePaths).toHaveLength(66);
+      expect(filePaths).toHaveLength(67);
 
       for (const filePath of filePaths) {
         expect(isAbsolute(filePath)).toBeTruthy();
@@ -94,7 +94,7 @@ describe('migration', () => {
       });
 
       expect(Array.isArray(filePaths)).toBeTruthy();
-      expect(filePaths).toHaveLength(104);
+      expect(filePaths).toHaveLength(105);
       expect(filePaths).toContainEqual(expect.stringContaining('nested'));
 
       for (const filePath of filePaths) {
@@ -114,7 +114,7 @@ describe('migration', () => {
       });
 
       expect(Array.isArray(filePaths)).toBeTruthy();
-      expect(filePaths).toHaveLength(103);
+      expect(filePaths).toHaveLength(104);
       expect(filePaths).toContainEqual(expect.stringContaining('nested'));
 
       for (const filePath of filePaths) {

--- a/test/migrations/092_partition.js
+++ b/test/migrations/092_partition.js
@@ -1,0 +1,20 @@
+exports.up = (pgm) => {
+  pgm.createTable(
+    't1',
+    {
+      id: 'id',
+      string: { type: 'text', notNull: true },
+      created: {
+        type: 'timestamp',
+        notNull: true,
+        default: pgm.func('current_timestamp'),
+      },
+    },
+    {
+      partition: {
+        strategy: 'RANGE',
+        columns: 'created',
+      },
+    }
+  );
+};

--- a/test/migrations/092_partition.js
+++ b/test/migrations/092_partition.js
@@ -2,7 +2,7 @@ exports.up = (pgm) => {
   pgm.createTable(
     't_partition',
     {
-      id: 'id',
+      id: 'serial',
       string: { type: 'text', notNull: true },
       created: {
         type: 'timestamp',
@@ -11,6 +11,9 @@ exports.up = (pgm) => {
       },
     },
     {
+      constraints: {
+        primaryKey: ['id', 'created'],
+      },
       partition: {
         strategy: 'RANGE',
         columns: 'created',

--- a/test/migrations/092_partition.js
+++ b/test/migrations/092_partition.js
@@ -1,6 +1,6 @@
 exports.up = (pgm) => {
   pgm.createTable(
-    't1',
+    't_partition',
     {
       id: 'id',
       string: { type: 'text', notNull: true },


### PR DESCRIPTION
Added support for partitioning for tables. 

```
pgm.createTable('mytable', {
  id: 'serial',
  title: 'text',
  language: 'text'
},
{
  partition: {
    strategy: 'RANGE',
    columns: 'timestamp'
  }
}
```

Supports the follow partition types: 'RANGE', 'LIST', 'HASH'.
Supports collation: ```PARTITION BY LIST ("language" COLLATE en_US)```
Supports opclass:

```
pgm.createTable('mytable', {
  id: 'uuid',
  title: 'text',
  language: 'text'
},
{
  partition: {
    strategy: 'RANGE',
    columns: { name: 'id', opclass: 'hash_extension.uuid_ops' }
  }
}
```

Supports multiple columns:
```
pgm.createTable('mytable', {
  id: 'serial',
  title: 'text',
  language: 'text'
},
{
  partition: {
    strategy: 'RANGE',
    columns: ['id', 'title']
  }
}
```

Supports multiple columns with collate: 

```
pgm.createTable('mytable', {
  id: 'serial',
  title: 'text',
  language: 'text'
},
{
  partition: {
    strategy: 'RANGE',
    columns: [{ name: 'title', collate: 'en_US'}, { name: 'language', collate: 'fr-FR'}]
  }
}
```

I tried my best to interpret the Postgresql standard for how this is suppose to work.  I wrote a bunch of unit tests and added them to the existing ones. All unit tests are passing.

Also addresses #667