### PR TITLE
fix: migration files not sorted by timestamp when using glob

### DIFF
--- a/src/migration.ts
+++ b/src/migration.ts
@@ -128,9 +128,16 @@ export async function getMigrationFilePaths(
     const globMatches = await glob(dir, {
       ignore: ignorePattern,
       nodir: true,
-      absolute: true,
+      withFileTypes: true,
     });
-    return globMatches.sort(localeCompareStringsNumerically);
+
+    return globMatches
+      .sort(
+        (a, b) =>
+          compareFileNamesByTimestamp(a.name, b.name, logger) ||
+          localeCompareStringsNumerically(a.name, b.name)
+      )
+      .map((pathScurry) => pathScurry.fullpath());
   }
 
   if (Array.isArray(dir) || Array.isArray(ignorePattern)) {


### PR DESCRIPTION
I originally thought that sorting migration files by their absolute path is good enough. Working with this has painfully taught me otherwise.
So, this changes the sorting of matched files to be done exactly the same way as the non-glob version does it (by the numeric value of the `timestamp` prefix in the filename first - and just locale string compare otherwise (when both timestamps represent the same numeric value).

Result is still an array of absolute paths.