### PR TITLE
fix!: throw error on missing db option

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -390,11 +390,16 @@ function getLogger(options: RunnerOption): Logger {
 
 export async function runner(options: RunnerOption): Promise<RunMigration[]> {
   const logger = getLogger(options);
-  const db = Db(
+
+  const connection =
     (options as RunnerOptionClient).dbClient ||
-      (options as RunnerOptionUrl).databaseUrl,
-    logger
-  );
+    (options as RunnerOptionUrl).databaseUrl;
+
+  if (connection == null) {
+    throw new Error('You must provide either a databaseUrl or a dbClient');
+  }
+
+  const db = Db(connection, logger);
 
   try {
     await db.createConnection();

--- a/test/runner.spec.ts
+++ b/test/runner.spec.ts
@@ -18,17 +18,14 @@ describe('runner', () => {
     );
   });
 
-  it.todo(
-    'should throw an error when no databaseUrl or dbClient passed',
-    async () => {
-      await expect(
-        // @ts-expect-error: runner needs options
-        runner({ log: console.log })
-      ).rejects.toThrow(
-        new Error('You must provide either a databaseUrl or a dbClient')
-      );
-    }
-  );
+  it('should throw an error when no databaseUrl or dbClient passed', async () => {
+    await expect(
+      // @ts-expect-error: runner needs options
+      runner({ log: console.log })
+    ).rejects.toThrow(
+      new Error('You must provide either a databaseUrl or a dbClient')
+    );
+  });
 
   it('should execute a basic up migration', async () => {
     const executedMigrations: Array<{


### PR DESCRIPTION
previously it throwed a `TypeError`, now it throws a more human readable error