### PR TITLE
fix: `config-file` argument support

### DIFF
--- a/bin/node-pg-migrate.ts
+++ b/bin/node-pg-migrate.ts
@@ -444,8 +444,8 @@ function readJson(json: unknown): void {
 
     if ('url' in json && json.url) {
       DB_CONNECTION ??= json.url;
-    } else if (isClientConfig(json)) {
-      DB_CONNECTION ??= {
+    } else if (isClientConfig(json) && !DB_CONNECTION) {
+      DB_CONNECTION = {
         user: json.user,
         host: json.host || 'localhost',
         database: json.name || json.database,
@@ -475,7 +475,7 @@ if (configFileName) {
   const jsonConfig = await import(`file://${resolve(configFileName)}`, {
     with: { type: 'json' },
   });
-  readJson(jsonConfig);
+  readJson(jsonConfig.default || jsonConfig);
 }
 
 await readTsconfig();

--- a/test/db-config.spec.ts
+++ b/test/db-config.spec.ts
@@ -1,9 +1,13 @@
 import { spawnSync } from 'node:child_process';
 import { unlinkSync, writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const BIN_PATH = resolve(__dirname, '../bin/node-pg-migrate.js');
+const BIN_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../bin/node-pg-migrate.js'
+);
 
 const CONFIG_JSON = {
   user: 'postgres',
@@ -17,7 +21,10 @@ const ERROR_MESSAGE =
   'environment variable is not set or incomplete connection parameters are provided';
 
 describe('node-pg-migrate config file and env fallback', () => {
-  const configFile = resolve(__dirname, 'test-config.json');
+  const configFile = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    'test-config.json'
+  );
 
   afterEach(() => {
     try {

--- a/test/db-config.spec.ts
+++ b/test/db-config.spec.ts
@@ -31,7 +31,7 @@ describe('node-pg-migrate config file and env fallback', () => {
 
   it('fails when no config file or env vars are provided', () => {
     const result = spawnSync('node', [BIN_PATH, 'up', '--dry-run'], {
-      env: {},
+      env: { ...process.env },
       encoding: 'utf8',
     });
     const errorOutput = result.stderr || result.stdout || '';

--- a/test/db-config.spec.ts
+++ b/test/db-config.spec.ts
@@ -1,7 +1,6 @@
 import { spawnSync } from 'node:child_process';
 import { unlinkSync, writeFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const BIN_PATH = resolve(import.meta.dirname, '../bin/node-pg-migrate.js');
@@ -18,10 +17,7 @@ const ERROR_MESSAGE =
   'environment variable is not set or incomplete connection parameters are provided';
 
 describe('node-pg-migrate config file and env fallback', () => {
-  const configFile = resolve(
-    dirname(fileURLToPath(import.meta.url)),
-    'test-config.json'
-  );
+  const configFile = resolve(import.meta.dirname, 'test-config.json');
 
   afterEach(() => {
     try {

--- a/test/db-config.spec.ts
+++ b/test/db-config.spec.ts
@@ -1,0 +1,90 @@
+import { spawnSync } from 'node:child_process';
+import { unlinkSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const BIN_PATH = resolve(__dirname, '../bin/node-pg-migrate.js');
+
+const CONFIG_JSON = {
+  user: 'postgres',
+  password: 'password',
+  host: 'localhost',
+  port: 5432,
+  database: 'pgmigrations',
+};
+
+describe('node-pg-migrate config file and env fallback', () => {
+  const configFile = resolve(__dirname, 'test-config.json');
+
+  afterEach(() => {
+    try {
+      unlinkSync(configFile);
+    } catch {
+      // Ignore if the file does not exist
+    }
+
+    vi.unstubAllEnvs();
+  });
+
+  it('fails with config file missing DB connection', () => {
+    writeFileSync(configFile, JSON.stringify({}), 'utf8');
+    const result = spawnSync(
+      'node',
+      [BIN_PATH, 'up', '--dry-run', '--config-file', configFile],
+      {
+        env: { ...process.env, DATABASE_URL: '' },
+        encoding: 'utf8',
+      }
+    );
+    expect(result.stderr).toContain(
+      'environment variable is not set or incomplete connection parameters are provided'
+    );
+    expect(result.status).toBe(1);
+  });
+
+  it('succeeds with valid config file containing user, database, etc', () => {
+    writeFileSync(configFile, JSON.stringify(CONFIG_JSON), 'utf8');
+    const result = spawnSync(
+      'node',
+      [BIN_PATH, 'up', '--dry-run', '--config-file', configFile],
+      {
+        env: { ...process.env, DATABASE_URL: '' },
+        encoding: 'utf8',
+      }
+    );
+    expect(result.stderr).not.toContain(
+      'environment variable is not set or incomplete connection parameters are provided'
+    );
+  });
+
+  it('succeeds with DATABASE_URL env var', () => {
+    const result = spawnSync('node', [BIN_PATH, 'up', '--dry-run'], {
+      env: {
+        ...process.env,
+        DATABASE_URL: 'postgres://myuser:mypassword@localhost:5432/mydb',
+      },
+      encoding: 'utf8',
+    });
+    expect(result.stderr).not.toContain(
+      'environment variable is not set or incomplete connection parameters are provided'
+    );
+  });
+
+  it('succeeds with PGHOST, PGUSER, PGDATABASE env vars', () => {
+    const result = spawnSync('node', [BIN_PATH, 'up', '--dry-run'], {
+      env: {
+        ...process.env,
+        DATABASE_URL: '',
+        PGHOST: 'localhost',
+        PGUSER: 'user',
+        PGDATABASE: 'db',
+        PGPASSWORD: 'pass',
+        PGPORT: '5432',
+      },
+      encoding: 'utf8',
+    });
+    expect(result.stderr).not.toContain(
+      'environment variable is not set or incomplete connection parameters are provided'
+    );
+  });
+});

--- a/test/db-config.spec.ts
+++ b/test/db-config.spec.ts
@@ -4,10 +4,7 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const BIN_PATH = resolve(
-  dirname(fileURLToPath(import.meta.url)),
-  '../bin/node-pg-migrate.js'
-);
+const BIN_PATH = resolve(import.meta.dirname, '../bin/node-pg-migrate.js');
 
 const CONFIG_JSON = {
   user: 'postgres',

--- a/test/db-config.spec.ts
+++ b/test/db-config.spec.ts
@@ -34,7 +34,8 @@ describe('node-pg-migrate config file and env fallback', () => {
       env: {},
       encoding: 'utf8',
     });
-    expect(result.stderr).toContain(ERROR_MESSAGE);
+    const errorOutput = result.stderr || result.stdout || '';
+    expect(errorOutput).toContain(ERROR_MESSAGE);
     expect(result.status).toBe(1);
   });
 

--- a/test/db-config.spec.ts
+++ b/test/db-config.spec.ts
@@ -13,6 +13,9 @@ const CONFIG_JSON = {
   database: 'pgmigrations',
 };
 
+const ERROR_MESSAGE =
+  'environment variable is not set or incomplete connection parameters are provided';
+
 describe('node-pg-migrate config file and env fallback', () => {
   const configFile = resolve(__dirname, 'test-config.json');
 
@@ -26,6 +29,15 @@ describe('node-pg-migrate config file and env fallback', () => {
     vi.unstubAllEnvs();
   });
 
+  it('fails when no config file or env vars are provided', () => {
+    const result = spawnSync('node', [BIN_PATH, 'up', '--dry-run'], {
+      env: {},
+      encoding: 'utf8',
+    });
+    expect(result.stderr).toContain(ERROR_MESSAGE);
+    expect(result.status).toBe(1);
+  });
+
   it('fails with config file missing DB connection', () => {
     writeFileSync(configFile, JSON.stringify({}), 'utf8');
     const result = spawnSync(
@@ -36,9 +48,7 @@ describe('node-pg-migrate config file and env fallback', () => {
         encoding: 'utf8',
       }
     );
-    expect(result.stderr).toContain(
-      'environment variable is not set or incomplete connection parameters are provided'
-    );
+    expect(result.stderr).toContain(ERROR_MESSAGE);
     expect(result.status).toBe(1);
   });
 
@@ -52,9 +62,7 @@ describe('node-pg-migrate config file and env fallback', () => {
         encoding: 'utf8',
       }
     );
-    expect(result.stderr).not.toContain(
-      'environment variable is not set or incomplete connection parameters are provided'
-    );
+    expect(result.stderr).not.toContain(ERROR_MESSAGE);
   });
 
   it('succeeds with DATABASE_URL env var', () => {
@@ -65,9 +73,7 @@ describe('node-pg-migrate config file and env fallback', () => {
       },
       encoding: 'utf8',
     });
-    expect(result.stderr).not.toContain(
-      'environment variable is not set or incomplete connection parameters are provided'
-    );
+    expect(result.stderr).not.toContain(ERROR_MESSAGE);
   });
 
   it('succeeds with PGHOST, PGUSER, PGDATABASE env vars', () => {
@@ -83,8 +89,6 @@ describe('node-pg-migrate config file and env fallback', () => {
       },
       encoding: 'utf8',
     });
-    expect(result.stderr).not.toContain(
-      'environment variable is not set or incomplete connection parameters are provided'
-    );
+    expect(result.stderr).not.toContain(ERROR_MESSAGE);
   });
 });


### PR DESCRIPTION


This PR fixes #1419 `--config-file` option when using JSON modules in ESM. ESM returns JSON imports wrapped in a `default` property, but the code expected a flat object. This caused valid config files to be ignored.

Changes:

* Supports unwrapping the `default` export from ESM JSON
* Handles both flat and ESM-style config objects
* Improves fallback logic for DB connection

Test coverage:

* Fails when the config file is empty and no env vars are set
* Fails when no config file or env vars are provided
* Succeeds with a valid config file
* Succeeds with DATABASE\_URL env var
* Succeeds with PGHOST, PGUSER, PGDATABASE env vars

Let me know if more cases should be added.
