### PR TITLE
fix: support `config-value` with `config-file`

### DIFF
--- a/bin/node-pg-migrate.ts
+++ b/bin/node-pg-migrate.ts
@@ -6,8 +6,8 @@ import type { DotenvConfigOptions } from 'dotenv';
 // @ts-ignore: when a clean was made, the types are not present in the first run
 import {
   Migration,
-  runner as migrationRunner,
   PG_MIGRATE_LOCK_ID,
+  runner as migrationRunner,
 } from 'node-pg-migrate';
 import { readFileSync } from 'node:fs';
 import { register } from 'node:module';
@@ -463,7 +463,7 @@ function readJson(json: unknown): void {
 const oldSuppressWarning = process.env.SUPPRESS_NO_CONFIG_WARNING;
 process.env.SUPPRESS_NO_CONFIG_WARNING = 'yes';
 const config = await tryImport<typeof import('config')>('config');
-if (config && config.has(argv[configValueArg])) {
+if (config?.has(argv[configValueArg])) {
   const db = config.get(argv[configValueArg]);
   readJson(db);
 }
@@ -475,7 +475,9 @@ if (configFileName) {
   const jsonConfig = await import(`file://${resolve(configFileName)}`, {
     with: { type: 'json' },
   });
-  readJson(jsonConfig.default || jsonConfig);
+  const json = jsonConfig.default ?? jsonConfig;
+  const section = argv[configValueArg];
+  readJson(json?.[section] === undefined ? json : json[section]);
 }
 
 await readTsconfig();

--- a/test/db-config.spec.ts
+++ b/test/db-config.spec.ts
@@ -13,6 +13,23 @@ const CONFIG_JSON = {
   database: 'pgmigrations',
 };
 
+const CONFIG_MULTI_USER_JSON = {
+  dev: {
+    user: 'pgmigrations',
+    password: 'password',
+    host: 'localhost',
+    port: 5432,
+    database: 'pgmigrations',
+  },
+  test: {
+    user: 'pgmigrations2',
+    password: 'password',
+    host: 'localhost',
+    port: 5432,
+    database: 'pgmigrations2',
+  },
+};
+
 const ERROR_MESSAGE =
   'environment variable is not set or incomplete connection parameters are provided';
 
@@ -90,6 +107,62 @@ describe('node-pg-migrate config file and env fallback', () => {
       },
       encoding: 'utf8',
     });
+    expect(result.stderr).not.toContain(ERROR_MESSAGE);
+  });
+});
+
+describe('node-pg-migrate config file with config-value section', () => {
+  const configFile = resolve(import.meta.dirname, 'test-config-multi.json');
+
+  afterEach(() => {
+    try {
+      unlinkSync(configFile);
+    } catch {
+      // Ignore if the file does not exist
+    }
+
+    vi.unstubAllEnvs();
+  });
+
+  it('succeeds with config-value "dev"', () => {
+    writeFileSync(configFile, JSON.stringify(CONFIG_MULTI_USER_JSON), 'utf8');
+    const result = spawnSync(
+      'node',
+      [
+        BIN_PATH,
+        'up',
+        '--dry-run',
+        '--config-file',
+        configFile,
+        '--config-value',
+        'dev',
+      ],
+      {
+        env: { ...process.env, DATABASE_URL: '' },
+        encoding: 'utf8',
+      }
+    );
+    expect(result.stderr).not.toContain(ERROR_MESSAGE);
+  });
+
+  it('succeeds with config-value "test"', () => {
+    writeFileSync(configFile, JSON.stringify(CONFIG_MULTI_USER_JSON), 'utf8');
+    const result = spawnSync(
+      'node',
+      [
+        BIN_PATH,
+        'up',
+        '--dry-run',
+        '--config-file',
+        configFile,
+        '--config-value',
+        'test',
+      ],
+      {
+        env: { ...process.env, DATABASE_URL: '' },
+        encoding: 'utf8',
+      }
+    );
     expect(result.stderr).not.toContain(ERROR_MESSAGE);
   });
 });


### PR DESCRIPTION
Ensures the correct config section is selected when both `--config-file` and `--config-value` are provided.
Adds unit tests for multi-section config files to prevent regressions.
Closes #891.

