### PR TITLE
fix: remove unused silent option from dotenv config

### DIFF
--- a/bin/node-pg-migrate.ts
+++ b/bin/node-pg-migrate.ts
@@ -253,10 +253,7 @@ if (argv.help || argv._.length === 0) {
 const envPath = argv[envPathArg];
 
 // Create default dotenv config
-const dotenvConfig: DotenvConfigOptions & { silent: boolean } = {
-  // TODO @Shinigami92 2024-04-05: Does the silent option even still exists and do anything?
-  silent: true,
-};
+const dotenvConfig: DotenvConfigOptions = {};
 
 // If the path has been configured, add it to the config, otherwise don't change the default dotenv path
 if (envPath) {


### PR DESCRIPTION
This PR removes the unused (since 2016!) `silent` option from the dotenv config. It was dropped in dotenv v3, so keeping it just adds confusion.

See:
https://github.com/motdotla/dotenv/blob/master/CHANGELOG.md#removed-6
and finally
https://github.com/motdotla/dotenv/blob/master/CHANGELOG.md#removed-5