### PR TITLE
fix: enable quiet mode in default dotenv config

### DIFF
--- a/bin/node-pg-migrate.ts
+++ b/bin/node-pg-migrate.ts
@@ -233,7 +233,9 @@ if (argv.help || argv._.length === 0) {
 const envPath = argv[envPathArg];
 
 // Create default dotenv config
-const dotenvConfig: DotenvConfigOptions = {};
+const dotenvConfig: DotenvConfigOptions = {
+  quiet: true,
+};
 
 // If the path has been configured, add it to the config, otherwise don't change the default dotenv path
 if (envPath) {


### PR DESCRIPTION
This will suppress noise on every run when you use last `dotenv` versions like `silent` was intended to-do, but it got removed a long time ago (see #1461) and added back (see https://github.com/motdotla/dotenv/blob/master/CHANGELOG.md#1700-2025-06-27)
<img width="948" height="129" alt="image" src="https://github.com/user-attachments/assets/86f9e7fe-7236-48cf-b01f-265250eae5da" />
