### PR TITLE
docs: Fix documentation of JSON config options

### DIFF
--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -125,16 +125,39 @@ Other available options are:
 ```jsonc
 {
   "schema": "public",
-  "createSchema": false,
-  "migrationsDir": "migrations",
-  "migrationsSchema": "public",
-  "createMigrationsSchema": false,
-  "migrationsTable": "pgmigrations",
-  "migrationFilenameFormat": "utc",
-  "migrationFileLanguage": "js",
-  "ignorePattern": undefined,
-  "checkOrder": true,
+  "create-schema": false,
+  "database-url-var": "SECRET_DB_URL",
+  "migrations-dir": "migrations",
+  "use-glob": false,
+  "migrations-schema": "public",
+  "create-migrations-schema": false,
+  "migrations-table": "pgmigrations",
+  "migration-filename-format": "utc",
+  "migration-file-language": "js",
+  "ignore-pattern": "/SKIP$/",
+  "template-file-name": "templates/new-migration.js",
+  "check-order": true,
   "verbose": true,
   "decamelize": false,
 }
 ```
+
+If you want to vary the configuration (e.g. for different environments), you can provide a map of configuration
+groups and specify which to use with the `--config-value` command line option.
+
+For example with a config like:
+
+```jsonc
+{
+  "dev": {
+    "migrations-schema": "public",
+    "verbose": true
+  },
+  "prod": {
+    "migrations-schema": "myapp"
+  }
+}
+```
+
+The command `node-pg-migrate --config-file=migrations.config.js --config-value=prod` will apply the `prod` configuration.
+There are no constraints on how you name your configuration groups.

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -151,11 +151,11 @@ For example with a config like:
 {
   "dev": {
     "migrations-schema": "public",
-    "verbose": true
+    "verbose": true,
   },
   "prod": {
-    "migrations-schema": "myapp"
-  }
+    "migrations-schema": "myapp",
+  },
 }
 ```
 


### PR DESCRIPTION
The documentation currently shows that JSON config options should be given in camelCase.

However, this is incorrect - [readJson uses the same keys as the CLI argument values](https://github.com/salsita/node-pg-migrate/blob/main/bin/node-pg-migrate.ts#L325). 

So for example `"migrationsDir": "migrations"` will never be applied, it should instead be `"migrations-dir": "migrations"`. It looks like this has always been the case - the old documentation  mentions using the CLI argument names but this was replaced with a JSON example when the docs were rewritten in #1132.

I have also added an example showing the support for using different config sections and the `-config-value` flag, which is not currently documented AFAICS.