### PR TITLE
feat: add jiti tsconfigPaths option for migrations

### DIFF
--- a/bin/node-pg-migrate.ts
+++ b/bin/node-pg-migrate.ts
@@ -77,6 +77,7 @@ const verboseArg = 'verbose';
 const rejectUnauthorizedArg = 'reject-unauthorized';
 const envPathArg = 'envPath';
 const advisoryLockModeArg = 'advisory-lock-mode';
+const tsconfigPathsArg = 'tsconfig-paths';
 
 const parser = yargs(process.argv.slice(2))
   .usage('Usage: $0 [up|down|create|redo] [migrationName] [options]')
@@ -224,6 +225,12 @@ const parser = yargs(process.argv.slice(2))
       choices: ['fail', 'wait'],
       type: 'string',
     },
+    [tsconfigPathsArg]: {
+      defaultDescription: 'false',
+      describe:
+        "Enable jiti's tsconfig paths resolution when loading TS/JS migration files. Pass `true` to auto-discover tsconfig.json, or a path to a specific tsconfig.json",
+      type: 'string',
+    },
   })
 
   .version()
@@ -301,6 +308,9 @@ let DECAMELIZE = argv[decamelizeArg];
 let ADVISORY_LOCK_MODE: 'fail' | 'wait' | undefined = argv[
   advisoryLockModeArg
 ] as 'fail' | 'wait' | undefined;
+let TSCONFIG_PATHS: boolean | string | undefined = parseTsconfigPaths(
+  argv[tsconfigPathsArg]
+);
 
 function applyIf<TArg, TKey extends string = string>(
   arg: TArg,
@@ -323,6 +333,33 @@ function isString(val: unknown): val is string {
 
 function isBoolean(val: unknown): val is boolean {
   return typeof val === 'boolean';
+}
+
+function isBooleanOrString(val: unknown): val is boolean | string {
+  return typeof val === 'boolean' || typeof val === 'string';
+}
+
+/**
+ * Coerces the `--tsconfig-paths` CLI value into the `boolean | string` shape that
+ * jiti expects: the literals `true`/`false` toggle auto-discovery, any other
+ * string is treated as an explicit path to a `tsconfig.json`.
+ */
+function parseTsconfigPaths(
+  val: string | undefined
+): boolean | string | undefined {
+  if (val === undefined) {
+    return undefined;
+  }
+
+  if (val === 'true') {
+    return true;
+  }
+
+  if (val === 'false') {
+    return false;
+  }
+
+  return val;
 }
 
 function isClientConfig(val: unknown): val is ClientConfig & { name?: string } {
@@ -396,6 +433,12 @@ function readJson(json: unknown): void {
     CHECK_ORDER = applyIf(CHECK_ORDER, checkOrderArg, json, isBoolean);
     VERBOSE = applyIf(VERBOSE, verboseArg, json, isBoolean);
     DECAMELIZE = applyIf(DECAMELIZE, decamelizeArg, json, isBoolean);
+    TSCONFIG_PATHS = applyIf(
+      TSCONFIG_PATHS,
+      tsconfigPathsArg,
+      json,
+      isBooleanOrString
+    );
     DB_CONNECTION = applyIf(
       DB_CONNECTION,
       databaseUrlVarArg,
@@ -605,6 +648,7 @@ if (action === 'create') {
       fake,
       decamelize: DECAMELIZE,
       advisoryLockMode: ADVISORY_LOCK_MODE,
+      tsconfigPaths: TSCONFIG_PATHS,
     };
   };
 

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -106,6 +106,7 @@ You can adjust defaults by passing arguments to `node-pg-migrate`:
 | `decamelize`                |         | `false`                         | Runs `decamelize` on table/column/etc. names                                                                                                                                                                                                                                            |
 | `verbose`                   |         | `true`                          | Print all debug messages like DB queries run, to switch it off supply `--no-verbose`                                                                                                                                                                                                    |
 | `reject-unauthorized`       |         | `undefined`                     | Sets ssl `rejectUnauthorized` parameter. Use for e.g. self-signed certificates on the server. [see](https://node-postgres.com/announcements#2020-02-25)                                                                                                                                 |
+| `tsconfig-paths`            |         | `false`                         | Enable [`jiti`](https://github.com/unjs/jiti) tsconfig paths resolution when loading TS/JS migration files. Pass `true` to auto-discover the nearest `tsconfig.json`, or a path to a specific `tsconfig.json` (e.g. `--tsconfig-paths ./tsconfig.json`)                                 |
 
 For SSL connection to DB you can set `PGSSLMODE` environment variable to value
 from [list](https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNECT-SSLMODE) other
@@ -140,6 +141,7 @@ Other available options are:
   "check-order": true,
   "verbose": true,
   "decamelize": false,
+  "tsconfig-paths": "./tsconfig.json",
 }
 ```
 

--- a/docs/src/migration-loading-strategies.md
+++ b/docs/src/migration-loading-strategies.md
@@ -73,6 +73,33 @@ await runner({
 });
 ```
 
+## TypeScript Path Aliases (`tsconfigPaths`)
+
+The default loader uses [`jiti`](https://github.com/unjs/jiti) to load `.js` / `.ts` migration files.
+By default, `compilerOptions.paths` aliases from your `tsconfig.json` are **not** resolved.
+Set `tsconfigPaths` to enable them:
+
+- `true` — auto-discover the nearest `tsconfig.json` (walking up from `cwd()`)
+- a `string` — explicit path to a `tsconfig.json` file
+- `false` / omitted (default) — disabled
+
+```ts
+import { runner } from 'node-pg-migrate';
+
+await runner({
+  databaseUrl: process.env.DATABASE_URL!,
+  dir: 'migrations',
+  direction: 'up',
+  migrationsTable: 'pgmigrations',
+  // resolve `compilerOptions.paths` aliases inside migration files
+  tsconfigPaths: './tsconfig.json',
+});
+```
+
+This option only affects the jiti-based loader; it has no effect on the SQL loaders.
+When a custom `migrationLoaderStrategies` array maps an extension to the `'default'` predefined
+loader, that loader honors `tsconfigPaths` as well.
+
 ## Strategy Matching Rules
 
 - Extension matching is case-insensitive

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     'templates',
     'test/jiti/migrations/**/*.js',
     'test/jiti/migrations/**/*.mjs',
+    'test/jiti/tsconfig-paths/**',
   ],
   options: {
     reportUnusedDisableDirectives: 'error',

--- a/src/migrationLoader.ts
+++ b/src/migrationLoader.ts
@@ -1,3 +1,4 @@
+import type { Jiti } from 'jiti';
 import { createJiti } from 'jiti';
 import { readFile } from 'node:fs/promises';
 import { basename, extname } from 'node:path';
@@ -75,6 +76,21 @@ export interface MigrationLoaderConfig {
   migrationLoaderStrategies?: MigrationLoaderStrategy[];
 
   /**
+   * Enable [`jiti`](https://github.com/unjs/jiti) tsconfig paths resolution when
+   * loading TypeScript/JavaScript migration files. This makes `compilerOptions.paths`
+   * aliases defined in your `tsconfig.json` resolvable from within migration files.
+   *
+   * - `true`: auto-discover the nearest `tsconfig.json` (walking up from `cwd()`)
+   * - `string`: explicit path to a `tsconfig.json` file
+   * - `false` / `undefined` (default): disabled
+   *
+   * Has no effect on the built-in SQL loaders.
+   *
+   * @default false
+   */
+  tsconfigPaths?: boolean | string;
+
+  /**
    * Redirect messages to this logger object, rather than `console`.
    */
   logger?: Logger;
@@ -105,16 +121,20 @@ export interface MigrationLoaderStrategy {
 
 /**
  * Creates a default migration loader that uses jiti to load migrations from the file paths.
+ * @param jitiInstance - The jiti instance to use to load migration files. Defaults to the shared {@link jiti} instance.
  * @returns The default migration loader.
  */
-export function createDefaultMigrationLoader(): MigrationLoader {
+export function createDefaultMigrationLoader(
+  jitiInstance: Jiti = jiti
+): MigrationLoader {
   const loader: MigrationLoader = async (filePaths: string[]) => {
     const migrationUnits: MigrationUnit[] = [];
 
     // Load migrations sequentially to avoid unnecessary parallelism and
     // potential handle pressure from many concurrent imports.
     for (const filePath of filePaths) {
-      const action: MigrationBuilderActions = await jiti.import(filePath);
+      const action: MigrationBuilderActions =
+        await jitiInstance.import(filePath);
       migrationUnits.push({
         id: filePath,
         filePaths: [filePath],
@@ -186,41 +206,73 @@ export const builtInLoaders: Record<PredefinedLoader, MigrationLoader> = {
 };
 
 /**
- * Default migration loader strategies.
+ * Builds the default migration loader strategies for a given default loader.
+ * @param defaultLoader - The loader to use for non-SQL extensions.
+ * @returns The default migration loader strategies.
  */
-const defaultStrategies: MigrationLoaderStrategy[] = [
-  { extensions: ['.sql'], loader: builtInLoaders.legacySql },
-  {
-    extensions: ['.js', '.ts', '.cjs', '.mjs', '.cts', '.mts'],
-    loader: builtInLoaders.default,
-  },
-];
+function getDefaultStrategies(
+  defaultLoader: MigrationLoader
+): MigrationLoaderStrategy[] {
+  return [
+    { extensions: ['.sql'], loader: builtInLoaders.legacySql },
+    {
+      extensions: ['.js', '.ts', '.cjs', '.mjs', '.cts', '.mts'],
+      loader: defaultLoader,
+    },
+  ];
+}
 
 /*************************
  * Loader utility functions
  *************************/
 
 /**
+ * Resolves the default (non-SQL) migration loader for a given configuration.
+ *
+ * When {@link MigrationLoaderConfig.tsconfigPaths} is enabled, a dedicated jiti
+ * instance is created so that TypeScript path aliases are resolved; otherwise the
+ * shared default loader (bound to the shared {@link jiti} instance) is reused.
+ *
+ * @param config - The Runner configuration object.
+ * @returns The default migration loader.
+ */
+function resolveDefaultLoader(config: MigrationLoaderConfig): MigrationLoader {
+  if (config.tsconfigPaths === undefined || config.tsconfigPaths === false) {
+    return builtInLoaders.default;
+  }
+
+  const configuredJiti = createJiti(process.cwd(), {
+    tsconfigPaths: config.tsconfigPaths,
+  });
+
+  return createDefaultMigrationLoader(configuredJiti);
+}
+
+/**
  * Resolves the migration loader for a given extension.
  * @param config - The Runner configuration object.
  * @param extension - The extension to resolve the loader for.
+ * @param defaultLoader - The fallback loader to use when no strategy matches or the `default` predefined loader is referenced.
  * @returns The migration loader.
  */
 function resolveMigrationLoader(
   config: MigrationLoaderConfig,
-  extension: string
+  extension: string,
+  defaultLoader: MigrationLoader
 ): MigrationLoader {
   const normalizedExtension = extension.toLowerCase();
-  const strategies = config.migrationLoaderStrategies ?? defaultStrategies;
+  const strategies =
+    config.migrationLoaderStrategies ?? getDefaultStrategies(defaultLoader);
 
   const foundStrategy = strategies.find((strategy) =>
     strategy.extensions.some((ext) => ext.toLowerCase() === normalizedExtension)
   );
 
-  const loader = foundStrategy?.loader ?? builtInLoaders.default;
+  const loader = foundStrategy?.loader ?? defaultLoader;
 
   if (typeof loader === 'string') {
-    const resolved = builtInLoaders[loader];
+    const resolved =
+      loader === 'default' ? defaultLoader : builtInLoaders[loader];
     if (!resolved) {
       throw new Error(`Unknown predefined loader: ${loader}`);
     }
@@ -273,9 +325,10 @@ export async function loadMigrationUnits(
   filePaths: string[]
 ): Promise<MigrationUnit[]> {
   const migrationUnits: MigrationUnit[] = [];
+  const defaultLoader = resolveDefaultLoader(config);
   const filesByExtension = associatePathsToExtensions(filePaths);
   for (const [extension, filePaths] of filesByExtension) {
-    const loader = resolveMigrationLoader(config, extension);
+    const loader = resolveMigrationLoader(config, extension, defaultLoader);
     const units = await loader(filePaths);
     migrationUnits.push(...units);
   }

--- a/test/jiti/tsconfig-paths.spec.ts
+++ b/test/jiti/tsconfig-paths.spec.ts
@@ -1,0 +1,56 @@
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { Migration, RunnerOption } from '../../src';
+import type { DBConnection } from '../../src/db';
+import { loadMigrations } from '../../src/runner';
+
+describe('loadMigrations with tsconfigPaths', () => {
+  const tsconfigPath = resolve(
+    import.meta.dirname,
+    'tsconfig-paths/tsconfig.json'
+  );
+  const db: DBConnection = {} as never;
+
+  function createOptions(
+    dir: string,
+    tsconfigPaths: RunnerOption['tsconfigPaths']
+  ): RunnerOption {
+    return {
+      dir,
+      ignorePattern: undefined,
+      useGlob: false,
+      migrationsTable: 'migrations',
+      direction: 'up',
+      databaseUrl: 'postgres://user:pass@localhost/db',
+      tsconfigPaths,
+    };
+  }
+
+  it('should resolve tsconfig path aliases when given an explicit tsconfig path', async () => {
+    const dir = resolve(import.meta.dirname, 'tsconfig-paths/migrations');
+
+    const migrations: Migration[] = await loadMigrations(
+      db,
+      createOptions(dir, tsconfigPath),
+      console
+    );
+
+    expect(migrations).toHaveLength(1);
+    expect(migrations[0].up).toBeTypeOf('function');
+    expect(migrations[0].down).toBeTypeOf('function');
+  });
+
+  it('should fail to resolve the alias when tsconfigPaths is disabled', async () => {
+    // Uses a dedicated migration file: jiti caches transforms per file path, so
+    // reusing the file from the test above would hit a cache entry that already
+    // has the alias resolved and mask the disabled behaviour.
+    const dir = resolve(
+      import.meta.dirname,
+      'tsconfig-paths/uncached-migrations'
+    );
+
+    await expect(
+      loadMigrations(db, createOptions(dir, undefined), console)
+    ).rejects.toThrow('Error loading migration files');
+  });
+});

--- a/test/jiti/tsconfig-paths/helpers/columns.ts
+++ b/test/jiti/tsconfig-paths/helpers/columns.ts
@@ -1,0 +1,5 @@
+export const tableName = 'aliased_table';
+
+export const columns = {
+  id: 'id',
+};

--- a/test/jiti/tsconfig-paths/migrations/1-with-alias.ts
+++ b/test/jiti/tsconfig-paths/migrations/1-with-alias.ts
@@ -1,0 +1,15 @@
+import { columns, tableName } from '@helpers/columns';
+import type {
+  ColumnDefinitions,
+  MigrationBuilder,
+} from '../../../../dist/bundle';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.createTable(tableName, columns);
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropTable(tableName);
+}

--- a/test/jiti/tsconfig-paths/tsconfig.json
+++ b/test/jiti/tsconfig-paths/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@helpers/*": ["./helpers/*"]
+    }
+  }
+}

--- a/test/jiti/tsconfig-paths/uncached-migrations/1-with-alias.ts
+++ b/test/jiti/tsconfig-paths/uncached-migrations/1-with-alias.ts
@@ -1,0 +1,15 @@
+import { columns, tableName } from '@helpers/columns';
+import type {
+  ColumnDefinitions,
+  MigrationBuilder,
+} from '../../../../dist/bundle';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.createTable(tableName, columns);
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropTable(tableName);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,11 @@
     "verbatimModuleSyntax": true,
     "erasableSyntaxOnly": true
   },
-  "exclude": ["node_modules", "templates", "dist", "migrations"]
+  "exclude": [
+    "node_modules",
+    "templates",
+    "dist",
+    "migrations",
+    "test/jiti/tsconfig-paths"
+  ]
 }


### PR DESCRIPTION
## Summary

Closes #1615.

Adds a `tsconfigPaths` option so TypeScript `compilerOptions.paths` aliases are resolved when loading TS/JS migration files. It's a thin pass-through to jiti's own `tsconfigPaths`:

- `true` - auto-discover the nearest `tsconfig.json`
- `string` - explicit path to a `tsconfig.json`
- `false` / omitted (default) - disabled

Only affects the jiti-based default loader; SQL loaders are untouched.

## Details

- Adds `tsconfigPaths` to `MigrationLoaderConfig` (flows through `RunnerOption`); when set, a dedicated jiti instance is used instead of the shared one.
- New `--tsconfig-paths` CLI flag and `tsconfig-paths` JSON-config key.
- Docs and tests (positive + negative cases) added.

## Design notes

Defaults to `false` to match jiti's own default. Open question for @osdiab: should v9 default to auto-discovery (`true`) instead? Alpha is the cheap window to decide before stable.
