### PR TITLE
feat: support array column type option

### DIFF
--- a/docs/src/migrations/columns.md
+++ b/docs/src/migrations/columns.md
@@ -6,32 +6,48 @@ The `createTable` and `addColumns` methods both take a `columns` argument that s
 It is an object (key/value) where each key is the name of the column,
 and the value is another object that defines the options for the column.
 
-| Option                        | Type                                  | Description                                                                                  |
-| ----------------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `type`                        | `string`                              | Data type (use normal postgres types)                                                        |
-| `collation`                   | `string`                              | Collation of data type                                                                       |
-| `unique`                      | `boolean`                             | Set to true to add a unique constraint on this column                                        |
-| `primaryKey`                  | `boolean`                             | Set to true to make this column the primary key                                              |
-| `notNull`                     | `boolean`                             | Set to true to make this column not null                                                     |
-| `default`                     | `string`                              | Adds DEFAULT clause for column. Accepts null, a literal value, or a `pgm.func()` expression. |
-| `check`                       | `string`                              | SQL for a check constraint for this column                                                   |
-| `references`                  | [Name](/migrations/#type) or `string` | A table name that this column is a foreign key to                                            |
-| `referencesConstraintName`    | `string`                              | Name of the created constraint                                                               |
-| `referencesConstraintComment` | `string`                              | Comment on the created constraint                                                            |
-| `onDelete`                    | `string`                              | Adds ON DELETE constraint for a reference column                                             |
-| `onUpdate`                    | `string`                              | Adds ON UPDATE constraint for a reference column                                             |
-| `match`                       | `string`                              | `FULL` or `SIMPLE`                                                                           |
-| `deferrable`                  | `boolean`                             | Flag for deferrable column constraint                                                        |
-| `deferred`                    | `boolean`                             | Flag for initially deferred deferrable column constraint                                     |
-| `comment`                     | `string`                              | Adds comment on column                                                                       |
-| `expressionGenerated`         | `string`                              | Expression to compute column value                                                           |
-| `sequenceGenerated`           | `object`                              | Creates identity column see [sequence options section](sequences.md#sequence-options)        |
-| `precedence`                  | `string`                              | `ALWAYS` or `BY DEFAULT`                                                                     |
+| Option                        | Type                                  | Description                                                                                       |
+| ----------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `type`                        | `string`                              | Data type (use normal postgres types)                                                             |
+| `array`                       | `boolean` or `number`                 | Defines the column as a PostgreSQL array type. Use `true` for `ARRAY` or a number for `ARRAY[n]`. |
+| `collation`                   | `string`                              | Collation of data type                                                                            |
+| `unique`                      | `boolean`                             | Set to true to add a unique constraint on this column                                             |
+| `primaryKey`                  | `boolean`                             | Set to true to make this column the primary key                                                   |
+| `notNull`                     | `boolean`                             | Set to true to make this column not null                                                          |
+| `default`                     | `string`                              | Adds DEFAULT clause for column. Accepts null, a literal value, or a `pgm.func()` expression.      |
+| `check`                       | `string`                              | SQL for a check constraint for this column                                                        |
+| `references`                  | [Name](/migrations/#type) or `string` | A table name that this column is a foreign key to                                                 |
+| `referencesConstraintName`    | `string`                              | Name of the created constraint                                                                    |
+| `referencesConstraintComment` | `string`                              | Comment on the created constraint                                                                 |
+| `onDelete`                    | `string`                              | Adds ON DELETE constraint for a reference column                                                  |
+| `onUpdate`                    | `string`                              | Adds ON UPDATE constraint for a reference column                                                  |
+| `match`                       | `string`                              | `FULL` or `SIMPLE`                                                                                |
+| `deferrable`                  | `boolean`                             | Flag for deferrable column constraint                                                             |
+| `deferred`                    | `boolean`                             | Flag for initially deferred deferrable column constraint                                          |
+| `comment`                     | `string`                              | Adds comment on column                                                                            |
+| `expressionGenerated`         | `string`                              | Expression to compute column value                                                                |
+| `sequenceGenerated`           | `object`                              | Creates identity column see [sequence options section](sequences.md#sequence-options)             |
+| `precedence`                  | `string`                              | `ALWAYS` or `BY DEFAULT`                                                                          |
 
 ## Data types & Convenience Shorthand
 
 Data type strings will be passed through directly to postgres, so write types as you would if you were writing the
 queries by hand.
+
+**PostgreSQL array columns can be defined with the `array` option:**
+
+```ts
+pgm.addColumns('myTable', {
+  tags: { type: PgType.TEXT, array: true },
+  payByQuarter: { type: PgType.INTEGER, array: 4 },
+});
+```
+
+String-based PostgreSQL array type declarations continue to work as before:
+
+```ts
+pgm.addColumns('myTable', { tags: { type: 'text[]' } });
+```
 
 **There are some aliases on types to make things more foolproof:** _(int, string, float, double, datetime, bool)_
 

--- a/src/operations/tables/shared.ts
+++ b/src/operations/tables/shared.ts
@@ -35,6 +35,8 @@ export type SequenceGeneratedOptions = {
 export interface ColumnDefinition extends Partial<ReferencesOptions> {
   type: string;
 
+  array?: boolean | number;
+
   collation?: string;
 
   unique?: boolean;
@@ -219,6 +221,7 @@ export function parseColumns(
     columns: Object.entries(columnsWithOptions).map(([columnName, options]) => {
       const {
         type,
+        array,
         collation,
         default: defaultValue,
         unique,
@@ -302,7 +305,14 @@ export function parseColumns(
       const constraintsStr =
         constraints.length > 0 ? ` ${constraints.join(' ')}` : '';
 
-      const sType = typeof type === 'object' ? mOptions.literal(type) : type;
+      const baseType = typeof type === 'object' ? mOptions.literal(type) : type;
+
+      const sType =
+        array === true
+          ? `${baseType} ARRAY`
+          : typeof array === 'number'
+            ? `${baseType} ARRAY[${array}]`
+            : baseType;
 
       return `${mOptions.literal(columnName)} ${sType}${constraintsStr}`;
     }),

--- a/test/operations/columns/addColumns.spec.ts
+++ b/test/operations/columns/addColumns.spec.ts
@@ -64,6 +64,77 @@ describe('operations', () => {
         );
       });
 
+      it('should support unbounded array column type option', () => {
+        const statement = addColumnsFn('transactions', {
+          tags: {
+            type: PgType.TEXT,
+            array: true,
+          },
+        });
+
+        expect(statement).toBeTypeOf('string');
+        expect(statement).toBe(`ALTER TABLE "transactions"
+  ADD "tags" text ARRAY;`);
+      });
+
+      it('should pass numeric array dimensions through to SQL', () => {
+        const arrayDimension = 17;
+
+        const statement = addColumnsFn('transactions', {
+          scores: {
+            type: PgType.INTEGER,
+            array: arrayDimension,
+          },
+        });
+
+        expect(statement).toBeTypeOf('string');
+        expect(statement).toBe(`ALTER TABLE "transactions"
+  ADD "scores" integer ARRAY[${arrayDimension}];`);
+      });
+
+      it('should support array option for different column types', () => {
+        const statement = addColumnsFn('transactions', {
+          ids: {
+            type: PgType.UUID,
+            array: true,
+          },
+          aliases: {
+            type: 'varchar(30)',
+            array: true,
+          },
+        });
+
+        expect(statement).toBeTypeOf('string');
+        expect(statement).toBe(`ALTER TABLE "transactions"
+  ADD "ids" uuid ARRAY,
+  ADD "aliases" varchar(30) ARRAY;`);
+      });
+
+      it('should keep string-based array type declarations unchanged', () => {
+        const statement = addColumnsFn('transactions', {
+          tags: {
+            type: `${PgType.TEXT}[]`,
+          },
+        });
+
+        expect(statement).toBeTypeOf('string');
+        expect(statement).toBe(`ALTER TABLE "transactions"
+  ADD "tags" text[];`);
+      });
+
+      it('should ignore false array option', () => {
+        const statement = addColumnsFn('transactions', {
+          description: {
+            type: PgType.TEXT,
+            array: false,
+          },
+        });
+
+        expect(statement).toBeTypeOf('string');
+        expect(statement).toBe(`ALTER TABLE "transactions"
+  ADD "description" text;`);
+      });
+
       describe('reverse', () => {
         it('should contain a reverse function', () => {
           expect(addColumnsFn.reverse).toBeTypeOf('function');

--- a/test/operations/tables/createTable.spec.ts
+++ b/test/operations/tables/createTable.spec.ts
@@ -728,6 +728,29 @@ COMMENT ON CONSTRAINT "fk_col_b" ON "my_table_name" IS $pga$fk b comment$pga$;`,
         }
       );
 
+      it('should support array column type options', () => {
+        const arrayDimension = 8;
+
+        const statement = createTableFn('arrays', {
+          tags: {
+            type: PgType.TEXT,
+            array: true,
+          },
+          scores: {
+            type: PgType.INTEGER,
+            array: arrayDimension,
+          },
+        });
+
+        expect(statement).toBeTypeOf('string');
+        expect(statement).toBe(
+          `CREATE TABLE "arrays" (
+  "tags" text ARRAY,
+  "scores" integer ARRAY[${arrayDimension}]
+);`
+        );
+      });
+
       describe('reverse', () => {
         it('should contain a reverse function', () => {
           expect(createTableFn.reverse).toBeTypeOf('function');


### PR DESCRIPTION
## Summary

Adds support for defining PostgreSQL array column types through the column options API.

Supported examples:

```ts
{ type: PgType.TEXT, array: true }
{ type: PgType.INTEGER, array: 4 }
```

Existing string-based type declarations such as:

```ts
{ type: `${PgType.TEXT}[]` }
```

continue to work unchanged.

## Scope

This PR only supports defining array column types through column options.

It does not implement altering existing non-array columns into array columns, as that was discussed as a separate feature in #1524.

This change intentionally does not add validation for numeric array dimensions. Numeric values are passed through to PostgreSQL as `ARRAY[n]`, matching the existing SQL-generation style.

## Tests

- Added tests for `array: true`
- Added a test that numeric array dimensions are passed through to SQL
- Added coverage for different column types
- Verified existing string-based array type declarations remain unchanged
- Verified `array: false` keeps existing non-array behavior
- Verified both `addColumns` and `createTable` paths

Ran:

- `pnpm run build`
- `pnpm run ts-check`
- `pnpm run lint`
  - Passed with 4 unrelated existing warnings
- `pnpm run format:check`
- `pnpm run test:unit`

Closes #1524
