### PR TITLE
feat: support IF EXISTS table guard for dropConstraint

### DIFF
--- a/docs/src/migrations/constraints.md
+++ b/docs/src/migrations/constraints.md
@@ -59,10 +59,14 @@
 
 #### Options
 
-| Option     | Type      | Description                        |
-| ---------- | --------- | ---------------------------------- |
-| `ifExists` | `boolean` | Drops constraint only if it exists |
-| `cascade`  | `boolean` | Drops also dependent objects       |
+| Option          | Type      | Description                                                                  |
+| --------------- | --------- | ---------------------------------------------------------------------------- |
+| `ifExists`      | `boolean` | Adds `IF EXISTS` to `DROP CONSTRAINT` so a missing constraint does not error |
+| `ifTableExists` | `boolean` | Adds `IF EXISTS` to `ALTER TABLE` so a missing table does not error          |
+| `cascade`       | `boolean` | Drops also dependent objects                                                 |
+
+> [!NOTE]
+> `ifExists` only guards the constraint name (`DROP CONSTRAINT IF EXISTS`). `ifTableExists` guards the table (`ALTER TABLE IF EXISTS`) and can hide typos, schema mistakes, or migration-order issues. It is mainly useful for retry-safe non-transactional migrations.
 
 ## Operation: `renameConstraint`
 

--- a/src/operations/tables/dropConstraint.ts
+++ b/src/operations/tables/dropConstraint.ts
@@ -1,7 +1,9 @@
 import type { MigrationOptions } from '../../migrationOptions';
 import type { DropOptions, Name } from '../generalTypes';
 
-export type DropConstraintOptions = DropOptions;
+export type DropConstraintOptions = DropOptions & {
+  ifTableExists?: boolean;
+};
 
 export type DropConstraint = (
   tableName: Name,
@@ -11,14 +13,21 @@ export type DropConstraint = (
 
 export function dropConstraint(mOptions: MigrationOptions): DropConstraint {
   const _drop: DropConstraint = (tableName, constraintName, options = {}) => {
-    const { ifExists = false, cascade = false } = options;
+    const {
+      ifExists = false,
+      ifTableExists = false,
+      cascade = false,
+    } = options;
 
+    const alterTableStr = ifTableExists
+      ? 'ALTER TABLE IF EXISTS'
+      : 'ALTER TABLE';
     const ifExistsStr = ifExists ? ' IF EXISTS' : '';
     const cascadeStr = cascade ? ' CASCADE' : '';
     const tableNameStr = mOptions.literal(tableName);
     const constraintNameStr = mOptions.literal(constraintName);
 
-    return `ALTER TABLE ${tableNameStr} DROP CONSTRAINT${ifExistsStr} ${constraintNameStr}${cascadeStr};`;
+    return `${alterTableStr} ${tableNameStr} DROP CONSTRAINT${ifExistsStr} ${constraintNameStr}${cascadeStr};`;
   };
 
   return _drop;

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-13.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-13.stdout.log
@@ -1,4 +1,5 @@
 > Migrating files:
+> - 097_drop_constraint_if_table_exists
 > - 096_expression_index
 > - 095_index_nulls
 > - 094_unlogged_table
@@ -95,6 +96,10 @@
 > - 003_promise
 > - 002_callback
 > - 001_noop
+### MIGRATION 097_drop_constraint_if_table_exists (DOWN) ###
+DELETE FROM "public"."pgmigrations" WHERE name='097_drop_constraint_if_table_exists';
+
+
 ### MIGRATION 096_expression_index (DOWN) ###
 DROP INDEX "pgm_users_meta_id_json_operator_idx";
 DROP INDEX "pgm_users_meta_id_text_operator_idx";

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-14.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-14.stdout.log
@@ -1,4 +1,5 @@
 > Migrating files:
+> - 097_drop_constraint_if_table_exists
 > - 096_expression_index
 > - 095_index_nulls
 > - 094_unlogged_table
@@ -95,6 +96,10 @@
 > - 003_promise
 > - 002_callback
 > - 001_noop
+### MIGRATION 097_drop_constraint_if_table_exists (DOWN) ###
+DELETE FROM "public"."pgmigrations" WHERE name='097_drop_constraint_if_table_exists';
+
+
 ### MIGRATION 096_expression_index (DOWN) ###
 DROP INDEX "pgm_users_meta_id_json_operator_idx";
 DROP INDEX "pgm_users_meta_id_text_operator_idx";

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-15.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-15.stdout.log
@@ -1,4 +1,5 @@
 > Migrating files:
+> - 097_drop_constraint_if_table_exists
 > - 096_expression_index
 > - 095_index_nulls
 > - 094_unlogged_table
@@ -95,6 +96,10 @@
 > - 003_promise
 > - 002_callback
 > - 001_noop
+### MIGRATION 097_drop_constraint_if_table_exists (DOWN) ###
+DELETE FROM "public"."pgmigrations" WHERE name='097_drop_constraint_if_table_exists';
+
+
 ### MIGRATION 096_expression_index (DOWN) ###
 DROP INDEX "pgm_users_meta_id_json_operator_idx";
 DROP INDEX "pgm_users_meta_id_text_operator_idx";

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-16.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-16.stdout.log
@@ -1,4 +1,5 @@
 > Migrating files:
+> - 097_drop_constraint_if_table_exists
 > - 096_expression_index
 > - 095_index_nulls
 > - 094_unlogged_table
@@ -95,6 +96,10 @@
 > - 003_promise
 > - 002_callback
 > - 001_noop
+### MIGRATION 097_drop_constraint_if_table_exists (DOWN) ###
+DELETE FROM "public"."pgmigrations" WHERE name='097_drop_constraint_if_table_exists';
+
+
 ### MIGRATION 096_expression_index (DOWN) ###
 DROP INDEX "pgm_users_meta_id_json_operator_idx";
 DROP INDEX "pgm_users_meta_id_text_operator_idx";

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-17.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-17.stdout.log
@@ -1,4 +1,5 @@
 > Migrating files:
+> - 097_drop_constraint_if_table_exists
 > - 096_expression_index
 > - 095_index_nulls
 > - 094_unlogged_table
@@ -95,6 +96,10 @@
 > - 003_promise
 > - 002_callback
 > - 001_noop
+### MIGRATION 097_drop_constraint_if_table_exists (DOWN) ###
+DELETE FROM "public"."pgmigrations" WHERE name='097_drop_constraint_if_table_exists';
+
+
 ### MIGRATION 096_expression_index (DOWN) ###
 DROP INDEX "pgm_users_meta_id_json_operator_idx";
 DROP INDEX "pgm_users_meta_id_text_operator_idx";

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-18.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-18.stdout.log
@@ -1,4 +1,5 @@
 > Migrating files:
+> - 097_drop_constraint_if_table_exists
 > - 096_expression_index
 > - 095_index_nulls
 > - 094_unlogged_table
@@ -95,6 +96,10 @@
 > - 003_promise
 > - 002_callback
 > - 001_noop
+### MIGRATION 097_drop_constraint_if_table_exists (DOWN) ###
+DELETE FROM "public"."pgmigrations" WHERE name='097_drop_constraint_if_table_exists';
+
+
 ### MIGRATION 096_expression_index (DOWN) ###
 DROP INDEX "pgm_users_meta_id_json_operator_idx";
 DROP INDEX "pgm_users_meta_id_text_operator_idx";

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-13.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-13.stdout.log
@@ -95,6 +95,7 @@
 > - 094_unlogged_table
 > - 095_index_nulls
 > - 096_expression_index
+> - 097_drop_constraint_if_table_exists
 ### MIGRATION 001_noop (UP) ###
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('001_noop', NOW());
 
@@ -847,6 +848,18 @@ CREATE INDEX "pgm_users_meta_remove_path_operator_idx" ON "pgm_users" ((meta #- 
 CREATE INDEX "pgm_users_meta_path_exists_operator_idx" ON "pgm_users" ((meta @? '$.id ? (@ == 1)'));
 CREATE INDEX "pgm_users_meta_path_predicate_operator_idx" ON "pgm_users" ((meta @@ '$.id == 1'));
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('096_expression_index', NOW());
+
+
+### MIGRATION 097_drop_constraint_if_table_exists (UP) ###
+CREATE TABLE "drop_constraint_if_table_exists" (
+  "id" serial PRIMARY KEY,
+  "value" integer
+);
+ALTER TABLE "drop_constraint_if_table_exists"
+  ADD CONSTRAINT "drop_constraint_if_table_exists_check" CHECK (value > 0);
+DROP TABLE "drop_constraint_if_table_exists";
+ALTER TABLE IF EXISTS "drop_constraint_if_table_exists" DROP CONSTRAINT IF EXISTS "drop_constraint_if_table_exists_check";
+INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('097_drop_constraint_if_table_exists', NOW());
 
 
 Migrations complete!

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-14.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-14.stdout.log
@@ -95,6 +95,7 @@
 > - 094_unlogged_table
 > - 095_index_nulls
 > - 096_expression_index
+> - 097_drop_constraint_if_table_exists
 ### MIGRATION 001_noop (UP) ###
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('001_noop', NOW());
 
@@ -847,6 +848,18 @@ CREATE INDEX "pgm_users_meta_remove_path_operator_idx" ON "pgm_users" ((meta #- 
 CREATE INDEX "pgm_users_meta_path_exists_operator_idx" ON "pgm_users" ((meta @? '$.id ? (@ == 1)'));
 CREATE INDEX "pgm_users_meta_path_predicate_operator_idx" ON "pgm_users" ((meta @@ '$.id == 1'));
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('096_expression_index', NOW());
+
+
+### MIGRATION 097_drop_constraint_if_table_exists (UP) ###
+CREATE TABLE "drop_constraint_if_table_exists" (
+  "id" serial PRIMARY KEY,
+  "value" integer
+);
+ALTER TABLE "drop_constraint_if_table_exists"
+  ADD CONSTRAINT "drop_constraint_if_table_exists_check" CHECK (value > 0);
+DROP TABLE "drop_constraint_if_table_exists";
+ALTER TABLE IF EXISTS "drop_constraint_if_table_exists" DROP CONSTRAINT IF EXISTS "drop_constraint_if_table_exists_check";
+INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('097_drop_constraint_if_table_exists', NOW());
 
 
 Migrations complete!

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-15.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-15.stdout.log
@@ -95,6 +95,7 @@
 > - 094_unlogged_table
 > - 095_index_nulls
 > - 096_expression_index
+> - 097_drop_constraint_if_table_exists
 ### MIGRATION 001_noop (UP) ###
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('001_noop', NOW());
 
@@ -851,6 +852,18 @@ CREATE INDEX "pgm_users_meta_remove_path_operator_idx" ON "pgm_users" ((meta #- 
 CREATE INDEX "pgm_users_meta_path_exists_operator_idx" ON "pgm_users" ((meta @? '$.id ? (@ == 1)'));
 CREATE INDEX "pgm_users_meta_path_predicate_operator_idx" ON "pgm_users" ((meta @@ '$.id == 1'));
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('096_expression_index', NOW());
+
+
+### MIGRATION 097_drop_constraint_if_table_exists (UP) ###
+CREATE TABLE "drop_constraint_if_table_exists" (
+  "id" serial PRIMARY KEY,
+  "value" integer
+);
+ALTER TABLE "drop_constraint_if_table_exists"
+  ADD CONSTRAINT "drop_constraint_if_table_exists_check" CHECK (value > 0);
+DROP TABLE "drop_constraint_if_table_exists";
+ALTER TABLE IF EXISTS "drop_constraint_if_table_exists" DROP CONSTRAINT IF EXISTS "drop_constraint_if_table_exists_check";
+INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('097_drop_constraint_if_table_exists', NOW());
 
 
 Migrations complete!

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-16.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-16.stdout.log
@@ -95,6 +95,7 @@
 > - 094_unlogged_table
 > - 095_index_nulls
 > - 096_expression_index
+> - 097_drop_constraint_if_table_exists
 ### MIGRATION 001_noop (UP) ###
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('001_noop', NOW());
 
@@ -851,6 +852,18 @@ CREATE INDEX "pgm_users_meta_remove_path_operator_idx" ON "pgm_users" ((meta #- 
 CREATE INDEX "pgm_users_meta_path_exists_operator_idx" ON "pgm_users" ((meta @? '$.id ? (@ == 1)'));
 CREATE INDEX "pgm_users_meta_path_predicate_operator_idx" ON "pgm_users" ((meta @@ '$.id == 1'));
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('096_expression_index', NOW());
+
+
+### MIGRATION 097_drop_constraint_if_table_exists (UP) ###
+CREATE TABLE "drop_constraint_if_table_exists" (
+  "id" serial PRIMARY KEY,
+  "value" integer
+);
+ALTER TABLE "drop_constraint_if_table_exists"
+  ADD CONSTRAINT "drop_constraint_if_table_exists_check" CHECK (value > 0);
+DROP TABLE "drop_constraint_if_table_exists";
+ALTER TABLE IF EXISTS "drop_constraint_if_table_exists" DROP CONSTRAINT IF EXISTS "drop_constraint_if_table_exists_check";
+INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('097_drop_constraint_if_table_exists', NOW());
 
 
 Migrations complete!

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-17.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-17.stdout.log
@@ -95,6 +95,7 @@
 > - 094_unlogged_table
 > - 095_index_nulls
 > - 096_expression_index
+> - 097_drop_constraint_if_table_exists
 ### MIGRATION 001_noop (UP) ###
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('001_noop', NOW());
 
@@ -861,6 +862,18 @@ CREATE INDEX "pgm_users_meta_remove_path_operator_idx" ON "pgm_users" ((meta #- 
 CREATE INDEX "pgm_users_meta_path_exists_operator_idx" ON "pgm_users" ((meta @? '$.id ? (@ == 1)'));
 CREATE INDEX "pgm_users_meta_path_predicate_operator_idx" ON "pgm_users" ((meta @@ '$.id == 1'));
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('096_expression_index', NOW());
+
+
+### MIGRATION 097_drop_constraint_if_table_exists (UP) ###
+CREATE TABLE "drop_constraint_if_table_exists" (
+  "id" serial PRIMARY KEY,
+  "value" integer
+);
+ALTER TABLE "drop_constraint_if_table_exists"
+  ADD CONSTRAINT "drop_constraint_if_table_exists_check" CHECK (value > 0);
+DROP TABLE "drop_constraint_if_table_exists";
+ALTER TABLE IF EXISTS "drop_constraint_if_table_exists" DROP CONSTRAINT IF EXISTS "drop_constraint_if_table_exists_check";
+INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('097_drop_constraint_if_table_exists', NOW());
 
 
 Migrations complete!

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-18.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-18.stdout.log
@@ -95,6 +95,7 @@
 > - 094_unlogged_table
 > - 095_index_nulls
 > - 096_expression_index
+> - 097_drop_constraint_if_table_exists
 ### MIGRATION 001_noop (UP) ###
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('001_noop', NOW());
 
@@ -861,6 +862,18 @@ CREATE INDEX "pgm_users_meta_remove_path_operator_idx" ON "pgm_users" ((meta #- 
 CREATE INDEX "pgm_users_meta_path_exists_operator_idx" ON "pgm_users" ((meta @? '$.id ? (@ == 1)'));
 CREATE INDEX "pgm_users_meta_path_predicate_operator_idx" ON "pgm_users" ((meta @@ '$.id == 1'));
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('096_expression_index', NOW());
+
+
+### MIGRATION 097_drop_constraint_if_table_exists (UP) ###
+CREATE TABLE "drop_constraint_if_table_exists" (
+  "id" serial PRIMARY KEY,
+  "value" integer
+);
+ALTER TABLE "drop_constraint_if_table_exists"
+  ADD CONSTRAINT "drop_constraint_if_table_exists_check" CHECK (value > 0);
+DROP TABLE "drop_constraint_if_table_exists";
+ALTER TABLE IF EXISTS "drop_constraint_if_table_exists" DROP CONSTRAINT IF EXISTS "drop_constraint_if_table_exists_check";
+INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('097_drop_constraint_if_table_exists', NOW());
 
 
 Migrations complete!

--- a/test/migration.spec.ts
+++ b/test/migration.spec.ts
@@ -46,7 +46,7 @@ describe('migration', () => {
       const filePaths = await getMigrationFilePaths(dir, { logger });
 
       expect(Array.isArray(filePaths)).toBeTruthy();
-      expect(filePaths).toHaveLength(96);
+      expect(filePaths).toHaveLength(97);
       expect(filePaths).not.toContainEqual(expect.stringContaining('nested'));
 
       for (const filePath of filePaths) {
@@ -67,7 +67,7 @@ describe('migration', () => {
       });
 
       expect(Array.isArray(filePaths)).toBeTruthy();
-      expect(filePaths).toHaveLength(71);
+      expect(filePaths).toHaveLength(72);
 
       for (const filePath of filePaths) {
         expect(isAbsolute(filePath)).toBeTruthy();
@@ -83,7 +83,7 @@ describe('migration', () => {
       });
 
       expect(Array.isArray(filePaths)).toBeTruthy();
-      expect(filePaths).toHaveLength(109);
+      expect(filePaths).toHaveLength(110);
       expect(filePaths).toContainEqual(expect.stringContaining('nested'));
 
       for (const filePath of filePaths) {
@@ -103,7 +103,7 @@ describe('migration', () => {
       });
 
       expect(Array.isArray(filePaths)).toBeTruthy();
-      expect(filePaths).toHaveLength(108);
+      expect(filePaths).toHaveLength(109);
       expect(filePaths).toContainEqual(expect.stringContaining('nested'));
 
       for (const filePath of filePaths) {
@@ -133,7 +133,7 @@ describe('migration', () => {
         ignorePattern
       );
 
-      expect(nextPrefix).toEqual('097');
+      expect(nextPrefix).toEqual('098');
     });
 
     it('should fail to get the next index with invalid filenames', async () => {

--- a/test/migrations/097_drop_constraint_if_table_exists.js
+++ b/test/migrations/097_drop_constraint_if_table_exists.js
@@ -1,0 +1,22 @@
+export const up = (pgm) => {
+  const tableName = 'drop_constraint_if_table_exists';
+  const constraintName = 'drop_constraint_if_table_exists_check';
+
+  pgm.createTable(tableName, {
+    id: 'id',
+    value: 'integer',
+  });
+
+  pgm.addConstraint(tableName, constraintName, {
+    check: 'value > 0',
+  });
+
+  pgm.dropTable(tableName);
+
+  pgm.dropConstraint(tableName, constraintName, {
+    ifTableExists: true,
+    ifExists: true,
+  });
+};
+
+export const down = () => null;

--- a/test/operations/constraints/addConstraint.spec.ts
+++ b/test/operations/constraints/addConstraint.spec.ts
@@ -171,6 +171,18 @@ COMMENT ON CONSTRAINT "my_constraint_name" ON "my_table_name" IS $pga$this is an
             )
           );
         });
+
+        it('should forward dropConstraint options in reverse', () => {
+          const statement = addConstraintFn.reverse('distributors', 'zipchk', {
+            ifTableExists: true,
+            ifExists: true,
+          });
+
+          expect(statement).toBeTypeOf('string');
+          expect(statement).toBe(
+            'ALTER TABLE IF EXISTS "distributors" DROP CONSTRAINT IF EXISTS "zipchk";'
+          );
+        });
       });
     });
   });

--- a/test/operations/constraints/dropConstraint.spec.ts
+++ b/test/operations/constraints/dropConstraint.spec.ts
@@ -31,6 +31,37 @@ describe('operations', () => {
           'ALTER TABLE "distributors" DROP CONSTRAINT IF EXISTS "zipchk" CASCADE;'
         );
       });
+
+      it.each([
+        [
+          'ifExists',
+          { ifExists: true },
+          'ALTER TABLE "distributors" DROP CONSTRAINT IF EXISTS "zipchk";',
+        ],
+        [
+          'ifTableExists',
+          { ifTableExists: true },
+          'ALTER TABLE IF EXISTS "distributors" DROP CONSTRAINT "zipchk";',
+        ],
+        [
+          'ifTableExists and ifExists',
+          { ifTableExists: true, ifExists: true },
+          'ALTER TABLE IF EXISTS "distributors" DROP CONSTRAINT IF EXISTS "zipchk";',
+        ],
+        [
+          'ifTableExists, ifExists and cascade',
+          { ifTableExists: true, ifExists: true, cascade: true },
+          'ALTER TABLE IF EXISTS "distributors" DROP CONSTRAINT IF EXISTS "zipchk" CASCADE;',
+        ],
+      ] as const)(
+        'should return sql statement with %s',
+        (_, options, expected) => {
+          const statement = dropConstraintFn('distributors', 'zipchk', options);
+
+          expect(statement).toBeTypeOf('string');
+          expect(statement).toBe(expected);
+        }
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add an explicit `ifTableExists` option to `dropConstraint`
- Emit `ALTER TABLE IF EXISTS` when the option is set
- Preserve the existing `ifExists` behavior for `DROP CONSTRAINT IF EXISTS`

## Why

`dropConstraint` already supports `ifExists`, but that only applies to the constraint itself:

```sql
ALTER TABLE "my_table" DROP CONSTRAINT IF EXISTS "my_table_userId_fkey";
```

This still fails if the table no longer exists.

The issue describes a retry case for non-transactional migrations, where a previous migration attempt may have already dropped the table but failed before the migration was recorded as complete. In that case, retrying can fail at an earlier `dropConstraint` call.

PostgreSQL supports guarding the table separately:

```sql
ALTER TABLE IF EXISTS "my_table"
DROP CONSTRAINT IF EXISTS "my_table_userId_fkey";
```

So this PR adds a separate `ifTableExists` option for that case.

## Notes

I kept `ifTableExists` separate from `ifExists` on purpose.

Changing `ifExists` to also emit `ALTER TABLE IF EXISTS` would be a behavior change. A missing table can still be useful as an error signal, for example when there is a typo, a wrong schema name, or a migration-order issue.

`ifTableExists` only guards the table part of the statement. If callers also want to ignore a missing constraint, they still need to pass `ifExists: true`.

I also avoided adding this option to the shared `DropOptions` type, since that would expose it to unrelated operations such as `dropTable`. Instead, `DropConstraintOptions` now extends `DropOptions` and adds only this option.

`addConstraint` already combines forward constraint options with reverse `dropConstraint` options, so I kept that existing structure and added a small test for the reverse pass-through path.

This does not make non-transactional migrations fully safe. It only lets `dropConstraint` emit `ALTER TABLE IF EXISTS` when the caller explicitly asks for it.

## Tests

- Added SQL generation coverage for `ifTableExists`
- Added coverage for `ifTableExists` with `ifExists`
- Added coverage for `ifTableExists` with `ifExists` and `cascade`
- Added coverage for reverse pass-through from `addConstraint` to `dropConstraint`
- Ran `pnpm test`
- Ran `pnpm test:unit test/operations/constraints/dropConstraint.spec.ts test/operations/constraints/addConstraint.spec.ts`
- Ran `pnpm ts-check`
- Ran `pnpm lint` (0 errors; existing warnings are unrelated to this change)
- Ran `pnpm format:check`
- Ran `pnpm docs:build`
- Added integration coverage under `test/migrations`
- Updated migration snapshots/counts

Closes #1628
