### PR TITLE
fix(escapeValue): stop deleting the ARRAY keyword from escaped strings

### DIFF
--- a/src/utils/escapeValue.ts
+++ b/src/utils/escapeValue.ts
@@ -1,6 +1,8 @@
 import { isPgLiteral, stringIdGenerator } from '.';
 import type { Value } from '../operations/generalTypes';
 
+const ARRAY_KEYWORD = 'ARRAY';
+
 export function escapeValue(val: Value): string | number {
   if (val === null) {
     return 'NULL';
@@ -28,8 +30,18 @@ export function escapeValue(val: Value): string | number {
   }
 
   if (Array.isArray(val)) {
-    const arrayStr = val.map(escapeValue).join(',').replace(/ARRAY/g, '');
-    return `ARRAY[${arrayStr}]`;
+    // A nested array escapes to its own `ARRAY[…]` constructor, but Postgres
+    // expects the keyword only on the outermost one: `ARRAY[[1],[2]]` rather
+    // than `ARRAY[ARRAY[1],ARRAY[2]]`. Strip the keyword from the nested
+    // element itself — stripping it from the joined string would also delete
+    // `ARRAY` wherever it occurs inside escaped string values.
+    const elements = val.map((element) =>
+      Array.isArray(element)
+        ? String(escapeValue(element)).slice(ARRAY_KEYWORD.length)
+        : escapeValue(element)
+    );
+
+    return `${ARRAY_KEYWORD}[${elements.join(',')}]`;
   }
 
   if (isPgLiteral(val)) {

--- a/test/utils/escapeValue.spec.ts
+++ b/test/utils/escapeValue.spec.ts
@@ -59,6 +59,36 @@ describe('utils', () => {
       expect(actual).toBe('ARRAY[[$pga$a$pga$],[$pga$b$pga$]]');
     });
 
+    it('should parse deeply nested array to ARRAY constructor syntax string', () => {
+      const value = [
+        [[1], [2]],
+        [[3], [4]],
+      ];
+
+      const actual = escapeValue(value);
+
+      expect(actual).toBeTypeOf('string');
+      expect(actual).toBe('ARRAY[[[1],[2]],[[3],[4]]]');
+    });
+
+    it('should keep the ARRAY substring inside escaped strings', () => {
+      const value = ['ARRAY_A', 'ARRAY_B'];
+
+      const actual = escapeValue(value);
+
+      expect(actual).toBeTypeOf('string');
+      expect(actual).toBe('ARRAY[$pga$ARRAY_A$pga$,$pga$ARRAY_B$pga$]');
+    });
+
+    it('should keep the ARRAY substring inside nested escaped strings', () => {
+      const value = [['an ARRAY of things']];
+
+      const actual = escapeValue(value);
+
+      expect(actual).toBeTypeOf('string');
+      expect(actual).toBe('ARRAY[[$pga$an ARRAY of things$pga$]]');
+    });
+
     it('should parse PgLiteral to unescaped string', () => {
       const input = '@l|<e';
       const value = PgLiteral.create(input);


### PR DESCRIPTION
## Problem

`escapeValue` flattens nested array constructors by running a global string replace over the already-escaped element list:

```js
const arrayStr = val.map(escapeValue).join(',').replace(/ARRAY/g, '');
return `ARRAY[${arrayStr}]`;
```

That replace cannot tell the `ARRAY` keyword of a nested constructor apart from the characters `A R R A Y` occurring **inside a dollar-quoted string value**. So any string element containing the uppercase substring `ARRAY` gets it deleted:

```js
pgm.createTable('t', {
  kind: { type: 'text[]', default: ['ARRAY_A', 'ARRAY_B'] },
});
```

```sql
-- emitted today
CREATE TABLE "t" ("kind" text[] DEFAULT ARRAY[$pga$_A$pga$,$pga$_B$pga$]);
```

The result is valid SQL that runs without error and silently stores `{_A,_B}`. Confirmed against Postgres:

```
BEFORE  DDL     : ... DEFAULT ARRAY[$pga$_A$pga$,$pga$_B$pga$]
        default : ARRAY['_A'::text, '_B'::text]
        stored  : ["_A","_B"]          <-- wrong

AFTER   DDL     : ... DEFAULT ARRAY[$pga$ARRAY_A$pga$,$pga$ARRAY_B$pga$]
        default : ARRAY['ARRAY_A'::text, 'ARRAY_B'::text]
        stored  : ["ARRAY_A","ARRAY_B"]
```

The same corruption reaches every caller that escapes an array value — `createTable` / `addColumns` / `alterColumn` / `alterViewColumn` defaults, `createDomain` and `alterDomain` defaults, and `createTrigger` function params. Note the inconsistency it produces: `pgm.createType('mood', ['ARRAY_LIKE', 'sad'])` keeps the value intact, because that path escapes each element separately and never enters the array branch.

The replace has been there since [`d68bcef`](https://github.com/salsita/node-pg-migrate/commit/d68bcefc086028c8f377478e442a4c805d0fb5c3) (2017), and the existing tests only cover array elements that don't contain the keyword, so it has been green throughout.

## Fix

Strip the keyword from each nested element individually rather than from the joined string. Only a value that *is* an array can contribute an `ARRAY` prefix, so escaped string content is never touched:

```ts
const elements = val.map((element) =>
  Array.isArray(element)
    ? String(escapeValue(element)).slice(ARRAY_KEYWORD.length)
    : escapeValue(element)
);

return `${ARRAY_KEYWORD}[${elements.join(',')}]`;
```

Output for nested arrays is unchanged (`ARRAY[[1],[2]]`), and unlike the old code it now stays correct at any nesting depth.

## Tests

Three cases added to `test/utils/escapeValue.spec.ts`:

- `should keep the ARRAY substring inside escaped strings` — fails on `main`, passes here.
- `should keep the ARRAY substring inside nested escaped strings` — fails on `main`, passes here.
- `should parse deeply nested array to ARRAY constructor syntax string` — passes both ways; guards the flattening behaviour this refactor touches.

## Verification

| Check | Result |
| --- | --- |
| `oxfmt --check` | clean |
| `oxlint` | no new findings (only the pre-existing `warn-todo` in `createType.spec.ts`) |
| `tsc` | clean |
| `vitest --project unit` | 105 files, 716 passed, 1 todo |
| `vitest --project unit --coverage` | 93.67 % stmts / 87.58 % branch — above thresholds |
| Generated SQL | executed against Postgres, before/after table above |

No behaviour change beyond the corrupted-string case; no public API change. I left `CHANGELOG.md` alone since releases appear to collect it — happy to add an entry if you'd prefer.
