### PR TITLE
fix(operations)!: forward drop options to reverse operations

### DIFF
--- a/docs/src/migrations/types.md
+++ b/docs/src/migrations/types.md
@@ -2,7 +2,7 @@
 
 ## Operation: `createType`
 
-### `pgm.createType( type_name, values )`
+### `pgm.createType( type_name, values, type_options )`
 
 > [!IMPORTANT]
 > Create a new data type - [postgres docs](http://www.postgresql.org/docs/current/static/sql-createtype.html)
@@ -10,23 +10,42 @@
 
 ### Arguments
 
-| Name        | Type                        | Description                                                              |
-| ----------- | --------------------------- | ------------------------------------------------------------------------ |
-| `type_name` | [Name](/migrations/#type)   | name of the new type                                                     |
-| `values`    | `array[string]` or `object` | possible values for an enum type or names and types for a composite type |
+| Name           | Type                        | Description                                                              |
+| -------------- | --------------------------- | ------------------------------------------------------------------------ |
+| `type_name`    | [Name](/migrations/#type)   | name of the new type                                                     |
+| `values`       | `array[string]` or `object` | possible values for an enum type or names and types for a composite type |
+| `type_options` | `object`                    | Check below for available options                                        |
+
+### Options
+
+`CREATE TYPE` itself takes no options - these are forwarded to the reverse
+operation (`dropType`) when the migration is rolled back.
+
+| Option     | Type      | Description                  |
+| ---------- | --------- | ---------------------------- |
+| `ifExists` | `boolean` | drops type only if it exists |
+| `cascade`  | `boolean` | drops also dependent objects |
 
 ## Reverse Operation: `dropType`
 
-#### `pgm.dropType( type_name )`
+#### `pgm.dropType( type_name, drop_options )`
 
 > [!IMPORTANT]
 > Drop a custom data type - [postgres docs](http://www.postgresql.org/docs/current/static/sql-droptype.html)
 
 ### Arguments
 
-| Name        | Type                      | Description              |
-| ----------- | ------------------------- | ------------------------ |
-| `type_name` | [Name](/migrations/#type) | name of the type to drop |
+| Name           | Type                      | Description                       |
+| -------------- | ------------------------- | --------------------------------- |
+| `type_name`    | [Name](/migrations/#type) | name of the type to drop          |
+| `drop_options` | `object`                  | Check below for available options |
+
+### Options
+
+| Option     | Type      | Description                  |
+| ---------- | --------- | ---------------------------- |
+| `ifExists` | `boolean` | drops type only if it exists |
+| `cascade`  | `boolean` | drops also dependent objects |
 
 ## Operation: `alterType`
 

--- a/src/operations/tables/createTable.ts
+++ b/src/operations/tables/createTable.ts
@@ -104,7 +104,8 @@ export function createTable(mOptions: MigrationOptions): CreateTable {
     return `${createTableQuery}${comments.length > 0 ? `\n${comments.join('\n')}` : ''}`;
   };
 
-  _create.reverse = dropTable(mOptions);
+  _create.reverse = (tableName, columns, options) =>
+    dropTable(mOptions)(tableName, options);
 
   return _create;
 }

--- a/src/operations/types/createType.ts
+++ b/src/operations/types/createType.ts
@@ -11,21 +11,22 @@ import { dropType } from './dropType';
 
 export type CreateTypeFn = (
   typeName: Name,
-  values: (Value[] | { [name: string]: Type }) & DropTypeOptions
+  values: Value[] | { [name: string]: Type },
+  typeOptions?: DropTypeOptions
 ) => string;
 
 export type CreateType = Reversible<CreateTypeFn>;
 
 export function createType(mOptions: MigrationOptions): CreateType {
-  const _create: CreateType = (typeName, options) => {
-    if (Array.isArray(options)) {
-      const optionsStr = options.map(escapeValue).join(', ');
+  const _create: CreateType = (typeName, values) => {
+    if (Array.isArray(values)) {
+      const valuesStr = values.map(escapeValue).join(', ');
       const typeNameStr = mOptions.literal(typeName);
 
-      return `CREATE TYPE ${typeNameStr} AS ENUM (${optionsStr});`;
+      return `CREATE TYPE ${typeNameStr} AS ENUM (${valuesStr});`;
     }
 
-    const attributes = Object.entries(options)
+    const attributes = Object.entries(values)
       .map(([attributeName, attribute]) => {
         const typeStr = applyType(attribute, mOptions.typeShorthands).type;
 
@@ -36,7 +37,8 @@ export function createType(mOptions: MigrationOptions): CreateType {
     return `CREATE TYPE ${mOptions.literal(typeName)} AS (${formatBlock(attributes, mOptions.pretty)});`;
   };
 
-  _create.reverse = dropType(mOptions);
+  _create.reverse = (typeName, values, typeOptions) =>
+    dropType(mOptions)(typeName, typeOptions);
 
   return _create;
 }

--- a/test/operations/tables/createTable.spec.ts
+++ b/test/operations/tables/createTable.spec.ts
@@ -670,6 +670,17 @@ COMMENT ON CONSTRAINT "fk_col_b" ON "my_table_name" IS $pga$fk b comment$pga$;`,
           expect(statement).toBeTypeOf('string');
           expect(statement).toBe('DROP TABLE "films";');
         });
+
+        it('should return sql statement with drop options', () => {
+          const statement = createTableFn.reverse(
+            'films',
+            {},
+            { ifExists: true, cascade: true }
+          );
+
+          expect(statement).toBeTypeOf('string');
+          expect(statement).toBe('DROP TABLE IF EXISTS "films" CASCADE;');
+        });
       });
     });
   });

--- a/test/operations/types/createType.spec.ts
+++ b/test/operations/types/createType.spec.ts
@@ -37,8 +37,18 @@ describe('operations', () => {
 );`);
       });
 
-      // TODO @Shinigami92 2024-03-18: The typeOptions are buggy
-      it.todo('should return sql statement with typeOptions');
+      it('should ignore typeOptions, because they only affect the reverse', () => {
+        const statement = createTypeFn(
+          'compfoo',
+          { f1: 'int', f2: PgType.TEXT },
+          { ifExists: true, cascade: true }
+        );
+
+        expect(statement).toBeTypeOf('string');
+        expect(statement).toBe(
+          `CREATE TYPE "compfoo" AS ("f1" integer, "f2" text);`
+        );
+      });
 
       it('should return sql statement with schema', () => {
         const statement = createTypeFn(
@@ -68,6 +78,26 @@ describe('operations', () => {
 
           expect(statement).toBeTypeOf('string');
           expect(statement).toBe('DROP TYPE "compfoo";');
+        });
+
+        it('should return sql statement with typeOptions', () => {
+          const statement = createTypeFn.reverse(
+            'compfoo',
+            { f1: 'int', f2: PgType.TEXT },
+            { ifExists: true, cascade: true }
+          );
+
+          expect(statement).toBeTypeOf('string');
+          expect(statement).toBe('DROP TYPE IF EXISTS "compfoo" CASCADE;');
+        });
+
+        it('should return sql statement with typeOptions for an enum', () => {
+          const statement = createTypeFn.reverse('myenum', ['a', 'b'], {
+            ifExists: true,
+          });
+
+          expect(statement).toBeTypeOf('string');
+          expect(statement).toBe('DROP TYPE IF EXISTS "myenum";');
         });
       });
     });


### PR DESCRIPTION
Two reversible operations never passed their drop options to the reverse, because `migrationBuilder` invokes `operation.reverse(...args)` with the *create* arguments, and in both cases the drop function read the wrong positional slot.

## `createType`

The payload and the options shared a single parameter:

```ts
values: (Value[] | { [name: string]: Type }) & DropTypeOptions
```

For the composite form there was no way to tell an attribute from an option, so they were emitted as attributes:

```sql
CREATE TYPE "compfoo" AS ("f1" integer, "ifExists" undefined, "cascade" undefined);
```

TypeScript rejected it anyway, since `boolean` is not assignable to the `Type` index signature. For the enum form the options could only be smuggled in with `Object.assign(['a', 'b'], { ifExists: true })`. There was no legitimate way to pass them at all, which is why the test was an `it.todo` marked "the typeOptions are buggy".

`values` and `typeOptions` are now separate parameters, matching every sibling operation:

```ts
export type CreateTypeFn = (
  typeName: Name,
  values: Value[] | { [name: string]: Type },
  typeOptions?: DropTypeOptions
) => string;
```

`CREATE TYPE` itself takes no options in Postgres — no `IF NOT EXISTS`, no `CASCADE` — so `typeOptions` exist purely to configure the rollback, and the forward statement ignores them. The docs say so explicitly.

## `createTable`

`createTable(tableName, columns, options)` assigned `dropTable(mOptions)` directly as its reverse, so `dropTable` received `columns` in its options slot. Rollback options were silently dropped, and a column literally named `ifExists` would have flipped `IF EXISTS` on.

## Both

Both now use the wrapper idiom `createDomain` already uses:

```ts
_create.reverse = (typeName, values, typeOptions) =>
  dropType(mOptions)(typeName, typeOptions);
```

## Breaking changes

- `pgm.createType(name, values)` is unchanged — every usage in `test/migrations` is two-arg and needed no edits.
- Only the `Object.assign(['a', 'b'], { ifExists: true })` form breaks, which was never documented and is unlikely to exist in the wild.
- `createTable` rollback options now actually take effect. Migrations that passed `ifExists` or `cascade` and silently got neither will start emitting them.

## Not in this PR

I enumerated all 24 `& Drop*Options` intersections in `src/operations`. Every remaining one lands on a dedicated `*Options` parameter, which is the intended design — an options object legitimately carrying both create and drop options. The direct `reverse = dropX(mOptions)` assignment is correct for all of them, because their options parameter sits at the same positional index as the drop's.

One payload-parameter intersection is left: `addTypeAttribute.ts:10`, `attributeType: Type & DropTypeAttributeOptions`. It works correctly today (`applyType` reads only `.type`, and the positions align), so it is a cosmetic break rather than a fix and follows in a stacked `refactor!` PR.

## Verification

Full unit suite (720 tests), `tsc --noEmit`, `oxlint` and `oxfmt --check` all pass.
