### PR TITLE
refactor(operations)!: separate addTypeAttribute drop options

### DIFF
--- a/docs/src/migrations/types.md
+++ b/docs/src/migrations/types.md
@@ -63,7 +63,7 @@ operation (`dropType`) when the migration is rolled back.
 
 ## Operation: `alterType`
 
-#### `pgm.addTypeAttribute( type_name, attribute_name, attribute_type )`
+#### `pgm.addTypeAttribute( type_name, attribute_name, attribute_type, attribute_options )`
 
 > [!IMPORTANT]
 > Add attribute to an existing data
@@ -71,11 +71,21 @@ operation (`dropType`) when the migration is rolled back.
 
 ### Arguments
 
-| Name             | Type                      | Description                  |
-| ---------------- | ------------------------- | ---------------------------- |
-| `type_name`      | [Name](/migrations/#type) | name of the type             |
-| `attribute_name` | `string`                  | name of the attribute to add |
-| `attribute_type` | `string`                  | type of the attribute to add |
+| Name                | Type                      | Description                       |
+| ------------------- | ------------------------- | --------------------------------- |
+| `type_name`         | [Name](/migrations/#type) | name of the type                  |
+| `attribute_name`    | `string`                  | name of the attribute to add      |
+| `attribute_type`    | `string`                  | type of the attribute to add      |
+| `attribute_options` | `object`                  | Check below for available options |
+
+### Options
+
+`ADD ATTRIBUTE` itself takes no options - these are forwarded to the reverse
+operation (`dropTypeAttribute`) when the migration is rolled back.
+
+| Option     | Type      | Description                       |
+| ---------- | --------- | --------------------------------- |
+| `ifExists` | `boolean` | drops attribute only if it exists |
 
 ## Reverse Operation: `dropTypeAttribute`
 

--- a/src/operations/types/addTypeAttribute.ts
+++ b/src/operations/types/addTypeAttribute.ts
@@ -7,7 +7,8 @@ import { dropTypeAttribute } from './dropTypeAttribute';
 export type AddTypeAttributeFn = (
   typeName: Name,
   attributeName: string,
-  attributeType: Type & DropTypeAttributeOptions
+  attributeType: Type,
+  attributeOptions?: DropTypeAttributeOptions
 ) => string;
 
 export type AddTypeAttribute = Reversible<AddTypeAttributeFn>;
@@ -25,7 +26,12 @@ export function addTypeAttribute(mOptions: MigrationOptions): AddTypeAttribute {
     return `ALTER TYPE ${typeNameStr} ADD ATTRIBUTE ${attributeNameStr} ${typeStr};`;
   };
 
-  _alterAttributeAdd.reverse = dropTypeAttribute(mOptions);
+  _alterAttributeAdd.reverse = (
+    typeName,
+    attributeName,
+    attributeType,
+    attributeOptions
+  ) => dropTypeAttribute(mOptions)(typeName, attributeName, attributeOptions);
 
   return _alterAttributeAdd;
 }

--- a/test/operations/types/addTypeAttribute.spec.ts
+++ b/test/operations/types/addTypeAttribute.spec.ts
@@ -21,6 +21,17 @@ describe('operations', () => {
         );
       });
 
+      it('should ignore attributeOptions, because they only affect the reverse', () => {
+        const statement = addTypeAttributeFn('compfoo', 'f3', PgType.INT, {
+          ifExists: true,
+        });
+
+        expect(statement).toBeTypeOf('string');
+        expect(statement).toBe(
+          'ALTER TYPE "compfoo" ADD ATTRIBUTE "f3" integer;'
+        );
+      });
+
       it('should return sql statement with schema', () => {
         const statement = addTypeAttributeFn(
           { name: 'compfoo', schema: 'myschema' },
@@ -48,6 +59,20 @@ describe('operations', () => {
 
           expect(statement).toBeTypeOf('string');
           expect(statement).toBe('ALTER TYPE "compfoo" DROP ATTRIBUTE "f3";');
+        });
+
+        it('should return sql statement with attributeOptions', () => {
+          const statement = addTypeAttributeFn.reverse(
+            'compfoo',
+            'f3',
+            PgType.INT,
+            { ifExists: true }
+          );
+
+          expect(statement).toBeTypeOf('string');
+          expect(statement).toBe(
+            'ALTER TYPE "compfoo" DROP ATTRIBUTE "f3" IF EXISTS;'
+          );
         });
       });
     });


### PR DESCRIPTION
#1707 fixed the two reversible operations that were actually broken. This one removes the last remaining instance of the same smell, which is not broken — hence `refactor!` rather than `fix!`.

## The smell

`addTypeAttribute` merged the reverse operation's drop options into the attribute type descriptor:

```ts
attributeType: Type & DropTypeAttributeOptions
```

Since `Type = string | { type: string }`, the only way to reach `ifExists` was to abandon the string form and smuggle the option into the object form:

```ts
pgm.addTypeAttribute('t', 'a', { type: 'int', ifExists: true });
```

This works today, and always has. `applyType` reads only `.type` and ignores the rest, and `dropTypeAttribute` takes its options at the same positional index that `addTypeAttribute` takes the type, so `reverse = dropTypeAttribute(mOptions)` happened to line up:

```
object form fwd : ALTER TYPE "t" ADD ATTRIBUTE "a" integer;
object form rev : ALTER TYPE "t" DROP ATTRIBUTE "a" IF EXISTS;
string form fwd : ALTER TYPE "t" ADD ATTRIBUTE "a" integer;
string form rev : ALTER TYPE "t" DROP ATTRIBUTE "a";
```

It is still the wrong shape. A drop option is not part of a type descriptor, the capability was never documented, and it is unreachable from the string form that both integration migrations and every doc example use.

## The change

The options become their own parameter, and the reverse uses the wrapper idiom established in #1707:

```ts
export type AddTypeAttributeFn = (
  typeName: Name,
  attributeName: string,
  attributeType: Type,
  attributeOptions?: DropTypeAttributeOptions
) => string;
```

`ALTER TYPE ... ADD ATTRIBUTE` takes no options in Postgres, so `attributeOptions` exist purely to configure the rollback and the forward statement ignores them - the same contract as `createType`'s `typeOptions` in #1707. Tests cover both directions and the docs now say so.

## Breaking changes

Only the undocumented `{ type: 'int', ifExists: true }` form breaks. `pgm.addTypeAttribute(type, name, type)` is unchanged, and both usages in `test/migrations` are three-arg and needed no edits.

## After this

No payload-parameter intersections remain. Every surviving `& Drop*Options` in `src/operations` lands on a dedicated `*Options` parameter, which is the intended design - an options object legitimately carrying both create and drop options - and their direct `reverse = dropX(mOptions)` assignments are correct because the options sit at the same positional index in both.

## Verification

Full unit suite (722 tests), `tsc --noEmit`, `oxlint` and `oxfmt --check` all pass.
