### PR TITLE
refactor: enable typescript/no-unsafe-type-assertion

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -89,8 +89,6 @@
     // --- type-aware typescript (high volume) ---
     // 183 violations
     "typescript/strict-boolean-expressions": "off",
-    // 36 violations
-    "typescript/no-unsafe-type-assertion": "off",
     // 32 violations — behaviour-changing (`??` vs `||`), review each
     "typescript/prefer-nullish-coalescing": "off",
     // 20 violations
@@ -162,6 +160,8 @@
       "files": ["test/**/*.spec.ts", "test/**/*.spec.d.ts"],
       "rules": {
         "typescript/no-deprecated": "off",
+        // Mocks and stubs are deliberately narrowed from partial fakes
+        "typescript/no-unsafe-type-assertion": "off",
 
         "typescript/restrict-template-expressions": [
           "error",

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -141,6 +141,9 @@ export async function runMigration(
 
     return {
       dryRun,
+      // The spread of the loosely typed config connection cannot be proven to
+      // produce a `ClientConfig`.
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
       databaseUrl: {
         // oxlint-disable-next-line typescript/no-misused-spread
         ...databaseUrl,

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -29,16 +29,7 @@ import {
   useGlobArg,
   verboseArg,
 } from './args';
-import type { CliOptions } from './options';
-
-type MigrationFileLanguage =
-  | 'js'
-  | 'ts'
-  | 'sql'
-  | 'cjs'
-  | 'mjs'
-  | 'cts'
-  | 'mts';
+import type { CliOptions, MigrationFileLanguage } from './options';
 
 type DbConnection =
   | string
@@ -208,21 +199,14 @@ export async function resolveConfig(
   let MIGRATIONS_SCHEMA = options.migrationsSchema;
   let CREATE_MIGRATIONS_SCHEMA = options.createMigrationsSchema;
   let MIGRATIONS_TABLE = options.migrationsTable;
-  let MIGRATIONS_FILE_LANGUAGE = options.migrationFileLanguage as
-    | MigrationFileLanguage
-    | undefined;
-  let MIGRATIONS_FILENAME_FORMAT = options.migrationFilenameFormat as
-    | FilenameFormat
-    | undefined;
+  let MIGRATIONS_FILE_LANGUAGE = options.migrationFileLanguage;
+  let MIGRATIONS_FILENAME_FORMAT = options.migrationFilenameFormat;
   let TEMPLATE_FILE_NAME = options.templateFileName;
   let CHECK_ORDER = options.checkOrder;
   let VERBOSE = options.verbose;
   let DECAMELIZE = options.decamelize;
   let PRETTY = options.pretty;
-  let ADVISORY_LOCK_MODE = options.advisoryLockMode as
-    | 'fail'
-    | 'wait'
-    | undefined;
+  let ADVISORY_LOCK_MODE = options.advisoryLockMode;
   let TSCONFIG_PATHS: boolean | string | undefined = parseTsconfigPaths(
     options.tsconfigPaths
   );
@@ -330,15 +314,16 @@ export async function resolveConfig(
         json,
         (val): val is 'fail' | 'wait' => val === 'fail' || val === 'wait'
       );
-    } else {
-      DB_CONNECTION ??= json as DbConnection;
+    } else if (typeof json === 'string') {
+      DB_CONNECTION ??= json;
     }
   }
 
   // Load config (and suppress the no-config-warning)
   const oldSuppressWarning = process.env.SUPPRESS_NO_CONFIG_WARNING;
   process.env.SUPPRESS_NO_CONFIG_WARNING = 'yes';
-  const configValue = options.configValue as string;
+  // commander defaults this flag, so it is always present.
+  const configValue = options.configValue ?? 'db';
   const config = await tryImport<typeof import('config')>('config');
   if (config?.has(configValue)) {
     const db = config.get(configValue);
@@ -359,7 +344,7 @@ export async function resolveConfig(
         : configModule;
 
     if (json && typeof json === 'object' && configValue in json) {
-      readJson((json as Record<string, unknown>)[configValue]);
+      readJson(Reflect.get(json, configValue));
     } else {
       readJson(json);
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,6 +14,8 @@ process.on('uncaughtException', (err) => {
 // Resolve the version from package.json. The built CLI lives in bin/, so the
 // package manifest is one directory up at runtime (both in this repo and once
 // published, where bin/ sits next to package.json).
+// `JSON.parse` returns `any`, so the shape of our own manifest has to be stated.
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion
 const { version } = JSON.parse(
   readFileSync(new URL('../package.json', import.meta.url), 'utf8')
 ) as { version: string };

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -1,6 +1,7 @@
 import type { Command } from 'commander';
 import { Option } from 'commander';
 import { PG_MIGRATE_LOCK_ID } from 'node-pg-migrate';
+import type { FilenameFormat } from '../migration';
 import {
   advisoryLockModeArg,
   checkOrderArg,
@@ -34,6 +35,18 @@ import {
 } from './args';
 
 /**
+ * Languages accepted by `--migration-file-language`.
+ */
+export type MigrationFileLanguage =
+  | 'js'
+  | 'ts'
+  | 'sql'
+  | 'cjs'
+  | 'mjs'
+  | 'cts'
+  | 'mts';
+
+/**
  * Parsed shape of the CLI options exposed by commander.
  *
  * commander exposes each option value under its camelCase name. Options that
@@ -57,8 +70,8 @@ export interface CliOptions {
   pretty?: boolean;
   configValue?: string;
   configFile?: string;
-  migrationFileLanguage?: string;
-  migrationFilenameFormat?: string;
+  migrationFileLanguage?: MigrationFileLanguage;
+  migrationFilenameFormat?: FilenameFormat;
   templateFileName?: string;
   envPath?: string;
   dryRun?: boolean;
@@ -68,7 +81,7 @@ export interface CliOptions {
   lockValue?: number;
   rejectUnauthorized?: boolean;
   timestamp?: boolean;
-  advisoryLockMode?: string;
+  advisoryLockMode?: 'fail' | 'wait';
   tsconfigPaths?: string;
   forceExit?: boolean;
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -57,18 +57,33 @@ export interface DBConnection extends DB {
 
 type ConnectionStatus = 'DISCONNECTED' | 'CONNECTED' | 'ERROR' | 'EXTERNAL';
 
+function isClientBase(
+  connection: ClientBase | string | ClientConfig
+): connection is ClientBase {
+  return (
+    typeof connection === 'object' &&
+    'query' in connection &&
+    typeof connection.query === 'function'
+  );
+}
+
 export function db(
   connection: ClientBase | string | ClientConfig,
   logger: Logger = console
 ): DBConnection {
-  const isExternalClient =
-    typeof connection === 'object' &&
-    'query' in connection &&
-    typeof connection.query === 'function';
+  // A client we create ourselves is also ours to close again, while an
+  // externally provided one stays under the caller's control.
+  let ownClient: Client | undefined;
+  let client: ClientBase;
 
-  const client: Client = isExternalClient
-    ? (connection as Client)
-    : new pg.Client(connection as string | ClientConfig);
+  if (isClientBase(connection)) {
+    client = connection;
+  } else {
+    ownClient = new pg.Client(connection);
+    client = ownClient;
+  }
+
+  const isExternalClient = ownClient === undefined;
 
   let connectionStatus: ConnectionStatus = isExternalClient
     ? 'EXTERNAL'
@@ -178,7 +193,7 @@ ${error}
       );
       if (!isExternalClient) {
         connectionStatus = 'DISCONNECTED';
-        client.end();
+        ownClient?.end();
       }
     },
   };

--- a/src/operations/indexes/shared.ts
+++ b/src/operations/indexes/shared.ts
@@ -88,7 +88,7 @@ export function generateColumnsString(
   return columns
     .map((column) => {
       if (typeof column === 'string' || isPgLiteral(column)) {
-        return generateColumnString(column as unknown as Name, mOptions);
+        return generateColumnString(column, mOptions);
       }
 
       return [

--- a/src/operations/tables/shared.ts
+++ b/src/operations/tables/shared.ts
@@ -270,7 +270,7 @@ export function parseColumns(
           ? `CONSTRAINT ${mOptions.literal(name)} `
           : '';
         constraints.push(
-          `${constraintName}${parseReferences(options as ReferencesOptions, mOptions.literal)}`
+          `${constraintName}${parseReferences({ ...options, references }, mOptions.literal)}`
         );
 
         if (referencesConstraintComment) {
@@ -363,6 +363,9 @@ export function parseConstraints(
       Array.isArray(uniqueSet)
     );
 
+    // `unique` accepts a single column, a column set, or a list of column sets,
+    // which the element type cannot express once the sets are nested.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
     for (const uniqueSet of (isArrayOfArrays
       ? uniqueArray
       : [uniqueArray]) as Array<Name | Name[]>) {

--- a/src/operations/triggers/createTrigger.ts
+++ b/src/operations/triggers/createTrigger.ts
@@ -93,6 +93,9 @@ export function createTrigger(mOptions: MigrationOptions): CreateTrigger {
       ? `${createFunction(mOptions)(
           functionName,
           [],
+          // Passing a `definition` selects the `CreateTriggerFn2` overload,
+          // which is the one that also carries the function options.
+          // oxlint-disable-next-line typescript/no-unsafe-type-assertion
           { ...(triggerOptions as FunctionOptions), returns: 'trigger' },
           definition
         )}\n`

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -359,7 +359,9 @@ function getMigrationsToRun(
       );
     }
 
-    return toRun as Migration[];
+    return toRun.filter(
+      (migration): migration is Migration => typeof migration === 'object'
+    );
   }
 
   const upMigrations = migrations.filter(
@@ -431,9 +433,10 @@ function getLogger(options: RunnerOption): Logger {
 export async function runner(options: RunnerOption): Promise<RunMigration[]> {
   const logger = getLogger(options);
 
-  const connection =
-    (options as RunnerOptionClient).dbClient ||
-    (options as RunnerOptionUrl).databaseUrl;
+  const dbClient = 'dbClient' in options ? options.dbClient : undefined;
+  const databaseUrl =
+    'databaseUrl' in options ? options.databaseUrl : undefined;
+  const connection = dbClient ?? databaseUrl;
 
   if (connection == null) {
     throw new Error('You must provide either a databaseUrl or a dbClient');
@@ -524,7 +527,7 @@ export async function runner(options: RunnerOption): Promise<RunMigration[]> {
     if (db.connected()) {
       if (!options.noLock) {
         await unlock(db, options.lockValue).catch((error: unknown) => {
-          logger.warn((error as Error).message);
+          logger.warn(error instanceof Error ? error.message : String(error));
         });
       }
 

--- a/src/utils/toArray.ts
+++ b/src/utils/toArray.ts
@@ -4,5 +4,8 @@
  * @param item The item to eventually wrap in an array.
  */
 export function toArray<T>(item: T | ReadonlyArray<T>): T[] {
+  // `Array.isArray` cannot narrow `T | ReadonlyArray<T>` while `T` is generic,
+  // because `T` itself could be an array type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   return Array.isArray(item) ? [...item] : [item as T];
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -2,7 +2,7 @@ import type { FunctionParamType } from '../operations/functions';
 import type { Type } from '../operations/generalTypes';
 import type { ColumnDefinition, ColumnDefinitions } from '../operations/tables';
 
-const TYPE_ADAPTERS = Object.freeze({
+const TYPE_ADAPTERS: Readonly<Record<string, string>> = Object.freeze({
   int: 'integer',
   string: 'text',
   float: 'real',
@@ -17,9 +17,7 @@ const DEFAULT_TYPE_SHORTHANDS: Readonly<ColumnDefinitions> = Object.freeze({
 
 // some convenience adapters -- see above
 export function applyTypeAdapters(type: string): string {
-  return type in TYPE_ADAPTERS
-    ? TYPE_ADAPTERS[type as keyof typeof TYPE_ADAPTERS]
-    : type;
+  return Object.hasOwn(TYPE_ADAPTERS, type) ? TYPE_ADAPTERS[type] : type;
 }
 
 function toType(type: string | Readonly<ColumnDefinition>): ColumnDefinition {


### PR DESCRIPTION
Turns on `typescript/no-unsafe-type-assertion`, the last of the high-volume type-aware rules that was still switched off with a violation count next to it.

The rule reported 36 violations. 18 of them were in tests, 12 turned out to be real type holes worth closing, and 4 are cases where TypeScript genuinely cannot express what the code knows.

## Tests: rule off via the existing override

Every violation under `test/` was a mock or a stub being narrowed from a partial fake — `as ClientBase` on an object with a single `query` method, `as never` on a `vi.mocked` argument, `as { stdout?: string }` on an exec result. That is what test doubles are, and reshaping them to satisfy the rule would only make the fakes harder to read, so the rule is off in the `test/**/*.spec.ts` override that already exists.

## The 12 real fixes

**`src/db.ts`** — the interesting one. The old code asserted an incoming `ClientBase` to `Client`, purely so that `client.end()` would type-check in `close()`:

```ts
const client: Client = isExternalClient
  ? (connection as Client)
  : new pg.Client(connection as string | ClientConfig);
```

That assertion is a lie for exactly the branch it applies to: an external client is a `ClientBase` and may well not have `end()`. It never broke, because `close()` guards on `isExternalClient` before calling it — the flag was doing the work the type system should have been doing.

Now an `isClientBase()` type predicate narrows both branches, and the client we construct ourselves is kept in its own binding:

```ts
let ownClient: Client | undefined;
let client: ClientBase;

if (isClientBase(connection)) {
  client = connection;
} else {
  ownClient = new pg.Client(connection);
  client = ownClient;
}
```

`close()` then calls `ownClient?.end()`, so "we created it, therefore we close it" is expressed in the types instead of in a boolean.

**`src/utils/types.ts`** — `applyTypeAdapters` looked up the shorthand map with `type in TYPE_ADAPTERS` and then asserted the key. `in` walks the prototype chain, so `applyTypeAdapters('toString')` returned `Object.prototype.toString`, a function, straight into the generated SQL. Typing the map as `Readonly<Record<string, string>>` and switching to `Object.hasOwn` removes the assertion and the prototype hit at once.

**`src/runner.ts`** — three spots:

- `getMigrationsToRun` filtered out the `string` entries to build an error message, threw if there were any, and then asserted the rest to `Migration[]`. It now filters with a `migration is Migration` predicate instead of asserting.
- `runner()` reached into the `RunnerOptionClient | RunnerOptionUrl` union with two assertions. `'dbClient' in options` narrows it properly. The `??` chain keeps the previous `||` behaviour for an object that carries the key with an `undefined` value.
- The unlock failure path did `(error as Error).message` on an `unknown`, which would have thrown a second time inside the `catch` if anything non-`Error` ever reached it. Now `error instanceof Error ? error.message : String(error)`.

**`src/cli/options.ts` and `src/cli/config.ts`** — `--migration-file-language`, `--migration-filename-format` and `--advisory-lock-mode` are all declared with commander `.choices()`, so their values are validated before we ever see them. `CliOptions` was still typing them as `string` and `config.ts` asserted them back to their unions afterwards. Declaring the real unions on `CliOptions` deletes three assertions and puts the type where the validation is. `MigrationFileLanguage` moved to `options.ts` for that (it was a local type in `config.ts`).

Two smaller ones in the same file: `configValue` is `.default('db')` in commander, so `?? 'db'` replaces `as string` and states the default in the one place that reads it; and the dynamic config-section lookup uses `Reflect.get(json, configValue)` rather than asserting `json` to a `Record`.

**`src/operations/tables/shared.ts`** — `parseReferences(options as ReferencesOptions, …)` was asserting a whole `ColumnDefinition` into `ReferencesOptions` just to satisfy the one property that is required there. `references` is already narrowed to a truthy `Name` by the surrounding `if`, so `parseReferences({ ...options, references }, …)` type-checks with no assertion.

**`src/operations/indexes/shared.ts`** — `generateColumnString(column as unknown as Name, …)` was simply unnecessary. After `typeof column === 'string' || isPgLiteral(column)` the value is `string | (IndexColumn & PgLiteral)`, which already satisfies `Name`. Removed.

## The 4 remaining assertions

These stay, each with a comment saying why:

- `src/utils/toArray.ts` — `Array.isArray` cannot narrow `T | ReadonlyArray<T>` while `T` is generic, because `T` itself could be an array type.
- `src/cli/index.ts` — `JSON.parse` returns `any`, so the shape of our own manifest has to be stated somewhere.
- `src/operations/tables/shared.ts` — `unique` accepts a single column, a column set, or a list of column sets; the element type cannot express that once the sets are nested.
- `src/operations/triggers/createTrigger.ts` — passing a `definition` selects the `CreateTriggerFn2` overload, which is the one that also carries the function options, but that link between the two parameters is not visible inside the implementation signature.

## Two behaviour changes

Neither is on a public export (`applyTypeAdapters` is not re-exported from `src/index.ts`, and `src/cli` is not in the `exports` map), but they are behaviour changes rather than pure typing:

- `applyTypeAdapters` no longer resolves inherited `Object.prototype` members, so `{ type: 'toString' }` now passes `toString` through verbatim instead of turning into a stringified function.
- The `readJson` fallback in `resolveConfig` only accepts a **string** connection now. A config value that is neither an object nor a string — a number, say — used to be handed to `pg` and fail there; it is now ignored, which surfaces as the regular "You must provide either a databaseUrl or a dbClient" error instead.

## Verification

`pnpm run lint`, `pnpm run ts-check` and `pnpm run format:check` are clean, and `pnpm run test` passes with 733 tests across 106 files (unit and integration).
