### PR TITLE
refactor: enable typescript/strict-void-return

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -91,8 +91,6 @@
     "typescript/strict-boolean-expressions": "off",
     // 32 violations — behaviour-changing (`??` vs `||`), review each
     "typescript/prefer-nullish-coalescing": "off",
-    // 20 violations
-    "typescript/strict-void-return": "off",
     // previously off ("enable later"); test override keeps it enforced
     "typescript/restrict-template-expressions": "off",
 

--- a/test/db.spec.ts
+++ b/test/db.spec.ts
@@ -3,7 +3,7 @@ import { Client } from 'pg';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DBConnection } from '../src/db';
 import { db as Db } from '../src/db';
-import type { Logger } from '../src/logger';
+import type { LogFn, Logger } from '../src/logger';
 
 type MockClient = {
   connect: (cb: (err?: Error | null) => void) => void;
@@ -40,10 +40,10 @@ vi.mock('pg', () => {
 
 describe('db', () => {
   const log: Logger = {
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
+    debug: vi.fn<LogFn>(),
+    error: vi.fn<LogFn>(),
+    info: vi.fn<LogFn>(),
+    warn: vi.fn<LogFn>(),
   };
 
   describe('constructor', () => {

--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -20,6 +20,9 @@ export const INTEGRATION_TIMEOUT = Number(
 /**
  * Promisified version of Node.js `child_process.exec` for running shell commands asynchronously.
  */
+// `exec` returns a `ChildProcess` instead of `void`, which is the documented
+// Node.js signature `promisify` is designed to consume.
+// oxlint-disable-next-line typescript/strict-void-return
 export const exec = promisify(processExec);
 
 /**

--- a/test/migration.spec.ts
+++ b/test/migration.spec.ts
@@ -3,7 +3,7 @@ import type { Mock } from 'vitest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { RunnerOption } from '../src';
 import type { DBConnection } from '../src/db';
-import type { Logger } from '../src/logger';
+import type { LogFn, Logger } from '../src/logger';
 import {
   FilenameFormat,
   getMigrationFilePaths,
@@ -25,9 +25,9 @@ describe('migration', () => {
   const dbMock = {} as DBConnection;
 
   const logger: Logger = {
-    info: () => null,
-    warn: () => null,
-    error: () => null,
+    info: vi.fn<LogFn>(),
+    warn: vi.fn<LogFn>(),
+    error: vi.fn<LogFn>(),
   };
 
   const options = { migrationsTable } as RunnerOption;

--- a/test/migrations/002_callback.js
+++ b/test/migrations/002_callback.js
@@ -1,3 +1,5 @@
 export const up = (pgm, done) => {
-  setTimeout(() => done(), 10);
+  setTimeout(() => {
+    done();
+  }, 10);
 };

--- a/test/utils/comparators.spec.ts
+++ b/test/utils/comparators.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { Logger } from '../../src/logger';
+import type { LogFn, Logger } from '../../src/logger';
 import {
   compareFileNamesByTimestamp,
   compareMigrationFileNames,
@@ -30,10 +30,10 @@ describe('localeCompareStringsNumerically', () => {
 
 describe('compareFileNamesByTimestamp', () => {
   const logger: Logger = {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
+    info: vi.fn<LogFn>(),
+    warn: vi.fn<LogFn>(),
+    error: vi.fn<LogFn>(),
+    debug: vi.fn<LogFn>(),
   };
 
   it('compares by numeric prefix (index / timestamp modes)', () => {
@@ -56,10 +56,10 @@ describe('compareFileNamesByTimestamp', () => {
 
 describe('compareMigrationFileNames', () => {
   const logger: Logger = {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
+    info: vi.fn<LogFn>(),
+    warn: vi.fn<LogFn>(),
+    error: vi.fn<LogFn>(),
+    debug: vi.fn<LogFn>(),
   };
 
   it('orders by numeric prefix when they differ', () => {

--- a/test/utils/fileNameUtils.spec.ts
+++ b/test/utils/fileNameUtils.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { Logger } from '../../src/logger';
+import type { LogFn, Logger } from '../../src/logger';
 import { getNumericPrefix, getSuffixFromFileName } from '../../src/utils';
 
 describe('getSuffixFromFileName', () => {
@@ -23,9 +23,9 @@ describe('getSuffixFromFileName', () => {
 
 describe('getNumericPrefix', () => {
   const logger: Logger = {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
+    info: vi.fn<LogFn>(),
+    warn: vi.fn<LogFn>(),
+    error: vi.fn<LogFn>(),
   };
 
   it('should allow any non-numeric character as a separator', () => {


### PR DESCRIPTION
Turns on `typescript/strict-void-return`, continuing the one-rule-per-PR cleanup of the type-aware rules that were still switched off with a violation count next to them in `.oxlintrc.json`.

The rule reported 20 violations, all of them in `test/`. They fall into three patterns, and only one of them needed anything more than a mechanical fix.

## Untyped `vi.fn()` logger mocks — 16 violations

`test/db.spec.ts`, `test/utils/comparators.spec.ts` and `test/utils/fileNameUtils.spec.ts` each build a `Logger` out of bare `vi.fn()` calls. A `vi.fn()` with no type parameter infers `Mock<(...args: any[]) => any>`, so every method reads as value-returning where `LogFn` declares `void`.

Passing the type through fixes all sixteen:

```ts
const log: Logger = {
  debug: vi.fn<LogFn>(),
  error: vi.fn<LogFn>(),
  info: vi.fn<LogFn>(),
  warn: vi.fn<LogFn>(),
};
```

This is the style `test/db.spec.ts` already uses at the top of the file for its `pg` client mock (`vi.fn<MockClient['connect']>()`), so the loggers now match their surroundings. Note that `vitest/require-mock-type-parameters` is currently `off` in the config — enabling it later would push the rest of the suite in this same direction.

## `() => null` stubs — 3 violations

`test/migration.spec.ts` built its logger from `() => null` no-ops. Switched to `vi.fn<LogFn>()` for consistency with the three files above; nothing in that file asserts on the logger, so this is a pure swap.

## Implicit-return arrow — 1 violation

`test/migrations/002_callback.js` had `setTimeout(() => done(), 10)`, which returns `done()`'s result into a `void` callback slot. Given a block body instead.

## The one exception: `promisify(exec)`

`test/integration/utils.ts` promisifies `child_process.exec`. That is flagged because `exec` returns a `ChildProcess` rather than `void` — but that *is* the documented Node.js signature, and `util.promisify` is the only promise-based way to call it. Rewriting it as a hand-rolled wrapper would mean restating the callback signature by hand and losing the `__promisify__` overload that gives us `{ stdout, stderr }`.

oxlint exposes no options for this rule (there is nothing but the rule name in `configuration_schema.json`), so this is a single `oxlint-disable-next-line` with a comment explaining why:

```ts
// `exec` returns a `ChildProcess` instead of `void`, which is the documented
// Node.js signature `promisify` is designed to consume.
// oxlint-disable-next-line typescript/strict-void-return
export const exec = promisify(processExec);
```

`reportUnusedDisableDirectives` is `error` in this config, so the directive will start failing lint if the rule ever stops firing here.

## No behaviour changes

Nothing outside `test/` was touched, and no production code changed. The logger stubs went from returning `null`/`any` to returning `undefined`, which no assertion depends on.

## Verification

`pnpm run lint`, `pnpm run ts-check` and `pnpm run format:check` are clean, and `pnpm run test` passes with 733 tests across 106 files (unit and integration).
