### PR TITLE
refactor: enable restrict-template-expressions

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -91,8 +91,6 @@
     "typescript/strict-boolean-expressions": "off",
     // 32 violations — behaviour-changing (`??` vs `||`), review each
     "typescript/prefer-nullish-coalescing": "off",
-    // previously off ("enable later"); test override keeps it enforced
-    "typescript/restrict-template-expressions": "off",
 
     // --- type-aware typescript (untyped `pgm` fixtures + misc, previously off) ---
     "typescript/no-unsafe-member-access": "off",

--- a/src/operations/generalTypes.ts
+++ b/src/operations/generalTypes.ts
@@ -39,6 +39,20 @@ export function isNameObject(
 }
 
 /**
+ * Extracts the plain (unescaped) identifier string from a {@link Name}.
+ *
+ * Useful for building derived names (e.g. default constraint or index names)
+ * where the raw string is needed instead of an escaped identifier.
+ */
+export function getNameString(name: Name): string {
+  if (isNameObject(name)) {
+    return name.name;
+  }
+
+  return typeof name === 'string' ? name : name.value;
+}
+
+/**
  * Type guard for schema-qualified {@link Name} objects.
  */
 export function isSchemaNameObject(

--- a/src/operations/indexes/shared.ts
+++ b/src/operations/indexes/shared.ts
@@ -2,7 +2,11 @@ import type { MigrationOptions } from '../../migrationOptions';
 import { isPgLiteral } from '../../utils';
 import type { Literal } from '../../utils/createTransformer';
 import type { Name } from '../generalTypes';
-import { isNameObject, isSchemaNameObject } from '../generalTypes';
+import {
+  getNameString,
+  isNameObject,
+  isSchemaNameObject,
+} from '../generalTypes';
 import type { CreateIndexOptions } from './createIndex';
 import type { DropIndexOptions } from './dropIndex';
 
@@ -58,7 +62,7 @@ export function generateIndexName(
         schema: table.schema,
         name: `${table.name}_${cols}${uniq}_index`,
       }
-    : `${table}_${cols}${uniq}_index`;
+    : `${getNameString(table)}_${cols}${uniq}_index`;
 }
 
 export function generateColumnString(

--- a/src/operations/materializedViews/shared.ts
+++ b/src/operations/materializedViews/shared.ts
@@ -14,7 +14,6 @@ export function storageParameterStr<
     const value =
       storageParameters[key] === true ? '' : ` = ${storageParameters[key]}`;
 
-    // @ts-expect-error: Implicit conversion of a 'symbol' to a 'string' will fail at runtime. Consider wrapping this expression in 'String(...)'. ts(2731)
-    return `${key}${value}`;
+    return `${String(key)}${value}`;
   };
 }

--- a/src/operations/tables/shared.ts
+++ b/src/operations/tables/shared.ts
@@ -3,7 +3,7 @@ import { applyType, escapeValue, makeComment, toArray } from '../../utils';
 import type { Literal } from '../../utils/createTransformer';
 import type { FunctionParamType } from '../functions';
 import type { IfNotExistsOption, Name, Value } from '../generalTypes';
-import { isNameObject } from '../generalTypes';
+import { getNameString } from '../generalTypes';
 import type { SequenceOptions } from '../sequences';
 import { parseSequenceOptions } from '../sequences';
 
@@ -265,7 +265,9 @@ export function parseColumns(
       if (references) {
         const name =
           referencesConstraintName ||
-          (referencesConstraintComment ? `${tableName}_fk_${columnName}` : '');
+          (referencesConstraintComment
+            ? `${getNameString(tableName)}_fk_${columnName}`
+            : '');
         const constraintName = name
           ? `CONSTRAINT ${mOptions.literal(name)} `
           : '';
@@ -340,7 +342,7 @@ export function parseConstraints(
     comment,
   }: ConstraintOptions = options;
 
-  const tableName = isNameObject(table) ? table.name : table;
+  const tableName = getNameString(table);
 
   let constraints: string[] = [];
   const comments: string[] = [];

--- a/src/operations/views/shared.ts
+++ b/src/operations/views/shared.ts
@@ -11,7 +11,6 @@ export function viewOptionStr<
   return (key) => {
     const value = options[key] === true ? '' : ` = ${options[key]}`;
 
-    // @ts-expect-error: Implicit conversion of a 'symbol' to a 'string' will fail at runtime. Consider wrapping this expression in 'String(...)'. ts(2731)
-    return `${key}${value}`;
+    return `${String(key)}${value}`;
   };
 }


### PR DESCRIPTION
Enables `typescript/restrict-template-expressions` for `src`, continuing the sweep through the deferred rules in `.oxlintrc.json`. The stricter test-file override (`allowNumber`/`allowBoolean`/`allowAny`) is untouched.

The 10 violations came from two distinct causes.

### 1. `Name` interpolated into a template literal (8 violations)

`Name` is `string | { schema?, name } | PgLiteralValue`, so narrowing with `isNameObject()` still leaves `string | PgLiteralValue` — an object — in the else branch. The affected sites all build *default* names (constraint names, index names) rather than escaped identifiers, so they need the raw string.

Added an internal `getNameString(name: Name): string` helper alongside the existing guards in `src/operations/generalTypes.ts`:

```ts
export function getNameString(name: Name): string {
  if (isNameObject(name)) {
    return name.name;
  }

  return typeof name === 'string' ? name : name.value;
}
```

Applied in `parseColumns` (foreign-key default name), `parseConstraints` (the shared `tableName` local, which accounted for 6 of the 7 violations in that file) and `generateIndexName`.

Behaviour is unchanged for real `PgLiteral` instances — `.value` is exactly what the implicit `toString()` returned. For plain `{ literal: true, value }` object literals, which satisfy `isPgLiteral()` but do not inherit `PgLiteral.prototype.toString`, the generated name was previously `[object Object]`; it is now the literal value.

### 2. `keyof T` interpolated into a template literal (2 violations)

`viewOptionStr` and `storageParameterStr` interpolate a `TKey extends keyof T` — which includes `symbol`. Both lines already carried a `@ts-expect-error` for `ts(2731)` ("Implicit conversion of a 'symbol' to a 'string' will fail at runtime. Consider wrapping this expression in 'String(...)'"), pointing at precisely this problem. Wrapping in `String(key)` fixes the lint error and lets both suppressions be deleted.

## Verification

- `pnpm run lint` — exit 0
- `pnpm exec tsc --noEmit` — clean
- `pnpm run format:check` — clean
- `pnpm exec vitest run --project unit` — 722 passed (105 files)

No public API change: `getNameString` is internal, and `src/index.ts` re-exports only types from `generalTypes`.
