### PR TITLE
refactor: enable no-floating-promises

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -98,7 +98,6 @@
     "typescript/no-unsafe-assignment": "off",
     "typescript/no-unsafe-return": "off",
     "typescript/no-unsafe-argument": "off",
-    "typescript/no-floating-promises": "off",
     "typescript/no-base-to-string": "off",
     "typescript/no-deprecated": "off",
     "typescript/no-unnecessary-type-parameters": "off",
@@ -110,9 +109,6 @@
     "typescript/prefer-includes": "off",
     "typescript/prefer-ts-expect-error": "off",
     "typescript/ban-ts-comment": "off",
-
-    // 37 violations — was newly set to error; defer the cleanup
-    "typescript/explicit-function-return-type": "off",
 
     // --- eslint core ---
     // 176 violations (mostly large test `describe` blocks)

--- a/src/db.ts
+++ b/src/db.ts
@@ -193,7 +193,7 @@ ${error}
       );
       if (!isExternalClient) {
         connectionStatus = 'DISCONNECTED';
-        ownClient?.end();
+        await ownClient?.end();
       }
     },
   };

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -355,7 +355,7 @@ export class Migration implements RunMigration {
   ): Promise<unknown> {
     await (action.length === 2
       ? new Promise<void>((resolve) => {
-          action(pgm, resolve);
+          void action(pgm, resolve);
         })
       : action(pgm));
 

--- a/test/db.spec.ts
+++ b/test/db.spec.ts
@@ -49,9 +49,9 @@ describe('db', () => {
   describe('constructor', () => {
     let db: DBConnection;
 
-    afterEach(() => {
+    afterEach(async () => {
       if (db) {
-        db.close();
+        await db.close();
       }
     });
 
@@ -81,8 +81,8 @@ describe('db', () => {
       db = Db(undefined, log);
     });
 
-    afterEach(() => {
-      db.close();
+    afterEach(async () => {
+      await db.close();
 
       vi.clearAllMocks();
     });

--- a/test/migration.spec.ts
+++ b/test/migration.spec.ts
@@ -270,7 +270,7 @@ describe('migration', () => {
       );
 
       expect(() => {
-        migration.apply(direction);
+        void migration.apply(direction);
       }).toThrow(
         new Error(
           `Unknown value for direction: ${direction}. Is the migration ${invalidMigrationName} exporting a '${direction}' function?`

--- a/test/ts/customRunnerDBClient.ts
+++ b/test/ts/customRunnerDBClient.ts
@@ -10,4 +10,4 @@ async function start(): Promise<void> {
   process.exit(result ? 0 : 1);
 }
 
-start();
+void start();

--- a/test/ts/customRunnerDBUrl.ts
+++ b/test/ts/customRunnerDBUrl.ts
@@ -9,4 +9,4 @@ async function start(): Promise<void> {
   process.exit(result ? 0 : 1);
 }
 
-start();
+void start();

--- a/test/ts/customRunnerUndefCount.ts
+++ b/test/ts/customRunnerUndefCount.ts
@@ -10,4 +10,4 @@ async function start(): Promise<void> {
   process.exit(result ? 0 : 1);
 }
 
-start();
+void start();


### PR DESCRIPTION
Enables `typescript/no-floating-promises` (dropping the `"off"` override) and fixes the 8 violations it surfaced.

## Changes

- `src/db.ts`: `close()` now awaits `ownClient.end()` instead of firing it and returning. Awaiting is the correct behaviour here — callers that `await db.close()` now actually get a closed connection.
- `src/migration.ts`: the callback-style migration action inside `new Promise` is marked `void`. The `MigrationAction` union allows a promise-returning signature, but in the `action.length === 2` branch the callback form is the one being invoked and `resolve` is the completion signal, so its (never-returned) promise is intentionally ignored.
- `test/db.spec.ts`: the two `afterEach` hooks are async and await `db.close()`.
- `test/migration.spec.ts`: `void migration.apply(direction)` inside the `expect(...).toThrow()` callback — the test asserts the synchronous throw from `_getAction`, so the promise is intentionally unused.
- `test/ts/customRunner*.ts`: `void start()` at the top level; `start()` already sets `process.exitCode` and calls `process.exit` itself.

Also removes the now-stale `explicit-function-return-type` override: that rule sits in the `restriction` category, which is `"off"` wholesale, so the explicit override (and its "37 violations, defer the cleanup" note) was redundant.

## Verification

`pnpm run lint` clean, `pnpm run build` and `tsc --noEmit` clean, `pnpm run test` 733 passed (106 files, unit + integration).
