### PR TITLE
fix(operations): use plain names for generated constraints

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -98,7 +98,6 @@
     "typescript/no-unsafe-assignment": "off",
     "typescript/no-unsafe-return": "off",
     "typescript/no-unsafe-argument": "off",
-    "typescript/no-base-to-string": "off",
     "typescript/no-deprecated": "off",
     "typescript/no-unnecessary-type-parameters": "off",
     "typescript/no-useless-default-assignment": "off",

--- a/src/operations/tables/shared.ts
+++ b/src/operations/tables/shared.ts
@@ -372,7 +372,9 @@ export function parseConstraints(
       ? uniqueArray
       : [uniqueArray]) as Array<Name | Name[]>) {
       const cols = toArray(uniqueSet);
-      const name = literal(optionName || `${tableName}_uniq_${cols.join('_')}`);
+      const name = literal(
+        optionName || `${tableName}_uniq_${cols.map(getNameString).join('_')}`
+      );
 
       constraints.push(
         `CONSTRAINT ${name} UNIQUE (${cols.map(literal).join(', ')})`
@@ -396,7 +398,7 @@ export function parseConstraints(
       const name = literal(
         referencesConstraintName ||
           optionName ||
-          `${tableName}_fk_${cols.join('_')}`
+          `${tableName}_fk_${cols.map(getNameString).join('_')}`
       );
       const key = cols.map(literal).join(', ');
       const referencesStr = parseReferences(fk, literal);

--- a/src/utils/createSchemalize.ts
+++ b/src/utils/createSchemalize.ts
@@ -1,4 +1,5 @@
 import type { Name } from '../operations/generalTypes';
+import { getNameString } from '../operations/generalTypes';
 import { decamelize } from './decamelize';
 import { identity } from './identity';
 import { isPgLiteral } from './PgLiteral';
@@ -81,6 +82,9 @@ export function createSchemalize(
       return transform(value);
     }
 
-    return transform(String(value));
+    // Remaining shapes are objects: a name object without a name, or a literal-like
+    // object that did not pass the `isPgLiteral` check. Extract the plain identifier
+    // instead of relying on default object stringification.
+    return transform(getNameString(value));
   };
 }

--- a/test/operations/tables/createTable.spec.ts
+++ b/test/operations/tables/createTable.spec.ts
@@ -303,6 +303,25 @@ describe('operations', () => {
           ],
           `CREATE TABLE "my_table_name" ("col_a" integer, "col_b" varchar, CONSTRAINT "my_table_name_fk_col_a_col_b" FOREIGN KEY ("col_a", "col_b") REFERENCES otherTable (A, B));`,
         ],
+        [
+          'should check table references work correctly for name objects',
+          options1,
+          [
+            'myTableName',
+            { colA: { type: 'integer' }, colB: { type: 'varchar' } },
+            {
+              constraints: {
+                foreignKeys: [
+                  {
+                    columns: [{ name: 'colA' }, { name: 'colB' }],
+                    references: 'otherTable (A, B)',
+                  },
+                ],
+              },
+            },
+          ],
+          `CREATE TABLE "myTableName" ("colA" integer, "colB" varchar, CONSTRAINT "myTableName_fk_colA_colB" FOREIGN KEY ("colA", "colB") REFERENCES otherTable (A, B));`,
+        ],
         // should check table unique constraint work correctly
         [
           'should check table unique constraint work correctly 1',
@@ -344,6 +363,27 @@ describe('operations', () => {
             { constraints: { unique: 'colA' } },
           ],
           `CREATE TABLE "my_table_name" ("col_a" integer, "col_b" varchar, CONSTRAINT "my_table_name_uniq_col_a" UNIQUE ("col_a"));`,
+        ],
+        // should check table unique constraint work correctly for name objects
+        [
+          'should check table unique constraint work correctly for name objects 1',
+          options1,
+          [
+            'myTableName',
+            { colA: { type: 'integer' }, colB: { type: 'varchar' } },
+            { constraints: { unique: [{ name: 'colA' }, { name: 'colB' }] } },
+          ],
+          `CREATE TABLE "myTableName" ("colA" integer, "colB" varchar, CONSTRAINT "myTableName_uniq_colA_colB" UNIQUE ("colA", "colB"));`,
+        ],
+        [
+          'should check table unique constraint work correctly for name objects 2',
+          options2,
+          [
+            'myTableName',
+            { colA: { type: 'integer' }, colB: { type: 'varchar' } },
+            { constraints: { unique: [{ name: 'colA' }, { name: 'colB' }] } },
+          ],
+          `CREATE TABLE "my_table_name" ("col_a" integer, "col_b" varchar, CONSTRAINT "my_table_name_uniq_col_a_col_b" UNIQUE ("col_a", "col_b"));`,
         ],
         // should check table unique constraint work correctly for array of arrays
         [

--- a/test/utils/createSchemalize.spec.ts
+++ b/test/utils/createSchemalize.spec.ts
@@ -219,6 +219,19 @@ describe('utils', () => {
       expect(actual).toBe('some_literal');
     });
 
+    it('should use the value of a literal-like object that is not a PgLiteral', () => {
+      const schemalize = createSchemalize({
+        shouldDecamelize: true,
+        shouldQuote: true,
+      });
+
+      const literalLike = { literal: false, value: 'myValue' };
+      // @ts-expect-error: Testing a runtime shape that `Name` does not allow
+      const actual = schemalize(literalLike);
+
+      expect(actual).toBe('"my_value"');
+    });
+
     it('should escape double quotes when quoting identifiers', () => {
       const schemalize = createSchemalize({
         shouldDecamelize: false,


### PR DESCRIPTION
Enables `typescript/no-base-to-string` (dropping the `"off"` override) and fixes the 3 violations it surfaced. Two of them were real bugs, hence the `fix` type: a column passed as a `Name` object landed in auto-generated constraint names as `[object Object]`.

## Changes

- `src/operations/tables/shared.ts`: `parseConstraints` builds the fallback constraint names (`<table>_uniq_<cols>` and `<table>_fk_<cols>`) from `cols.map(getNameString).join('_')` instead of `cols.join('_')`. `cols` is `Name[]`, so a column given in object form (`{ name: 'colA' }`) or literal form previously stringified to `[object Object]` in the generated name, while the column list itself was rendered correctly via `cols.map(literal)`.
- `src/utils/createSchemalize.ts`: the final fallback uses `getNameString(value)` instead of `String(value)`. At that point `value` is narrowed to the object shapes of `Name`, so `String()` could only ever yield `[object Object]`. The `Name` type makes that branch unreachable (a name object requires `name: string`, and `PgLiteralValue` pins `literal` to `true`, which `isPgLiteral` already catches), so it only guards untyped runtime input — e.g. a literal-like object without `literal: true`, which now resolves to its `value` instead of `[object Object]`.

## Tests

- `test/utils/createSchemalize.spec.ts`: covers the literal-like fallback (`{ literal: false, value: 'myValue' }` → `"my_value"`).
- `test/operations/tables/createTable.spec.ts`: two `unique` cases and one `foreignKeys` case with columns passed as name objects, asserting the constraint names now match the string-column output.

## Verification

`pnpm run lint` clean, `pnpm run build` clean, `pnpm run test` 737 passed (106 files, unit + integration).
