### PR TITLE
refactor: enable remaining type-aware lint rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -93,21 +93,12 @@
     "typescript/prefer-nullish-coalescing": "off",
 
     // --- type-aware typescript (untyped `pgm` fixtures + misc, previously off) ---
-    "typescript/no-unsafe-member-access": "off",
-    "typescript/no-unsafe-call": "off",
-    "typescript/no-unsafe-assignment": "off",
-    "typescript/no-unsafe-return": "off",
-    "typescript/no-unsafe-argument": "off",
-    "typescript/no-deprecated": "off",
-    "typescript/no-unnecessary-type-parameters": "off",
-    "typescript/no-useless-default-assignment": "off",
-    "typescript/unbound-method": "off",
-    "typescript/no-confusing-void-expression": "off",
-    "typescript/no-unnecessary-type-assertion": "off",
-    "typescript/return-await": "off",
-    "typescript/prefer-includes": "off",
-    "typescript/prefer-ts-expect-error": "off",
-    "typescript/ban-ts-comment": "off",
+    "typescript/no-unsafe-member-access": "off", // 360
+    "typescript/no-unsafe-call": "off", // 353
+    "typescript/no-unsafe-assignment": "off", // 52
+    "typescript/no-unsafe-return": "off", // 16
+    "typescript/no-unsafe-argument": "off", // 12
+    "typescript/no-useless-default-assignment": "off", // 8
 
     // --- eslint core ---
     // 176 violations (mostly large test `describe` blocks)

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -50,15 +50,12 @@ export async function runCreate(
           ignorePattern: config.ignorePattern,
         }),
   })
-    .then(
-      (
-        // @ts-ignore: when a clean was made, the types are not present in the first run
-        migrationPath
-      ) => {
-        console.log(format('Created migration -- %s', migrationPath));
-        process.exit(0);
-      }
-    )
+    // The parameter is annotated explicitly so this still type-checks when a
+    // clean was made and the built types are not present in the first run.
+    .then((migrationPath: string) => {
+      console.log(format('Created migration -- %s', migrationPath));
+      process.exit(0);
+    })
     .catch((error: unknown) => {
       console.error(error);
       process.exit(1);

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -340,7 +340,7 @@ export async function resolveConfig(
       configModule &&
       typeof configModule === 'object' &&
       'default' in configModule
-        ? (configModule as { default: unknown }).default
+        ? configModule.default
         : configModule;
 
     if (json && typeof json === 'object' && configValue in json) {

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -198,7 +198,7 @@ export class Migration implements RunMigration {
     if (filenameFormat === FilenameFormat.index) {
       const filePaths = await getMigrationFilePaths(directory, {
         ignorePattern,
-        useGlob: /\*/.test(directory) || /\*/.test(ignorePattern || ''),
+        useGlob: directory.includes('*') || (ignorePattern || '').includes('*'),
       });
 
       // Get the minimum last found prefix as the total number of matching files

--- a/src/migrationBuilder.ts
+++ b/src/migrationBuilder.ts
@@ -989,10 +989,14 @@ export class MigrationBuilder {
         return operation(...args);
       };
 
+    // `db.query` and `db.select` are standalone closures created by `db()`,
+    // not bound methods, so unbinding them here is safe.
+    /* oxlint-disable typescript/unbound-method */
     this.db = {
       query: wrapDB(db.query),
       select: wrapDB(db.select),
     };
+    /* oxlint-enable typescript/unbound-method */
   }
 
   /**

--- a/src/migrationLoader.ts
+++ b/src/migrationLoader.ts
@@ -324,8 +324,14 @@ async function readSqlFileGroup(group: SqlGroup): Promise<MigrationUnit> {
 
     const downSql = group.down ? await readFile(group.down, 'utf8') : undefined;
     actions = {
-      up: (pgm) => pgm.sql(upSql),
-      down: downSql ? (pgm) => pgm.sql(downSql) : undefined,
+      up: (pgm) => {
+        pgm.sql(upSql);
+      },
+      down: downSql
+        ? (pgm) => {
+            pgm.sql(downSql);
+          }
+        : undefined,
       shorthands: {},
     };
   }
@@ -352,7 +358,7 @@ export function createSqlMigrationLoader(): MigrationLoader {
   const loader: MigrationLoader = async (filePaths: string[]) => {
     const groups = groupSqlFiles(filePaths);
     const migrationUnits = await Promise.all(
-      groups.map(async (group) => await readSqlFileGroup(group))
+      groups.map((group) => readSqlFileGroup(group))
     );
     return migrationUnits;
   };

--- a/src/operations/functions/dropFunction.ts
+++ b/src/operations/functions/dropFunction.ts
@@ -26,7 +26,7 @@ export function dropFunction(mOptions: MigrationOptions): DropFunction {
       if (typeof param === 'object' && param !== null) {
         const copy = { ...param };
         delete copy.default;
-        return copy as FunctionParam;
+        return copy;
       }
 
       return param;

--- a/src/operations/materializedViews/shared.ts
+++ b/src/operations/materializedViews/shared.ts
@@ -8,8 +8,9 @@ export function dataClause(data?: boolean): string {
 
 export function storageParameterStr<
   TStorageParameters extends Nullable<StorageParameters>,
-  TKey extends keyof TStorageParameters,
->(storageParameters: TStorageParameters): (key: TKey) => string {
+>(
+  storageParameters: TStorageParameters
+): (key: keyof TStorageParameters) => string {
   return (key) => {
     const value =
       storageParameters[key] === true ? '' : ` = ${storageParameters[key]}`;

--- a/src/operations/views/shared.ts
+++ b/src/operations/views/shared.ts
@@ -4,10 +4,9 @@ export type ViewOptions = {
   [key: string]: boolean | number | string;
 };
 
-export function viewOptionStr<
-  TViewOptions extends Nullable<ViewOptions>,
-  TKey extends keyof TViewOptions,
->(options: TViewOptions): (key: TKey) => string {
+export function viewOptionStr<TViewOptions extends Nullable<ViewOptions>>(
+  options: TViewOptions
+): (key: keyof TViewOptions) => string {
   return (key) => {
     const value = options[key] === true ? '' : ` = ${options[key]}`;
 

--- a/src/pgType.ts
+++ b/src/pgType.ts
@@ -361,6 +361,7 @@ export const PgType = Object.freeze({
    *
    * @deprecated see `PG_SNAPSHOT`
    */
+  // oxlint-disable-next-line typescript/no-deprecated -- this is the declaration itself
   TXID_SNAPSHOT: 'txid_snapshot',
   /**
    * universally unique identifier

--- a/src/utils/PgLiteral.ts
+++ b/src/utils/PgLiteral.ts
@@ -9,10 +9,11 @@ export class PgLiteral {
   /**
    * Creates a new `PgLiteral` instance.
    *
+   * @param this Unused, declared so the method can be passed around unbound.
    * @param str The string value.
    * @returns The new `PgLiteral` instance.
    */
-  static create(str: string): PgLiteral {
+  static create(this: void, str: string): PgLiteral {
     return new PgLiteral(str);
   }
 
@@ -59,6 +60,6 @@ export function isPgLiteral(val: unknown): val is PgLiteral {
     (typeof val === 'object' &&
       val !== null &&
       'literal' in val &&
-      (val as { literal: unknown }).literal === true)
+      val.literal === true)
   );
 }

--- a/test/db.spec.ts
+++ b/test/db.spec.ts
@@ -88,7 +88,9 @@ describe('db', () => {
     });
 
     it('should call client.connect if this is the first query', async () => {
-      vi.spyOn(hoisted.client, 'connect').mockImplementation((fn) => fn());
+      vi.spyOn(hoisted.client, 'connect').mockImplementation((fn) => {
+        fn();
+      });
 
       await db.query('query');
 
@@ -114,9 +116,9 @@ describe('db', () => {
     it('should not call client.query if client.connect fails', async () => {
       const error = 'error';
 
-      vi.spyOn(hoisted.client, 'connect').mockImplementation((fn) =>
-        fn(new Error(error))
-      );
+      vi.spyOn(hoisted.client, 'connect').mockImplementation((fn) => {
+        fn(new Error(error));
+      });
 
       await expect(() => db.query('query')).rejects.toThrow(error);
       expect(hoisted.client.query).not.toHaveBeenCalled();
@@ -125,7 +127,9 @@ describe('db', () => {
     it('should resolve promise if query throws no error', async () => {
       const result = 'result';
 
-      vi.spyOn(hoisted.client, 'connect').mockImplementation((fn) => fn());
+      vi.spyOn(hoisted.client, 'connect').mockImplementation((fn) => {
+        fn();
+      });
       vi.spyOn(hoisted.client, 'query').mockResolvedValue(result);
 
       await expect(db.query('query')).resolves.toBe(result);

--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -73,7 +73,7 @@ export async function setupPostgresDatabase(
   containerImage: string,
   databaseName: string = 'node_pg_migrate'
 ): Promise<StartedPostgreSqlContainer> {
-  return await new PostgreSqlContainer(containerImage)
+  return new PostgreSqlContainer(containerImage)
     .withUsername('ubuntu')
     .withPassword('ubuntu')
     .withDatabase(databaseName)

--- a/test/runner.spec.ts
+++ b/test/runner.spec.ts
@@ -192,37 +192,36 @@ describe('runner', () => {
   });
 
   it('should call pg_advisory_lock when advisory lock mode is set to "wait"', async () => {
-    const dbClient = {
-      query: vi.fn((query) => {
-        switch (query) {
-          case 'SELECT pg_advisory_lock(7241865325823964)': {
-            return Promise.resolve();
-          }
-
-          case "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'pgmigrations'": {
-            return Promise.resolve({
-              rows: [{}], // migration table exists
-            });
-          }
-
-          case "SELECT constraint_name FROM information_schema.table_constraints WHERE table_schema = 'public' AND table_name = 'pgmigrations' AND constraint_type = 'PRIMARY KEY'": {
-            return Promise.resolve({
-              rows: [{ constraint_name: 'pk_constraint' }], // primary key exists
-            });
-          }
-
-          case 'SELECT name FROM "public"."pgmigrations" ORDER BY run_on, id': {
-            return Promise.resolve({
-              rows: [], // no migrations executed
-            });
-          }
-
-          default: {
-            return Promise.resolve({ rows: [{}] }); // bypass other queries
-          }
+    const queryMock = vi.fn((query) => {
+      switch (query) {
+        case 'SELECT pg_advisory_lock(7241865325823964)': {
+          return Promise.resolve();
         }
-      }),
-    } as unknown as ClientBase;
+
+        case "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'pgmigrations'": {
+          return Promise.resolve({
+            rows: [{}], // migration table exists
+          });
+        }
+
+        case "SELECT constraint_name FROM information_schema.table_constraints WHERE table_schema = 'public' AND table_name = 'pgmigrations' AND constraint_type = 'PRIMARY KEY'": {
+          return Promise.resolve({
+            rows: [{ constraint_name: 'pk_constraint' }], // primary key exists
+          });
+        }
+
+        case 'SELECT name FROM "public"."pgmigrations" ORDER BY run_on, id': {
+          return Promise.resolve({
+            rows: [], // no migrations executed
+          });
+        }
+
+        default: {
+          return Promise.resolve({ rows: [{}] }); // bypass other queries
+        }
+      }
+    });
+    const dbClient = { query: queryMock } as unknown as ClientBase;
 
     await expect(
       runner({
@@ -235,7 +234,7 @@ describe('runner', () => {
     ).resolves.not.toThrow();
 
     // Verify that the query with blocking lock was called
-    expect(dbClient.query).toHaveBeenCalledWith(
+    expect(queryMock).toHaveBeenCalledWith(
       'SELECT pg_advisory_lock(7241865325823964)',
       undefined
     );
@@ -243,39 +242,38 @@ describe('runner', () => {
 
   it('should use the provided lock value', async () => {
     const customLockValue = 12345;
-    const dbClient = {
-      query: vi.fn((query) => {
-        switch (query) {
-          case `SELECT pg_try_advisory_lock(${customLockValue}) AS "lockObtained"`: {
-            return Promise.resolve({
-              rows: [{ lockObtained: true }], // lock obtained with custom value
-            });
-          }
-
-          case "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'pgmigrations'": {
-            return Promise.resolve({
-              rows: [{}], // migration table exists
-            });
-          }
-
-          case "SELECT constraint_name FROM information_schema.table_constraints WHERE table_schema = 'public' AND table_name = 'pgmigrations' AND constraint_type = 'PRIMARY KEY'": {
-            return Promise.resolve({
-              rows: [{ constraint_name: 'pk_constraint' }], // primary key exists
-            });
-          }
-
-          case 'SELECT name FROM "public"."pgmigrations" ORDER BY run_on, id': {
-            return Promise.resolve({
-              rows: [], // no migrations executed
-            });
-          }
-
-          default: {
-            return Promise.resolve({ rows: [{}] }); // bypass other queries
-          }
+    const queryMock = vi.fn((query) => {
+      switch (query) {
+        case `SELECT pg_try_advisory_lock(${customLockValue}) AS "lockObtained"`: {
+          return Promise.resolve({
+            rows: [{ lockObtained: true }], // lock obtained with custom value
+          });
         }
-      }),
-    } as unknown as ClientBase;
+
+        case "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'pgmigrations'": {
+          return Promise.resolve({
+            rows: [{}], // migration table exists
+          });
+        }
+
+        case "SELECT constraint_name FROM information_schema.table_constraints WHERE table_schema = 'public' AND table_name = 'pgmigrations' AND constraint_type = 'PRIMARY KEY'": {
+          return Promise.resolve({
+            rows: [{ constraint_name: 'pk_constraint' }], // primary key exists
+          });
+        }
+
+        case 'SELECT name FROM "public"."pgmigrations" ORDER BY run_on, id': {
+          return Promise.resolve({
+            rows: [], // no migrations executed
+          });
+        }
+
+        default: {
+          return Promise.resolve({ rows: [{}] }); // bypass other queries
+        }
+      }
+    });
+    const dbClient = { query: queryMock } as unknown as ClientBase;
 
     await expect(
       runner({
@@ -288,7 +286,7 @@ describe('runner', () => {
     ).resolves.not.toThrow();
 
     // Verify that the query with custom lock value was called
-    expect(dbClient.query).toHaveBeenCalledWith(
+    expect(queryMock).toHaveBeenCalledWith(
       `SELECT pg_try_advisory_lock(${customLockValue}) AS "lockObtained"`,
       undefined
     );


### PR DESCRIPTION
Enables the last batch of type-aware oxlint rules that were previously disabled: no-deprecated, no-unnecessary-type-parameters, unbound-method, no-confusing-void-expression, no-unnecessary-type-assertion, return-await, prefer-includes, prefer-ts-expect-error and ban-ts-comment.

Only the five high-count `no-unsafe-*` rules and no-useless-default-assignment remain off, now annotated with their violation counts.

Notable fixes:

- `PgLiteral.create` declares `this: void`, since it never uses `this` and is passed around unbound as `pgm.func`.
- `src/cli/commands.ts` annotates the `migrationPath` parameter explicitly instead of suppressing it, so it type-checks whether or not the built types are present.
- `TXID_SNAPSHOT` in `src/pgType.ts` carries a targeted disable: oxlint reports the declaration itself, not a usage.
- `db.query`/`db.select` in the migration builder keep a scoped disable — they are closures from the `db()` factory, not bound methods.