### PR TITLE
refactor: enable no-unsafe-return

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -96,7 +96,6 @@
     "typescript/no-unsafe-member-access": "off", // 360
     "typescript/no-unsafe-call": "off", // 353
     "typescript/no-unsafe-assignment": "off", // 52
-    "typescript/no-unsafe-return": "off", // 16
     "typescript/no-unsafe-argument": "off", // 12
     "typescript/no-useless-default-assignment": "off", // 8
 

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -73,7 +73,8 @@ async function tryImport<TModule = unknown>(
   moduleName: string
 ): Promise<TModule | null> {
   try {
-    const module = await import(moduleName);
+    const module: { default?: TModule } & TModule = await import(moduleName);
+
     return module.default || module;
   } catch (error) {
     if (

--- a/src/db.ts
+++ b/src/db.ts
@@ -89,7 +89,7 @@ export function db(
     ? 'EXTERNAL'
     : 'DISCONNECTED';
 
-  const beforeCloseListeners: any[] = [];
+  const beforeCloseListeners: Array<() => unknown> = [];
 
   const connected: DBConnection['connected'] = () =>
     connectionStatus === 'CONNECTED' || connectionStatus === 'EXTERNAL';
@@ -162,7 +162,11 @@ ${error}
     queryTextOrConfig: string | QueryConfig | QueryArrayConfig,
     values?: any[]
   ) => {
-    const { rows } = await query(queryTextOrConfig, values);
+    const { rows }: { rows: unknown[] } = await query(
+      queryTextOrConfig,
+      values
+    );
+
     return rows;
   };
 
@@ -171,8 +175,12 @@ ${error}
     queryTextOrConfig: string | QueryConfig | QueryArrayConfig,
     values?: any[]
   ) => {
-    const rows = await select(queryTextOrConfig, values);
-    return rows.map((r: { [key: string]: any }) => r[columnName]);
+    const rows: Array<Record<string, unknown>> = await select(
+      queryTextOrConfig,
+      values
+    );
+
+    return rows.map((r) => r[columnName]);
   };
 
   return {
@@ -184,7 +192,7 @@ ${error}
     connected,
     addBeforeCloseListener: (listener) => beforeCloseListeners.push(listener),
     close: async () => {
-      await beforeCloseListeners.reduce(
+      await beforeCloseListeners.reduce<Promise<unknown>>(
         (promise, listener) =>
           promise.then(listener).catch((error: any) => {
             logger.error(error.stack || error);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -316,10 +316,12 @@ async function getRunMigrations(
     name: migrationsTable,
   });
 
-  return db.column(
+  const runNames: string[] = await db.column(
     nameColumn,
     `SELECT ${nameColumn} FROM ${fullTableName} ORDER BY ${runOnColumn}, ${idColumn}`
   );
+
+  return runNames;
 }
 
 function getMigrationsToRun(

--- a/test/migrations/007_table_rename_test.js
+++ b/test/migrations/007_table_rename_test.js
@@ -1,3 +1,6 @@
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ */
 export const up = (pgm) =>
   pgm.db
     .query("INSERT INTO t1(string) VALUES ('something') RETURNING id;")

--- a/test/migrations/018_drop_constraint_test.js
+++ b/test/migrations/018_drop_constraint_test.js
@@ -1,3 +1,6 @@
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ */
 export const up = (pgm) => pgm.db.query('INSERT INTO t1(nmbr) VALUES (30);');
 
 export const down = () => null;

--- a/test/migrations/086_grant_test.js
+++ b/test/migrations/086_grant_test.js
@@ -3,7 +3,14 @@ import { constants } from './085_grant_tables_schemas_roles.js';
 const { schema, table, role1, role2, tablePrivileges, schemaPrivilege } =
   constants;
 
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param role {string}
+ * @param tableName {string}
+ * @param privileges {string[]}
+ */
 const hasTablePrivileges = async (pgm, role, tableName, privileges) => {
+  /** @type {Array<{ privilege_type: string }>} */
   const rows = await pgm.db.select(`
     SELECT grantee, privilege_type
     FROM information_schema.role_table_grants
@@ -17,14 +24,27 @@ const hasTablePrivileges = async (pgm, role, tableName, privileges) => {
   );
 };
 
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param role {string}
+ * @param schemaName {string}
+ * @param privilege {string}
+ */
 const hasSchemaPrivilege = async (pgm, role, schemaName, privilege) => {
+  /** @type {Array<{ has_schema_privilege: boolean }>} */
   const rows = await pgm.db.select(`
     SELECT has_schema_privilege('${role}', '${schemaName}', '${privilege}');
   `);
   return rows.length > 0 && rows[0].has_schema_privilege;
 };
 
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param role {string}
+ * @param roleGroups {string[]}
+ */
 const isMemberOf = async (pgm, role, roleGroups) => {
+  /** @type {Array<{ rolname: string }>} */
   const rows = await pgm.db.select(`
     SELECT rolname FROM pg_roles WHERE pg_has_role('${role}', oid, 'member') AND rolname <> '${role}';
   `);


### PR DESCRIPTION
Enables typescript/no-unsafe-return and fixes the 16 violations. src/db.ts gets real types for the close-listener list and for the select/column row shapes; runner.ts and cli/config.ts route any through explicitly annotated locals; the three test migration fixtures get JSDoc annotations in the style already used by 014_add_constraint.js, with no runtime change.