### PR TITLE
fix: preserve schema when renaming tables

### DIFF
--- a/docs/src/migrations/tables.md
+++ b/docs/src/migrations/tables.md
@@ -73,7 +73,12 @@
 
 Renaming preserves the table’s schema, including during automatic reversal. If
 `new_tablename` specifies a schema, it must match the schema in `tablename`.
-Use a separate schema-changing operation to move a table to another schema.
+When specifying a destination schema, use the object form for `tablename` too;
+the schema cannot be inferred from a string table name or the database search path.
+
+To move a table between schemas, use SQL explicitly, for example
+`pgm.sql('ALTER TABLE "old_schema"."my_table" SET SCHEMA "new_schema"')`.
+Provide the corresponding SQL in your down migration to reverse that move.
 
 ## Operation: `alterTable`
 

--- a/docs/src/migrations/tables.md
+++ b/docs/src/migrations/tables.md
@@ -71,6 +71,10 @@
 | `tablename`     | [Name](/migrations/#type) | name of the table to rename |
 | `new_tablename` | [Name](/migrations/#type) | new name of the table       |
 
+Renaming preserves the table’s schema, including during automatic reversal. If
+`new_tablename` specifies a schema, it must match the schema in `tablename`.
+Use a separate schema-changing operation to move a table to another schema.
+
 ## Operation: `alterTable`
 
 #### `pgm.alterTable( tablename, options )`

--- a/src/operations/tables/renameTable.ts
+++ b/src/operations/tables/renameTable.ts
@@ -1,6 +1,6 @@
 import type { MigrationOptions } from '../../migrationOptions';
 import type { Name, Reversible } from '../generalTypes';
-import { isNameObject } from '../generalTypes';
+import { isNameObject, isSchemaNameObject } from '../generalTypes';
 
 export type RenameTableFn = (tableName: Name, newtableName: Name) => string;
 
@@ -8,8 +8,8 @@ export type RenameTable = Reversible<RenameTableFn>;
 
 export function renameTable(mOptions: MigrationOptions): RenameTable {
   const rename = (tableName: Name, newName: Name, reverse = false): string => {
-    const schema = isNameObject(tableName) ? tableName.schema : undefined;
-    if (isNameObject(newName) && newName.schema && newName.schema !== schema) {
+    const schema = isSchemaNameObject(tableName) ? tableName.schema : undefined;
+    if (isSchemaNameObject(newName) && newName.schema !== schema) {
       throw new Error('renameTable cannot change the schema of a table');
     }
 

--- a/src/operations/tables/renameTable.ts
+++ b/src/operations/tables/renameTable.ts
@@ -1,19 +1,32 @@
 import type { MigrationOptions } from '../../migrationOptions';
 import type { Name, Reversible } from '../generalTypes';
+import { isNameObject } from '../generalTypes';
 
 export type RenameTableFn = (tableName: Name, newtableName: Name) => string;
 
 export type RenameTable = Reversible<RenameTableFn>;
 
 export function renameTable(mOptions: MigrationOptions): RenameTable {
-  const _rename: RenameTable = (tableName, newName) => {
-    const tableNameStr = mOptions.literal(tableName);
-    const newNameStr = mOptions.literal(newName);
+  const rename = (tableName: Name, newName: Name, reverse = false): string => {
+    const schema = isNameObject(tableName) ? tableName.schema : undefined;
+    if (isNameObject(newName) && newName.schema && newName.schema !== schema) {
+      throw new Error('renameTable cannot change the schema of a table');
+    }
 
-    return `ALTER TABLE ${tableNameStr} RENAME TO ${newNameStr};`;
+    const oldName = isNameObject(tableName) ? tableName.name : tableName;
+    const destination = isNameObject(newName) ? newName.name : newName;
+    const newNameStr = mOptions.literal(destination);
+    const tableNameStr = reverse
+      ? (schema ? `${mOptions.literal(schema)}.` : '') + newNameStr
+      : mOptions.literal(tableName);
+    const destinationStr = reverse ? mOptions.literal(oldName) : newNameStr;
+
+    return `ALTER TABLE ${tableNameStr} RENAME TO ${destinationStr};`;
   };
 
-  _rename.reverse = (tableName, newName) => _rename(newName, tableName);
+  const _rename: RenameTable = (tableName, newName) =>
+    rename(tableName, newName);
+  _rename.reverse = (tableName, newName) => rename(tableName, newName, true);
 
   return _rename;
 }

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-14.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-14.stdout.log
@@ -617,6 +617,10 @@ DELETE FROM "public"."pgmigrations" WHERE name='007_table_rename_test';
 
 
 ### MIGRATION 006_table_rename (DOWN) ###
+ALTER TABLE "rename_schema"."renamed" RENAME TO "intermediate";
+ALTER TABLE "rename_schema"."intermediate" RENAME TO "original";
+DROP TABLE "rename_schema"."original";
+DROP SCHEMA "rename_schema";
 ALTER TABLE "t2r" RENAME TO "t2";
 DELETE FROM "public"."pgmigrations" WHERE name='006_table_rename';
 

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-15.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-15.stdout.log
@@ -618,6 +618,10 @@ DELETE FROM "public"."pgmigrations" WHERE name='007_table_rename_test';
 
 
 ### MIGRATION 006_table_rename (DOWN) ###
+ALTER TABLE "rename_schema"."renamed" RENAME TO "intermediate";
+ALTER TABLE "rename_schema"."intermediate" RENAME TO "original";
+DROP TABLE "rename_schema"."original";
+DROP SCHEMA "rename_schema";
 ALTER TABLE "t2r" RENAME TO "t2";
 DELETE FROM "public"."pgmigrations" WHERE name='006_table_rename';
 

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-16.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-16.stdout.log
@@ -618,6 +618,10 @@ DELETE FROM "public"."pgmigrations" WHERE name='007_table_rename_test';
 
 
 ### MIGRATION 006_table_rename (DOWN) ###
+ALTER TABLE "rename_schema"."renamed" RENAME TO "intermediate";
+ALTER TABLE "rename_schema"."intermediate" RENAME TO "original";
+DROP TABLE "rename_schema"."original";
+DROP SCHEMA "rename_schema";
 ALTER TABLE "t2r" RENAME TO "t2";
 DELETE FROM "public"."pgmigrations" WHERE name='006_table_rename';
 

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-17.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-17.stdout.log
@@ -619,6 +619,10 @@ DELETE FROM "public"."pgmigrations" WHERE name='007_table_rename_test';
 
 
 ### MIGRATION 006_table_rename (DOWN) ###
+ALTER TABLE "rename_schema"."renamed" RENAME TO "intermediate";
+ALTER TABLE "rename_schema"."intermediate" RENAME TO "original";
+DROP TABLE "rename_schema"."original";
+DROP SCHEMA "rename_schema";
 ALTER TABLE "t2r" RENAME TO "t2";
 DELETE FROM "public"."pgmigrations" WHERE name='006_table_rename';
 

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-18.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-18.stdout.log
@@ -619,6 +619,10 @@ DELETE FROM "public"."pgmigrations" WHERE name='007_table_rename_test';
 
 
 ### MIGRATION 006_table_rename (DOWN) ###
+ALTER TABLE "rename_schema"."renamed" RENAME TO "intermediate";
+ALTER TABLE "rename_schema"."intermediate" RENAME TO "original";
+DROP TABLE "rename_schema"."original";
+DROP SCHEMA "rename_schema";
 ALTER TABLE "t2r" RENAME TO "t2";
 DELETE FROM "public"."pgmigrations" WHERE name='006_table_rename';
 

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-14.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-14.stdout.log
@@ -122,6 +122,10 @@ INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('005_table_test', NOW
 
 ### MIGRATION 006_table_rename (UP) ###
 ALTER TABLE "t2" RENAME TO "t2r";
+CREATE SCHEMA "rename_schema";
+CREATE TABLE "rename_schema"."original" ("id" integer);
+ALTER TABLE "rename_schema"."original" RENAME TO "intermediate";
+ALTER TABLE "rename_schema"."intermediate" RENAME TO "renamed";
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('006_table_rename', NOW());
 
 

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-15.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-15.stdout.log
@@ -122,6 +122,10 @@ INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('005_table_test', NOW
 
 ### MIGRATION 006_table_rename (UP) ###
 ALTER TABLE "t2" RENAME TO "t2r";
+CREATE SCHEMA "rename_schema";
+CREATE TABLE "rename_schema"."original" ("id" integer);
+ALTER TABLE "rename_schema"."original" RENAME TO "intermediate";
+ALTER TABLE "rename_schema"."intermediate" RENAME TO "renamed";
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('006_table_rename', NOW());
 
 

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-16.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-16.stdout.log
@@ -122,6 +122,10 @@ INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('005_table_test', NOW
 
 ### MIGRATION 006_table_rename (UP) ###
 ALTER TABLE "t2" RENAME TO "t2r";
+CREATE SCHEMA "rename_schema";
+CREATE TABLE "rename_schema"."original" ("id" integer);
+ALTER TABLE "rename_schema"."original" RENAME TO "intermediate";
+ALTER TABLE "rename_schema"."intermediate" RENAME TO "renamed";
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('006_table_rename', NOW());
 
 

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-17.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-17.stdout.log
@@ -122,6 +122,10 @@ INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('005_table_test', NOW
 
 ### MIGRATION 006_table_rename (UP) ###
 ALTER TABLE "t2" RENAME TO "t2r";
+CREATE SCHEMA "rename_schema";
+CREATE TABLE "rename_schema"."original" ("id" integer);
+ALTER TABLE "rename_schema"."original" RENAME TO "intermediate";
+ALTER TABLE "rename_schema"."intermediate" RENAME TO "renamed";
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('006_table_rename', NOW());
 
 

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-18.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-18.stdout.log
@@ -122,6 +122,10 @@ INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('005_table_test', NOW
 
 ### MIGRATION 006_table_rename (UP) ###
 ALTER TABLE "t2" RENAME TO "t2r";
+CREATE SCHEMA "rename_schema";
+CREATE TABLE "rename_schema"."original" ("id" integer);
+ALTER TABLE "rename_schema"."original" RENAME TO "intermediate";
+ALTER TABLE "rename_schema"."intermediate" RENAME TO "renamed";
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('006_table_rename', NOW());
 
 

--- a/test/migrations/006_table_rename.js
+++ b/test/migrations/006_table_rename.js
@@ -1,3 +1,12 @@
 export const up = (pgm) => {
   pgm.renameTable('t2', 't2r');
+
+  const schema = 'rename_schema';
+  pgm.createSchema(schema);
+  pgm.createTable({ schema, name: 'original' }, { id: 'integer' });
+  pgm.renameTable({ schema, name: 'original' }, 'intermediate');
+  pgm.renameTable(
+    { schema, name: 'intermediate' },
+    { schema, name: 'renamed' }
+  );
 };

--- a/test/operations/tables/renameTable.spec.ts
+++ b/test/operations/tables/renameTable.spec.ts
@@ -49,9 +49,26 @@ describe('operations', () => {
         const from = { name: 'distributors', schema: 'myschema' };
         const to = { name: 'suppliers', schema: 'other' };
 
-        expect(() => renameTableFn(from, to)).toThrow('schema');
-        expect(() => renameTableFn.reverse(from, to)).toThrow('schema');
-        expect(() => renameTableFn('distributors', to)).toThrow('schema');
+        expect(() => renameTableFn(from, to)).toThrow(
+          new Error('renameTable cannot change the schema of a table')
+        );
+        expect(() => renameTableFn.reverse(from, to)).toThrow(
+          new Error('renameTable cannot change the schema of a table')
+        );
+        expect(() => renameTableFn('distributors', to)).toThrow(
+          new Error('renameTable cannot change the schema of a table')
+        );
+      });
+
+      it('should reject an explicitly empty destination schema', () => {
+        const from = { schema: 'myschema', name: 'distributors' };
+        const to = { schema: '', name: 'suppliers' };
+        const error = new Error(
+          'renameTable cannot change the schema of a table'
+        );
+
+        expect(() => renameTableFn(from, to)).toThrow(error);
+        expect(() => renameTableFn.reverse(from, to)).toThrow(error);
       });
 
       it('should escape schema and table names when reversing', () => {

--- a/test/operations/tables/renameTable.spec.ts
+++ b/test/operations/tables/renameTable.spec.ts
@@ -28,8 +28,39 @@ describe('operations', () => {
 
         expect(statement).toBeTypeOf('string');
         expect(statement).toBe(
-          'ALTER TABLE "myschema"."distributors" RENAME TO "myschema"."suppliers";'
+          'ALTER TABLE "myschema"."distributors" RENAME TO "suppliers";'
         );
+      });
+
+      it.each([
+        ['suppliers'],
+        [{ name: 'suppliers' }],
+        [{ name: 'suppliers', schema: 'myschema' }],
+      ])('should preserve the schema when reversing to %j', (newName) => {
+        expect(
+          renameTableFn.reverse(
+            { name: 'distributors', schema: 'myschema' },
+            newName
+          )
+        ).toBe('ALTER TABLE "myschema"."suppliers" RENAME TO "distributors";');
+      });
+
+      it('should reject a change of schema in either direction', () => {
+        const from = { name: 'distributors', schema: 'myschema' };
+        const to = { name: 'suppliers', schema: 'other' };
+
+        expect(() => renameTableFn(from, to)).toThrow('schema');
+        expect(() => renameTableFn.reverse(from, to)).toThrow('schema');
+        expect(() => renameTableFn('distributors', to)).toThrow('schema');
+      });
+
+      it('should escape schema and table names when reversing', () => {
+        expect(
+          renameTableFn.reverse(
+            { name: 'old"table', schema: 'my"schema' },
+            'new"table'
+          )
+        ).toBe('ALTER TABLE "my""schema"."new""table" RENAME TO "old""table";');
       });
 
       describe('reverse', () => {


### PR DESCRIPTION
Fixes #1179.

`renameTable({ schema: 'a', name: 'foo' }, 'bar')` currently works going up but generates `ALTER TABLE "bar" RENAME TO "a"."foo"` during automatic rollback. Passing the same schema in both arguments also generates an invalid schema-qualified `RENAME TO` target.

Keep the existing `Name` argument types, emit an unqualified destination identifier, and preserve the source schema during reversal. Destination objects with the same schema remain supported; an explicitly different schema raises an error instead of generating invalid SQL. Moving tables between schemas remains a separate operation, as discussed in the issue.

Added regression coverage for string/object destinations, automatic reversal, mismatched schemas, and quoted identifiers. Extended the existing table-rename migration fixture to exercise both forms up and down. The ten SQL snapshot changes are the same four statements per direction across the existing PostgreSQL 14–18 snapshots.

Validation:
- Regression tests failed before the implementation and pass afterward.
- All 744 unit tests pass (105 files).
- Build, type checking, lint, formatting, and `git diff --check` pass.
- The complete migration fixture sequence passed up and down on a fresh native PostgreSQL 16.15 cluster with Node 24.18.0. All ten changed snapshot sections match the SQL executed there.
- Docker-based integration tests and PostgreSQL 14, 15, 17, and 18 were not run locally; those remain for CI.

Reviewed with the help of AI.
