### PR TITLE
fix: preserve schema when renaming database objects

### DIFF
--- a/docs/src/migrations/domains.md
+++ b/docs/src/migrations/domains.md
@@ -84,3 +84,17 @@
 | ----------------- | ------------------------- | ---------------------- |
 | `old_domain_name` | [Name](/migrations/#type) | Old name of the domain |
 | `new_domain_name` | [Name](/migrations/#type) | New name of the domain |
+
+The destination name is unqualified in the generated SQL. A destination object
+may repeat the source schema, but cannot specify a different schema. When a
+destination schema is provided, use the object form for the source name too;
+the schema cannot be inferred from a string name or the database search path.
+Automatic reversal preserves the source schema.
+
+An undefined schema is treated as omitted. Explicit schemas are compared before
+decamelization, including empty strings: an empty destination schema is rejected
+when the source schema is omitted or nonempty; matching empty schemas remain
+unqualified.
+
+Moving a domain between schemas requires separate SQL and an explicit down
+migration to reverse that move.

--- a/docs/src/migrations/domains.md
+++ b/docs/src/migrations/domains.md
@@ -85,16 +85,15 @@
 | `old_domain_name` | [Name](/migrations/#type) | Old name of the domain |
 | `new_domain_name` | [Name](/migrations/#type) | New name of the domain |
 
-The destination name is unqualified in the generated SQL. A destination object
-may repeat the source schema, but cannot specify a different schema. When a
-destination schema is provided, use the object form for the source name too;
+The destination name is unqualified in the generated SQL. If a destination object
+specifies a schema, it must match the source schema. Use `{ schema, name }` for
+schema-qualified names so automatic reversal preserves the source schema;
 the schema cannot be inferred from a string name or the database search path.
-Automatic reversal preserves the source schema.
 
-An undefined schema is treated as omitted. Explicit schemas are compared before
-decamelization, including empty strings: an empty destination schema is rejected
-when the source schema is omitted or nonempty; matching empty schemas remain
-unqualified.
+Qualified `PgLiteral` names can produce invalid SQL, including during automatic
+reversal. Use structured name objects instead, or use `pgm.sql` with explicit SQL
+in both your up and down migrations.
 
-Moving a domain between schemas requires separate SQL and an explicit down
-migration to reverse that move.
+To move a domain between schemas, use SQL explicitly, for example
+`pgm.sql('ALTER DOMAIN "old_schema"."my_domain" SET SCHEMA "new_schema"')`.
+Provide the corresponding SQL in your down migration to reverse that move.

--- a/docs/src/migrations/indexes.md
+++ b/docs/src/migrations/indexes.md
@@ -110,3 +110,17 @@ pgm.renameIndex('index_name', 'new_index_name');
 ```
 
 :::
+
+The destination name is unqualified in the generated SQL. A destination object
+may repeat the source schema, but cannot specify a different schema. When a
+destination schema is provided, use the object form for the source name too;
+the schema cannot be inferred from a string name or the database search path.
+Automatic reversal preserves the source schema.
+
+An undefined schema is treated as omitted. Explicit schemas are compared before
+decamelization, including empty strings: an empty destination schema is rejected
+when the source schema is omitted or nonempty; matching empty schemas remain
+unqualified.
+
+Renaming an index does not move it to another schema. PostgreSQL does not provide
+`ALTER INDEX ... SET SCHEMA`; indexes follow their table when it changes schema.

--- a/docs/src/migrations/indexes.md
+++ b/docs/src/migrations/indexes.md
@@ -111,16 +111,14 @@ pgm.renameIndex('index_name', 'new_index_name');
 
 :::
 
-The destination name is unqualified in the generated SQL. A destination object
-may repeat the source schema, but cannot specify a different schema. When a
-destination schema is provided, use the object form for the source name too;
+The destination name is unqualified in the generated SQL. If a destination object
+specifies a schema, it must match the source schema. Use `{ schema, name }` for
+schema-qualified names so automatic reversal preserves the source schema;
 the schema cannot be inferred from a string name or the database search path.
-Automatic reversal preserves the source schema.
 
-An undefined schema is treated as omitted. Explicit schemas are compared before
-decamelization, including empty strings: an empty destination schema is rejected
-when the source schema is omitted or nonempty; matching empty schemas remain
-unqualified.
+Qualified `PgLiteral` names can produce invalid SQL, including during automatic
+reversal. Use structured name objects instead, or use `pgm.sql` with explicit SQL
+in both your up and down migrations.
 
 Renaming an index does not move it to another schema. PostgreSQL does not provide
 `ALTER INDEX ... SET SCHEMA`; indexes follow their table when it changes schema.

--- a/docs/src/migrations/mViews.md
+++ b/docs/src/migrations/mViews.md
@@ -81,10 +81,24 @@
 
 ### Arguments
 
-| Name          | Type     | Description          |
-| ------------- | -------- | -------------------- |
-| `viewName`    | `string` | old name of the view |
-| `newViewName` | `string` | new name of the view |
+| Name          | Type                      | Description          |
+| ------------- | ------------------------- | -------------------- |
+| `viewName`    | [Name](/migrations/#type) | old name of the view |
+| `newViewName` | [Name](/migrations/#type) | new name of the view |
+
+The destination name is unqualified in the generated SQL. A destination object
+may repeat the source schema, but cannot specify a different schema. When a
+destination schema is provided, use the object form for the source name too;
+the schema cannot be inferred from a string name or the database search path.
+Automatic reversal preserves the source schema.
+
+An undefined schema is treated as omitted. Explicit schemas are compared before
+decamelization, including empty strings: an empty destination schema is rejected
+when the source schema is omitted or nonempty; matching empty schemas remain
+unqualified.
+
+Moving a materialized view between schemas requires separate SQL and an explicit down
+migration to reverse that move.
 
 ## Operation: `alterMaterializedViewColumn`
 

--- a/docs/src/migrations/mViews.md
+++ b/docs/src/migrations/mViews.md
@@ -86,19 +86,18 @@
 | `viewName`    | [Name](/migrations/#type) | old name of the view |
 | `newViewName` | [Name](/migrations/#type) | new name of the view |
 
-The destination name is unqualified in the generated SQL. A destination object
-may repeat the source schema, but cannot specify a different schema. When a
-destination schema is provided, use the object form for the source name too;
+The destination name is unqualified in the generated SQL. If a destination object
+specifies a schema, it must match the source schema. Use `{ schema, name }` for
+schema-qualified names so automatic reversal preserves the source schema;
 the schema cannot be inferred from a string name or the database search path.
-Automatic reversal preserves the source schema.
 
-An undefined schema is treated as omitted. Explicit schemas are compared before
-decamelization, including empty strings: an empty destination schema is rejected
-when the source schema is omitted or nonempty; matching empty schemas remain
-unqualified.
+Qualified `PgLiteral` names can produce invalid SQL, including during automatic
+reversal. Use structured name objects instead, or use `pgm.sql` with explicit SQL
+in both your up and down migrations.
 
-Moving a materialized view between schemas requires separate SQL and an explicit down
-migration to reverse that move.
+To move a materialized view between schemas, use SQL explicitly, for example
+`pgm.sql('ALTER MATERIALIZED VIEW "old_schema"."my_view" SET SCHEMA "new_schema"')`.
+Provide the corresponding SQL in your down migration to reverse that move.
 
 ## Operation: `alterMaterializedViewColumn`
 

--- a/docs/src/migrations/sequences.md
+++ b/docs/src/migrations/sequences.md
@@ -89,7 +89,21 @@ sequence.
 
 ### Arguments
 
-| Name                | Type     | Description                                   |
-| ------------------- | -------- | --------------------------------------------- |
-| `old_sequence_name` | `string` | old [Name](/migrations/#type) of the sequence |
-| `new_sequence_name` | `string` | new [Name](/migrations/#type) of the sequence |
+| Name                | Type                      | Description                                   |
+| ------------------- | ------------------------- | --------------------------------------------- |
+| `old_sequence_name` | [Name](/migrations/#type) | old [Name](/migrations/#type) of the sequence |
+| `new_sequence_name` | [Name](/migrations/#type) | new [Name](/migrations/#type) of the sequence |
+
+The destination name is unqualified in the generated SQL. A destination object
+may repeat the source schema, but cannot specify a different schema. When a
+destination schema is provided, use the object form for the source name too;
+the schema cannot be inferred from a string name or the database search path.
+Automatic reversal preserves the source schema.
+
+An undefined schema is treated as omitted. Explicit schemas are compared before
+decamelization, including empty strings: an empty destination schema is rejected
+when the source schema is omitted or nonempty; matching empty schemas remain
+unqualified.
+
+Moving a sequence between schemas requires separate SQL and an explicit down
+migration to reverse that move.

--- a/docs/src/migrations/sequences.md
+++ b/docs/src/migrations/sequences.md
@@ -89,21 +89,20 @@ sequence.
 
 ### Arguments
 
-| Name                | Type                      | Description                                   |
-| ------------------- | ------------------------- | --------------------------------------------- |
-| `old_sequence_name` | [Name](/migrations/#type) | old [Name](/migrations/#type) of the sequence |
-| `new_sequence_name` | [Name](/migrations/#type) | new [Name](/migrations/#type) of the sequence |
+| Name                | Type                      | Description              |
+| ------------------- | ------------------------- | ------------------------ |
+| `old_sequence_name` | [Name](/migrations/#type) | Old name of the sequence |
+| `new_sequence_name` | [Name](/migrations/#type) | New name of the sequence |
 
-The destination name is unqualified in the generated SQL. A destination object
-may repeat the source schema, but cannot specify a different schema. When a
-destination schema is provided, use the object form for the source name too;
+The destination name is unqualified in the generated SQL. If a destination object
+specifies a schema, it must match the source schema. Use `{ schema, name }` for
+schema-qualified names so automatic reversal preserves the source schema;
 the schema cannot be inferred from a string name or the database search path.
-Automatic reversal preserves the source schema.
 
-An undefined schema is treated as omitted. Explicit schemas are compared before
-decamelization, including empty strings: an empty destination schema is rejected
-when the source schema is omitted or nonempty; matching empty schemas remain
-unqualified.
+Qualified `PgLiteral` names can produce invalid SQL, including during automatic
+reversal. Use structured name objects instead, or use `pgm.sql` with explicit SQL
+in both your up and down migrations.
 
-Moving a sequence between schemas requires separate SQL and an explicit down
-migration to reverse that move.
+To move a sequence between schemas, use SQL explicitly, for example
+`pgm.sql('ALTER SEQUENCE "old_schema"."my_sequence" SET SCHEMA "new_schema"')`.
+Provide the corresponding SQL in your down migration to reverse that move.

--- a/docs/src/migrations/types.md
+++ b/docs/src/migrations/types.md
@@ -61,19 +61,18 @@ operation (`dropType`) when the migration is rolled back.
 | `type_name`     | [Name](/migrations/#type) | name of the type to rename |
 | `new_type_name` | [Name](/migrations/#type) | name of the new type       |
 
-The destination name is unqualified in the generated SQL. A destination object
-may repeat the source schema, but cannot specify a different schema. When a
-destination schema is provided, use the object form for the source name too;
+The destination name is unqualified in the generated SQL. If a destination object
+specifies a schema, it must match the source schema. Use `{ schema, name }` for
+schema-qualified names so automatic reversal preserves the source schema;
 the schema cannot be inferred from a string name or the database search path.
-Automatic reversal preserves the source schema.
 
-An undefined schema is treated as omitted. Explicit schemas are compared before
-decamelization, including empty strings: an empty destination schema is rejected
-when the source schema is omitted or nonempty; matching empty schemas remain
-unqualified.
+Qualified `PgLiteral` names can produce invalid SQL, including during automatic
+reversal. Use structured name objects instead, or use `pgm.sql` with explicit SQL
+in both your up and down migrations.
 
-Moving a type between schemas requires separate SQL and an explicit down
-migration to reverse that move.
+To move a type between schemas, use SQL explicitly, for example
+`pgm.sql('ALTER TYPE "old_schema"."my_type" SET SCHEMA "new_schema"')`.
+Provide the corresponding SQL in your down migration to reverse that move.
 
 ## Operation: `alterType`
 

--- a/docs/src/migrations/types.md
+++ b/docs/src/migrations/types.md
@@ -61,6 +61,20 @@ operation (`dropType`) when the migration is rolled back.
 | `type_name`     | [Name](/migrations/#type) | name of the type to rename |
 | `new_type_name` | [Name](/migrations/#type) | name of the new type       |
 
+The destination name is unqualified in the generated SQL. A destination object
+may repeat the source schema, but cannot specify a different schema. When a
+destination schema is provided, use the object form for the source name too;
+the schema cannot be inferred from a string name or the database search path.
+Automatic reversal preserves the source schema.
+
+An undefined schema is treated as omitted. Explicit schemas are compared before
+decamelization, including empty strings: an empty destination schema is rejected
+when the source schema is omitted or nonempty; matching empty schemas remain
+unqualified.
+
+Moving a type between schemas requires separate SQL and an explicit down
+migration to reverse that move.
+
 ## Operation: `alterType`
 
 #### `pgm.addTypeAttribute( type_name, attribute_name, attribute_type, attribute_options )`

--- a/docs/src/migrations/views.md
+++ b/docs/src/migrations/views.md
@@ -98,7 +98,21 @@
 
 ### Arguments
 
-| Name          | Type     | Description          |
-| ------------- | -------- | -------------------- |
-| `viewName`    | `string` | old name of the view |
-| `newViewName` | `string` | new name of the view |
+| Name          | Type                      | Description          |
+| ------------- | ------------------------- | -------------------- |
+| `viewName`    | [Name](/migrations/#type) | old name of the view |
+| `newViewName` | [Name](/migrations/#type) | new name of the view |
+
+The destination name is unqualified in the generated SQL. A destination object
+may repeat the source schema, but cannot specify a different schema. When a
+destination schema is provided, use the object form for the source name too;
+the schema cannot be inferred from a string name or the database search path.
+Automatic reversal preserves the source schema.
+
+An undefined schema is treated as omitted. Explicit schemas are compared before
+decamelization, including empty strings: an empty destination schema is rejected
+when the source schema is omitted or nonempty; matching empty schemas remain
+unqualified.
+
+Moving a view between schemas requires separate SQL and an explicit down
+migration to reverse that move.

--- a/docs/src/migrations/views.md
+++ b/docs/src/migrations/views.md
@@ -103,16 +103,15 @@
 | `viewName`    | [Name](/migrations/#type) | old name of the view |
 | `newViewName` | [Name](/migrations/#type) | new name of the view |
 
-The destination name is unqualified in the generated SQL. A destination object
-may repeat the source schema, but cannot specify a different schema. When a
-destination schema is provided, use the object form for the source name too;
+The destination name is unqualified in the generated SQL. If a destination object
+specifies a schema, it must match the source schema. Use `{ schema, name }` for
+schema-qualified names so automatic reversal preserves the source schema;
 the schema cannot be inferred from a string name or the database search path.
-Automatic reversal preserves the source schema.
 
-An undefined schema is treated as omitted. Explicit schemas are compared before
-decamelization, including empty strings: an empty destination schema is rejected
-when the source schema is omitted or nonempty; matching empty schemas remain
-unqualified.
+Qualified `PgLiteral` names can produce invalid SQL, including during automatic
+reversal. Use structured name objects instead, or use `pgm.sql` with explicit SQL
+in both your up and down migrations.
 
-Moving a view between schemas requires separate SQL and an explicit down
-migration to reverse that move.
+To move a view between schemas, use SQL explicitly, for example
+`pgm.sql('ALTER VIEW "old_schema"."my_view" SET SCHEMA "new_schema"')`.
+Provide the corresponding SQL in your down migration to reverse that move.

--- a/src/operations/domains/renameDomain.ts
+++ b/src/operations/domains/renameDomain.ts
@@ -1,5 +1,6 @@
 import type { MigrationOptions } from '../../migrationOptions';
 import type { Name, Reversible } from '../generalTypes';
+import { isNameObject, isSchemaNameObject } from '../generalTypes';
 
 export type RenameDomainFn = (
   oldDomainName: Name,
@@ -9,15 +10,25 @@ export type RenameDomainFn = (
 export type RenameDomain = Reversible<RenameDomainFn>;
 
 export function renameDomain(mOptions: MigrationOptions): RenameDomain {
-  const _rename: RenameDomain = (domainName, newDomainName) => {
-    const domainNameStr = mOptions.literal(domainName);
-    const newDomainNameStr = mOptions.literal(newDomainName);
+  const rename = (source: Name, newName: Name, reverse = false): string => {
+    const schema = isSchemaNameObject(source) ? source.schema : undefined;
+    if (isSchemaNameObject(newName) && newName.schema !== schema) {
+      throw new Error('renameDomain cannot change the schema of a domain');
+    }
 
-    return `ALTER DOMAIN ${domainNameStr} RENAME TO ${newDomainNameStr};`;
+    const oldName = isNameObject(source) ? source.name : source;
+    const destination = isNameObject(newName) ? newName.name : newName;
+    const newNameStr = mOptions.literal(destination);
+    const sourceStr = reverse
+      ? (schema ? `${mOptions.literal(schema)}.` : '') + newNameStr
+      : mOptions.literal(source);
+    const destinationStr = reverse ? mOptions.literal(oldName) : newNameStr;
+
+    return `ALTER DOMAIN ${sourceStr} RENAME TO ${destinationStr};`;
   };
 
-  _rename.reverse = (domainName, newDomainName) =>
-    _rename(newDomainName, domainName);
+  const _rename: RenameDomain = (source, newName) => rename(source, newName);
+  _rename.reverse = (source, newName) => rename(source, newName, true);
 
   return _rename;
 }

--- a/src/operations/indexes/renameIndex.ts
+++ b/src/operations/indexes/renameIndex.ts
@@ -1,18 +1,30 @@
 import type { MigrationOptions } from '../../migrationOptions';
 import type { Name, Reversible } from '../generalTypes';
+import { isNameObject, isSchemaNameObject } from '../generalTypes';
 
 export type RenameIndexFn = (name: Name, newName: Name) => string;
 export type RenameIndex = Reversible<RenameIndexFn>;
 
 export function renameIndex(mOptions: MigrationOptions): RenameIndex {
-  const _rename: RenameIndex = (name, newName) => {
-    const indexNameStr = mOptions.literal(name);
-    const newNameStr = mOptions.literal(newName);
+  const rename = (source: Name, newName: Name, reverse = false): string => {
+    const schema = isSchemaNameObject(source) ? source.schema : undefined;
+    if (isSchemaNameObject(newName) && newName.schema !== schema) {
+      throw new Error('renameIndex cannot change the schema of an index');
+    }
 
-    return `ALTER INDEX ${indexNameStr} RENAME TO ${newNameStr};`;
+    const oldName = isNameObject(source) ? source.name : source;
+    const destination = isNameObject(newName) ? newName.name : newName;
+    const newNameStr = mOptions.literal(destination);
+    const sourceStr = reverse
+      ? (schema ? `${mOptions.literal(schema)}.` : '') + newNameStr
+      : mOptions.literal(source);
+    const destinationStr = reverse ? mOptions.literal(oldName) : newNameStr;
+
+    return `ALTER INDEX ${sourceStr} RENAME TO ${destinationStr};`;
   };
 
-  _rename.reverse = (name, newName) => _rename(newName, name);
+  const _rename: RenameIndex = (source, newName) => rename(source, newName);
+  _rename.reverse = (source, newName) => rename(source, newName, true);
 
   return _rename;
 }

--- a/src/operations/materializedViews/renameMaterializedView.ts
+++ b/src/operations/materializedViews/renameMaterializedView.ts
@@ -1,5 +1,6 @@
 import type { MigrationOptions } from '../../migrationOptions';
 import type { Name, Reversible } from '../generalTypes';
+import { isNameObject, isSchemaNameObject } from '../generalTypes';
 
 export type RenameMaterializedViewFn = (
   viewName: Name,
@@ -11,14 +12,28 @@ export type RenameMaterializedView = Reversible<RenameMaterializedViewFn>;
 export function renameMaterializedView(
   mOptions: MigrationOptions
 ): RenameMaterializedView {
-  const _rename: RenameMaterializedView = (viewName, newViewName) => {
-    const viewNameStr = mOptions.literal(viewName);
-    const newViewNameStr = mOptions.literal(newViewName);
+  const rename = (source: Name, newName: Name, reverse = false): string => {
+    const schema = isSchemaNameObject(source) ? source.schema : undefined;
+    if (isSchemaNameObject(newName) && newName.schema !== schema) {
+      throw new Error(
+        'renameMaterializedView cannot change the schema of a materialized view'
+      );
+    }
 
-    return `ALTER MATERIALIZED VIEW ${viewNameStr} RENAME TO ${newViewNameStr};`;
+    const oldName = isNameObject(source) ? source.name : source;
+    const destination = isNameObject(newName) ? newName.name : newName;
+    const newNameStr = mOptions.literal(destination);
+    const sourceStr = reverse
+      ? (schema ? `${mOptions.literal(schema)}.` : '') + newNameStr
+      : mOptions.literal(source);
+    const destinationStr = reverse ? mOptions.literal(oldName) : newNameStr;
+
+    return `ALTER MATERIALIZED VIEW ${sourceStr} RENAME TO ${destinationStr};`;
   };
 
-  _rename.reverse = (viewName, newViewName) => _rename(newViewName, viewName);
+  const _rename: RenameMaterializedView = (source, newName) =>
+    rename(source, newName);
+  _rename.reverse = (source, newName) => rename(source, newName, true);
 
   return _rename;
 }

--- a/src/operations/sequences/renameSequence.ts
+++ b/src/operations/sequences/renameSequence.ts
@@ -1,5 +1,6 @@
 import type { MigrationOptions } from '../../migrationOptions';
 import type { Name, Reversible } from '../generalTypes';
+import { isNameObject, isSchemaNameObject } from '../generalTypes';
 
 export type RenameSequenceFn = (
   oldSequenceName: Name,
@@ -9,15 +10,25 @@ export type RenameSequenceFn = (
 export type RenameSequence = Reversible<RenameSequenceFn>;
 
 export function renameSequence(mOptions: MigrationOptions): RenameSequence {
-  const _rename: RenameSequence = (sequenceName, newSequenceName) => {
-    const sequenceNameStr = mOptions.literal(sequenceName);
-    const newSequenceNameStr = mOptions.literal(newSequenceName);
+  const rename = (source: Name, newName: Name, reverse = false): string => {
+    const schema = isSchemaNameObject(source) ? source.schema : undefined;
+    if (isSchemaNameObject(newName) && newName.schema !== schema) {
+      throw new Error('renameSequence cannot change the schema of a sequence');
+    }
 
-    return `ALTER SEQUENCE ${sequenceNameStr} RENAME TO ${newSequenceNameStr};`;
+    const oldName = isNameObject(source) ? source.name : source;
+    const destination = isNameObject(newName) ? newName.name : newName;
+    const newNameStr = mOptions.literal(destination);
+    const sourceStr = reverse
+      ? (schema ? `${mOptions.literal(schema)}.` : '') + newNameStr
+      : mOptions.literal(source);
+    const destinationStr = reverse ? mOptions.literal(oldName) : newNameStr;
+
+    return `ALTER SEQUENCE ${sourceStr} RENAME TO ${destinationStr};`;
   };
 
-  _rename.reverse = (sequenceName, newSequenceName) =>
-    _rename(newSequenceName, sequenceName);
+  const _rename: RenameSequence = (source, newName) => rename(source, newName);
+  _rename.reverse = (source, newName) => rename(source, newName, true);
 
   return _rename;
 }

--- a/src/operations/types/renameType.ts
+++ b/src/operations/types/renameType.ts
@@ -1,19 +1,31 @@
 import type { MigrationOptions } from '../../migrationOptions';
 import type { Name, Reversible } from '../generalTypes';
+import { isNameObject, isSchemaNameObject } from '../generalTypes';
 
 export type RenameTypeFn = (typeName: Name, newTypeName: Name) => string;
 
 export type RenameType = Reversible<RenameTypeFn>;
 
 export function renameType(mOptions: MigrationOptions): RenameType {
-  const _rename: RenameType = (typeName, newTypeName) => {
-    const typeNameStr = mOptions.literal(typeName);
-    const newTypeNameStr = mOptions.literal(newTypeName);
+  const rename = (source: Name, newName: Name, reverse = false): string => {
+    const schema = isSchemaNameObject(source) ? source.schema : undefined;
+    if (isSchemaNameObject(newName) && newName.schema !== schema) {
+      throw new Error('renameType cannot change the schema of a type');
+    }
 
-    return `ALTER TYPE ${typeNameStr} RENAME TO ${newTypeNameStr};`;
+    const oldName = isNameObject(source) ? source.name : source;
+    const destination = isNameObject(newName) ? newName.name : newName;
+    const newNameStr = mOptions.literal(destination);
+    const sourceStr = reverse
+      ? (schema ? `${mOptions.literal(schema)}.` : '') + newNameStr
+      : mOptions.literal(source);
+    const destinationStr = reverse ? mOptions.literal(oldName) : newNameStr;
+
+    return `ALTER TYPE ${sourceStr} RENAME TO ${destinationStr};`;
   };
 
-  _rename.reverse = (typeName, newTypeName) => _rename(newTypeName, typeName);
+  const _rename: RenameType = (source, newName) => rename(source, newName);
+  _rename.reverse = (source, newName) => rename(source, newName, true);
 
   return _rename;
 }

--- a/src/operations/views/renameView.ts
+++ b/src/operations/views/renameView.ts
@@ -1,19 +1,31 @@
 import type { MigrationOptions } from '../../migrationOptions';
 import type { Name, Reversible } from '../generalTypes';
+import { isNameObject, isSchemaNameObject } from '../generalTypes';
 
 export type RenameViewFn = (viewName: Name, newViewName: Name) => string;
 
 export type RenameView = Reversible<RenameViewFn>;
 
 export function renameView(mOptions: MigrationOptions): RenameView {
-  const _rename: RenameView = (viewName, newViewName) => {
-    const viewNameStr = mOptions.literal(viewName);
-    const newViewNameStr = mOptions.literal(newViewName);
+  const rename = (source: Name, newName: Name, reverse = false): string => {
+    const schema = isSchemaNameObject(source) ? source.schema : undefined;
+    if (isSchemaNameObject(newName) && newName.schema !== schema) {
+      throw new Error('renameView cannot change the schema of a view');
+    }
 
-    return `ALTER VIEW ${viewNameStr} RENAME TO ${newViewNameStr};`;
+    const oldName = isNameObject(source) ? source.name : source;
+    const destination = isNameObject(newName) ? newName.name : newName;
+    const newNameStr = mOptions.literal(destination);
+    const sourceStr = reverse
+      ? (schema ? `${mOptions.literal(schema)}.` : '') + newNameStr
+      : mOptions.literal(source);
+    const destinationStr = reverse ? mOptions.literal(oldName) : newNameStr;
+
+    return `ALTER VIEW ${sourceStr} RENAME TO ${destinationStr};`;
   };
 
-  _rename.reverse = (viewName, newViewName) => _rename(newViewName, viewName);
+  const _rename: RenameView = (source, newName) => rename(source, newName);
+  _rename.reverse = (source, newName) => rename(source, newName, true);
 
   return _rename;
 }

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-14.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-14.stdout.log
@@ -1,4 +1,5 @@
 > Migrating files:
+> - 099_schema_qualified_renames
 > - 098_rename_index
 > - 097_drop_constraint_if_table_exists
 > - 096_expression_index
@@ -97,6 +98,30 @@
 > - 003_promise
 > - 002_callback
 > - 001_noop
+### MIGRATION 099_schema_qualified_renames (DOWN) ###
+ALTER INDEX "object_rename_schema"."new_index" RENAME TO "middle_index";
+ALTER INDEX "object_rename_schema"."middle_index" RENAME TO "old_index";
+DROP INDEX "object_rename_schema"."old_index";
+DROP TABLE "object_rename_schema"."indexed_table";
+ALTER SEQUENCE "object_rename_schema"."new_sequence" RENAME TO "middle_sequence";
+ALTER SEQUENCE "object_rename_schema"."middle_sequence" RENAME TO "old_sequence";
+DROP SEQUENCE "object_rename_schema"."old_sequence";
+ALTER MATERIALIZED VIEW "object_rename_schema"."new_materialized_view" RENAME TO "middle_materialized_view";
+ALTER MATERIALIZED VIEW "object_rename_schema"."middle_materialized_view" RENAME TO "old_materialized_view";
+DROP MATERIALIZED VIEW "object_rename_schema"."old_materialized_view";
+ALTER VIEW "object_rename_schema"."new_view" RENAME TO "middle_view";
+ALTER VIEW "object_rename_schema"."middle_view" RENAME TO "old_view";
+DROP VIEW "object_rename_schema"."old_view";
+ALTER DOMAIN "object_rename_schema"."new_domain" RENAME TO "middle_domain";
+ALTER DOMAIN "object_rename_schema"."middle_domain" RENAME TO "old_domain";
+DROP DOMAIN "object_rename_schema"."old_domain";
+ALTER TYPE "object_rename_schema"."new_type" RENAME TO "middle_type";
+ALTER TYPE "object_rename_schema"."middle_type" RENAME TO "old_type";
+DROP TYPE "object_rename_schema"."old_type";
+DROP SCHEMA "object_rename_schema";
+DELETE FROM "public"."pgmigrations" WHERE name='099_schema_qualified_renames';
+
+
 ### MIGRATION 098_rename_index (DOWN) ###
 ALTER INDEX "quxfoo" RENAME TO "idxfoo";
 DROP INDEX "idxfoo";

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-15.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-15.stdout.log
@@ -1,4 +1,5 @@
 > Migrating files:
+> - 099_schema_qualified_renames
 > - 098_rename_index
 > - 097_drop_constraint_if_table_exists
 > - 096_expression_index
@@ -97,6 +98,30 @@
 > - 003_promise
 > - 002_callback
 > - 001_noop
+### MIGRATION 099_schema_qualified_renames (DOWN) ###
+ALTER INDEX "object_rename_schema"."new_index" RENAME TO "middle_index";
+ALTER INDEX "object_rename_schema"."middle_index" RENAME TO "old_index";
+DROP INDEX "object_rename_schema"."old_index";
+DROP TABLE "object_rename_schema"."indexed_table";
+ALTER SEQUENCE "object_rename_schema"."new_sequence" RENAME TO "middle_sequence";
+ALTER SEQUENCE "object_rename_schema"."middle_sequence" RENAME TO "old_sequence";
+DROP SEQUENCE "object_rename_schema"."old_sequence";
+ALTER MATERIALIZED VIEW "object_rename_schema"."new_materialized_view" RENAME TO "middle_materialized_view";
+ALTER MATERIALIZED VIEW "object_rename_schema"."middle_materialized_view" RENAME TO "old_materialized_view";
+DROP MATERIALIZED VIEW "object_rename_schema"."old_materialized_view";
+ALTER VIEW "object_rename_schema"."new_view" RENAME TO "middle_view";
+ALTER VIEW "object_rename_schema"."middle_view" RENAME TO "old_view";
+DROP VIEW "object_rename_schema"."old_view";
+ALTER DOMAIN "object_rename_schema"."new_domain" RENAME TO "middle_domain";
+ALTER DOMAIN "object_rename_schema"."middle_domain" RENAME TO "old_domain";
+DROP DOMAIN "object_rename_schema"."old_domain";
+ALTER TYPE "object_rename_schema"."new_type" RENAME TO "middle_type";
+ALTER TYPE "object_rename_schema"."middle_type" RENAME TO "old_type";
+DROP TYPE "object_rename_schema"."old_type";
+DROP SCHEMA "object_rename_schema";
+DELETE FROM "public"."pgmigrations" WHERE name='099_schema_qualified_renames';
+
+
 ### MIGRATION 098_rename_index (DOWN) ###
 ALTER INDEX "quxfoo" RENAME TO "idxfoo";
 DROP INDEX "idxfoo";

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-16.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-16.stdout.log
@@ -1,4 +1,5 @@
 > Migrating files:
+> - 099_schema_qualified_renames
 > - 098_rename_index
 > - 097_drop_constraint_if_table_exists
 > - 096_expression_index
@@ -97,6 +98,30 @@
 > - 003_promise
 > - 002_callback
 > - 001_noop
+### MIGRATION 099_schema_qualified_renames (DOWN) ###
+ALTER INDEX "object_rename_schema"."new_index" RENAME TO "middle_index";
+ALTER INDEX "object_rename_schema"."middle_index" RENAME TO "old_index";
+DROP INDEX "object_rename_schema"."old_index";
+DROP TABLE "object_rename_schema"."indexed_table";
+ALTER SEQUENCE "object_rename_schema"."new_sequence" RENAME TO "middle_sequence";
+ALTER SEQUENCE "object_rename_schema"."middle_sequence" RENAME TO "old_sequence";
+DROP SEQUENCE "object_rename_schema"."old_sequence";
+ALTER MATERIALIZED VIEW "object_rename_schema"."new_materialized_view" RENAME TO "middle_materialized_view";
+ALTER MATERIALIZED VIEW "object_rename_schema"."middle_materialized_view" RENAME TO "old_materialized_view";
+DROP MATERIALIZED VIEW "object_rename_schema"."old_materialized_view";
+ALTER VIEW "object_rename_schema"."new_view" RENAME TO "middle_view";
+ALTER VIEW "object_rename_schema"."middle_view" RENAME TO "old_view";
+DROP VIEW "object_rename_schema"."old_view";
+ALTER DOMAIN "object_rename_schema"."new_domain" RENAME TO "middle_domain";
+ALTER DOMAIN "object_rename_schema"."middle_domain" RENAME TO "old_domain";
+DROP DOMAIN "object_rename_schema"."old_domain";
+ALTER TYPE "object_rename_schema"."new_type" RENAME TO "middle_type";
+ALTER TYPE "object_rename_schema"."middle_type" RENAME TO "old_type";
+DROP TYPE "object_rename_schema"."old_type";
+DROP SCHEMA "object_rename_schema";
+DELETE FROM "public"."pgmigrations" WHERE name='099_schema_qualified_renames';
+
+
 ### MIGRATION 098_rename_index (DOWN) ###
 ALTER INDEX "quxfoo" RENAME TO "idxfoo";
 DROP INDEX "idxfoo";

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-17.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-17.stdout.log
@@ -1,4 +1,5 @@
 > Migrating files:
+> - 099_schema_qualified_renames
 > - 098_rename_index
 > - 097_drop_constraint_if_table_exists
 > - 096_expression_index
@@ -97,6 +98,30 @@
 > - 003_promise
 > - 002_callback
 > - 001_noop
+### MIGRATION 099_schema_qualified_renames (DOWN) ###
+ALTER INDEX "object_rename_schema"."new_index" RENAME TO "middle_index";
+ALTER INDEX "object_rename_schema"."middle_index" RENAME TO "old_index";
+DROP INDEX "object_rename_schema"."old_index";
+DROP TABLE "object_rename_schema"."indexed_table";
+ALTER SEQUENCE "object_rename_schema"."new_sequence" RENAME TO "middle_sequence";
+ALTER SEQUENCE "object_rename_schema"."middle_sequence" RENAME TO "old_sequence";
+DROP SEQUENCE "object_rename_schema"."old_sequence";
+ALTER MATERIALIZED VIEW "object_rename_schema"."new_materialized_view" RENAME TO "middle_materialized_view";
+ALTER MATERIALIZED VIEW "object_rename_schema"."middle_materialized_view" RENAME TO "old_materialized_view";
+DROP MATERIALIZED VIEW "object_rename_schema"."old_materialized_view";
+ALTER VIEW "object_rename_schema"."new_view" RENAME TO "middle_view";
+ALTER VIEW "object_rename_schema"."middle_view" RENAME TO "old_view";
+DROP VIEW "object_rename_schema"."old_view";
+ALTER DOMAIN "object_rename_schema"."new_domain" RENAME TO "middle_domain";
+ALTER DOMAIN "object_rename_schema"."middle_domain" RENAME TO "old_domain";
+DROP DOMAIN "object_rename_schema"."old_domain";
+ALTER TYPE "object_rename_schema"."new_type" RENAME TO "middle_type";
+ALTER TYPE "object_rename_schema"."middle_type" RENAME TO "old_type";
+DROP TYPE "object_rename_schema"."old_type";
+DROP SCHEMA "object_rename_schema";
+DELETE FROM "public"."pgmigrations" WHERE name='099_schema_qualified_renames';
+
+
 ### MIGRATION 098_rename_index (DOWN) ###
 ALTER INDEX "quxfoo" RENAME TO "idxfoo";
 DROP INDEX "idxfoo";

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-18.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-down.pg-18.stdout.log
@@ -1,4 +1,5 @@
 > Migrating files:
+> - 099_schema_qualified_renames
 > - 098_rename_index
 > - 097_drop_constraint_if_table_exists
 > - 096_expression_index
@@ -97,6 +98,30 @@
 > - 003_promise
 > - 002_callback
 > - 001_noop
+### MIGRATION 099_schema_qualified_renames (DOWN) ###
+ALTER INDEX "object_rename_schema"."new_index" RENAME TO "middle_index";
+ALTER INDEX "object_rename_schema"."middle_index" RENAME TO "old_index";
+DROP INDEX "object_rename_schema"."old_index";
+DROP TABLE "object_rename_schema"."indexed_table";
+ALTER SEQUENCE "object_rename_schema"."new_sequence" RENAME TO "middle_sequence";
+ALTER SEQUENCE "object_rename_schema"."middle_sequence" RENAME TO "old_sequence";
+DROP SEQUENCE "object_rename_schema"."old_sequence";
+ALTER MATERIALIZED VIEW "object_rename_schema"."new_materialized_view" RENAME TO "middle_materialized_view";
+ALTER MATERIALIZED VIEW "object_rename_schema"."middle_materialized_view" RENAME TO "old_materialized_view";
+DROP MATERIALIZED VIEW "object_rename_schema"."old_materialized_view";
+ALTER VIEW "object_rename_schema"."new_view" RENAME TO "middle_view";
+ALTER VIEW "object_rename_schema"."middle_view" RENAME TO "old_view";
+DROP VIEW "object_rename_schema"."old_view";
+ALTER DOMAIN "object_rename_schema"."new_domain" RENAME TO "middle_domain";
+ALTER DOMAIN "object_rename_schema"."middle_domain" RENAME TO "old_domain";
+DROP DOMAIN "object_rename_schema"."old_domain";
+ALTER TYPE "object_rename_schema"."new_type" RENAME TO "middle_type";
+ALTER TYPE "object_rename_schema"."middle_type" RENAME TO "old_type";
+DROP TYPE "object_rename_schema"."old_type";
+DROP SCHEMA "object_rename_schema";
+DELETE FROM "public"."pgmigrations" WHERE name='099_schema_qualified_renames';
+
+
 ### MIGRATION 098_rename_index (DOWN) ###
 ALTER INDEX "quxfoo" RENAME TO "idxfoo";
 DROP INDEX "idxfoo";

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-14.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-14.stdout.log
@@ -97,6 +97,7 @@
 > - 096_expression_index
 > - 097_drop_constraint_if_table_exists
 > - 098_rename_index
+> - 099_schema_qualified_renames
 ### MIGRATION 001_noop (UP) ###
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('001_noop', NOW());
 
@@ -727,6 +728,30 @@ INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('097_drop_constraint_
 CREATE INDEX "idxfoo" ON "t1" ("nmbr");
 ALTER INDEX "idxfoo" RENAME TO "quxfoo";
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('098_rename_index', NOW());
+
+
+### MIGRATION 099_schema_qualified_renames (UP) ###
+CREATE SCHEMA "object_rename_schema";
+CREATE TYPE "object_rename_schema"."old_type" AS ENUM ($pga$active$pga$);
+ALTER TYPE "object_rename_schema"."old_type" RENAME TO "middle_type";
+ALTER TYPE "object_rename_schema"."middle_type" RENAME TO "new_type";
+CREATE DOMAIN "object_rename_schema"."old_domain" AS integer CHECK (VALUE >= 0);
+ALTER DOMAIN "object_rename_schema"."old_domain" RENAME TO "middle_domain";
+ALTER DOMAIN "object_rename_schema"."middle_domain" RENAME TO "new_domain";
+CREATE VIEW "object_rename_schema"."old_view" AS SELECT 1 AS value;
+ALTER VIEW "object_rename_schema"."old_view" RENAME TO "middle_view";
+ALTER VIEW "object_rename_schema"."middle_view" RENAME TO "new_view";
+CREATE MATERIALIZED VIEW "object_rename_schema"."old_materialized_view" AS SELECT 1 AS value;
+ALTER MATERIALIZED VIEW "object_rename_schema"."old_materialized_view" RENAME TO "middle_materialized_view";
+ALTER MATERIALIZED VIEW "object_rename_schema"."middle_materialized_view" RENAME TO "new_materialized_view";
+CREATE SEQUENCE "object_rename_schema"."old_sequence" START WITH 10;
+ALTER SEQUENCE "object_rename_schema"."old_sequence" RENAME TO "middle_sequence";
+ALTER SEQUENCE "object_rename_schema"."middle_sequence" RENAME TO "new_sequence";
+CREATE TABLE "object_rename_schema"."indexed_table" ("value" integer);
+CREATE INDEX "old_index" ON "object_rename_schema"."indexed_table" ("value");
+ALTER INDEX "object_rename_schema"."old_index" RENAME TO "middle_index";
+ALTER INDEX "object_rename_schema"."middle_index" RENAME TO "new_index";
+INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('099_schema_qualified_renames', NOW());
 
 
 Migrations complete!

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-15.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-15.stdout.log
@@ -97,6 +97,7 @@
 > - 096_expression_index
 > - 097_drop_constraint_if_table_exists
 > - 098_rename_index
+> - 099_schema_qualified_renames
 ### MIGRATION 001_noop (UP) ###
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('001_noop', NOW());
 
@@ -729,6 +730,30 @@ INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('097_drop_constraint_
 CREATE INDEX "idxfoo" ON "t1" ("nmbr");
 ALTER INDEX "idxfoo" RENAME TO "quxfoo";
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('098_rename_index', NOW());
+
+
+### MIGRATION 099_schema_qualified_renames (UP) ###
+CREATE SCHEMA "object_rename_schema";
+CREATE TYPE "object_rename_schema"."old_type" AS ENUM ($pga$active$pga$);
+ALTER TYPE "object_rename_schema"."old_type" RENAME TO "middle_type";
+ALTER TYPE "object_rename_schema"."middle_type" RENAME TO "new_type";
+CREATE DOMAIN "object_rename_schema"."old_domain" AS integer CHECK (VALUE >= 0);
+ALTER DOMAIN "object_rename_schema"."old_domain" RENAME TO "middle_domain";
+ALTER DOMAIN "object_rename_schema"."middle_domain" RENAME TO "new_domain";
+CREATE VIEW "object_rename_schema"."old_view" AS SELECT 1 AS value;
+ALTER VIEW "object_rename_schema"."old_view" RENAME TO "middle_view";
+ALTER VIEW "object_rename_schema"."middle_view" RENAME TO "new_view";
+CREATE MATERIALIZED VIEW "object_rename_schema"."old_materialized_view" AS SELECT 1 AS value;
+ALTER MATERIALIZED VIEW "object_rename_schema"."old_materialized_view" RENAME TO "middle_materialized_view";
+ALTER MATERIALIZED VIEW "object_rename_schema"."middle_materialized_view" RENAME TO "new_materialized_view";
+CREATE SEQUENCE "object_rename_schema"."old_sequence" START WITH 10;
+ALTER SEQUENCE "object_rename_schema"."old_sequence" RENAME TO "middle_sequence";
+ALTER SEQUENCE "object_rename_schema"."middle_sequence" RENAME TO "new_sequence";
+CREATE TABLE "object_rename_schema"."indexed_table" ("value" integer);
+CREATE INDEX "old_index" ON "object_rename_schema"."indexed_table" ("value");
+ALTER INDEX "object_rename_schema"."old_index" RENAME TO "middle_index";
+ALTER INDEX "object_rename_schema"."middle_index" RENAME TO "new_index";
+INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('099_schema_qualified_renames', NOW());
 
 
 Migrations complete!

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-16.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-16.stdout.log
@@ -97,6 +97,7 @@
 > - 096_expression_index
 > - 097_drop_constraint_if_table_exists
 > - 098_rename_index
+> - 099_schema_qualified_renames
 ### MIGRATION 001_noop (UP) ###
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('001_noop', NOW());
 
@@ -729,6 +730,30 @@ INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('097_drop_constraint_
 CREATE INDEX "idxfoo" ON "t1" ("nmbr");
 ALTER INDEX "idxfoo" RENAME TO "quxfoo";
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('098_rename_index', NOW());
+
+
+### MIGRATION 099_schema_qualified_renames (UP) ###
+CREATE SCHEMA "object_rename_schema";
+CREATE TYPE "object_rename_schema"."old_type" AS ENUM ($pga$active$pga$);
+ALTER TYPE "object_rename_schema"."old_type" RENAME TO "middle_type";
+ALTER TYPE "object_rename_schema"."middle_type" RENAME TO "new_type";
+CREATE DOMAIN "object_rename_schema"."old_domain" AS integer CHECK (VALUE >= 0);
+ALTER DOMAIN "object_rename_schema"."old_domain" RENAME TO "middle_domain";
+ALTER DOMAIN "object_rename_schema"."middle_domain" RENAME TO "new_domain";
+CREATE VIEW "object_rename_schema"."old_view" AS SELECT 1 AS value;
+ALTER VIEW "object_rename_schema"."old_view" RENAME TO "middle_view";
+ALTER VIEW "object_rename_schema"."middle_view" RENAME TO "new_view";
+CREATE MATERIALIZED VIEW "object_rename_schema"."old_materialized_view" AS SELECT 1 AS value;
+ALTER MATERIALIZED VIEW "object_rename_schema"."old_materialized_view" RENAME TO "middle_materialized_view";
+ALTER MATERIALIZED VIEW "object_rename_schema"."middle_materialized_view" RENAME TO "new_materialized_view";
+CREATE SEQUENCE "object_rename_schema"."old_sequence" START WITH 10;
+ALTER SEQUENCE "object_rename_schema"."old_sequence" RENAME TO "middle_sequence";
+ALTER SEQUENCE "object_rename_schema"."middle_sequence" RENAME TO "new_sequence";
+CREATE TABLE "object_rename_schema"."indexed_table" ("value" integer);
+CREATE INDEX "old_index" ON "object_rename_schema"."indexed_table" ("value");
+ALTER INDEX "object_rename_schema"."old_index" RENAME TO "middle_index";
+ALTER INDEX "object_rename_schema"."middle_index" RENAME TO "new_index";
+INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('099_schema_qualified_renames', NOW());
 
 
 Migrations complete!

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-17.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-17.stdout.log
@@ -97,6 +97,7 @@
 > - 096_expression_index
 > - 097_drop_constraint_if_table_exists
 > - 098_rename_index
+> - 099_schema_qualified_renames
 ### MIGRATION 001_noop (UP) ###
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('001_noop', NOW());
 
@@ -732,6 +733,30 @@ INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('097_drop_constraint_
 CREATE INDEX "idxfoo" ON "t1" ("nmbr");
 ALTER INDEX "idxfoo" RENAME TO "quxfoo";
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('098_rename_index', NOW());
+
+
+### MIGRATION 099_schema_qualified_renames (UP) ###
+CREATE SCHEMA "object_rename_schema";
+CREATE TYPE "object_rename_schema"."old_type" AS ENUM ($pga$active$pga$);
+ALTER TYPE "object_rename_schema"."old_type" RENAME TO "middle_type";
+ALTER TYPE "object_rename_schema"."middle_type" RENAME TO "new_type";
+CREATE DOMAIN "object_rename_schema"."old_domain" AS integer CHECK (VALUE >= 0);
+ALTER DOMAIN "object_rename_schema"."old_domain" RENAME TO "middle_domain";
+ALTER DOMAIN "object_rename_schema"."middle_domain" RENAME TO "new_domain";
+CREATE VIEW "object_rename_schema"."old_view" AS SELECT 1 AS value;
+ALTER VIEW "object_rename_schema"."old_view" RENAME TO "middle_view";
+ALTER VIEW "object_rename_schema"."middle_view" RENAME TO "new_view";
+CREATE MATERIALIZED VIEW "object_rename_schema"."old_materialized_view" AS SELECT 1 AS value;
+ALTER MATERIALIZED VIEW "object_rename_schema"."old_materialized_view" RENAME TO "middle_materialized_view";
+ALTER MATERIALIZED VIEW "object_rename_schema"."middle_materialized_view" RENAME TO "new_materialized_view";
+CREATE SEQUENCE "object_rename_schema"."old_sequence" START WITH 10;
+ALTER SEQUENCE "object_rename_schema"."old_sequence" RENAME TO "middle_sequence";
+ALTER SEQUENCE "object_rename_schema"."middle_sequence" RENAME TO "new_sequence";
+CREATE TABLE "object_rename_schema"."indexed_table" ("value" integer);
+CREATE INDEX "old_index" ON "object_rename_schema"."indexed_table" ("value");
+ALTER INDEX "object_rename_schema"."old_index" RENAME TO "middle_index";
+ALTER INDEX "object_rename_schema"."middle_index" RENAME TO "new_index";
+INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('099_schema_qualified_renames', NOW());
 
 
 Migrations complete!

--- a/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-18.stdout.log
+++ b/test/integration/__snapshots__/db-config-it.spec.ts.snap.d/migrations-up.pg-18.stdout.log
@@ -97,6 +97,7 @@
 > - 096_expression_index
 > - 097_drop_constraint_if_table_exists
 > - 098_rename_index
+> - 099_schema_qualified_renames
 ### MIGRATION 001_noop (UP) ###
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('001_noop', NOW());
 
@@ -732,6 +733,30 @@ INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('097_drop_constraint_
 CREATE INDEX "idxfoo" ON "t1" ("nmbr");
 ALTER INDEX "idxfoo" RENAME TO "quxfoo";
 INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('098_rename_index', NOW());
+
+
+### MIGRATION 099_schema_qualified_renames (UP) ###
+CREATE SCHEMA "object_rename_schema";
+CREATE TYPE "object_rename_schema"."old_type" AS ENUM ($pga$active$pga$);
+ALTER TYPE "object_rename_schema"."old_type" RENAME TO "middle_type";
+ALTER TYPE "object_rename_schema"."middle_type" RENAME TO "new_type";
+CREATE DOMAIN "object_rename_schema"."old_domain" AS integer CHECK (VALUE >= 0);
+ALTER DOMAIN "object_rename_schema"."old_domain" RENAME TO "middle_domain";
+ALTER DOMAIN "object_rename_schema"."middle_domain" RENAME TO "new_domain";
+CREATE VIEW "object_rename_schema"."old_view" AS SELECT 1 AS value;
+ALTER VIEW "object_rename_schema"."old_view" RENAME TO "middle_view";
+ALTER VIEW "object_rename_schema"."middle_view" RENAME TO "new_view";
+CREATE MATERIALIZED VIEW "object_rename_schema"."old_materialized_view" AS SELECT 1 AS value;
+ALTER MATERIALIZED VIEW "object_rename_schema"."old_materialized_view" RENAME TO "middle_materialized_view";
+ALTER MATERIALIZED VIEW "object_rename_schema"."middle_materialized_view" RENAME TO "new_materialized_view";
+CREATE SEQUENCE "object_rename_schema"."old_sequence" START WITH 10;
+ALTER SEQUENCE "object_rename_schema"."old_sequence" RENAME TO "middle_sequence";
+ALTER SEQUENCE "object_rename_schema"."middle_sequence" RENAME TO "new_sequence";
+CREATE TABLE "object_rename_schema"."indexed_table" ("value" integer);
+CREATE INDEX "old_index" ON "object_rename_schema"."indexed_table" ("value");
+ALTER INDEX "object_rename_schema"."old_index" RENAME TO "middle_index";
+ALTER INDEX "object_rename_schema"."middle_index" RENAME TO "new_index";
+INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('099_schema_qualified_renames', NOW());
 
 
 Migrations complete!

--- a/test/migration.spec.ts
+++ b/test/migration.spec.ts
@@ -46,7 +46,7 @@ describe('migration', () => {
       const filePaths = await getMigrationFilePaths(dir, { logger });
 
       expect(Array.isArray(filePaths)).toBeTruthy();
-      expect(filePaths.length).toMatchInlineSnapshot(`98`);
+      expect(filePaths.length).toMatchInlineSnapshot(`99`);
       expect(filePaths).not.toContainEqual(expect.stringContaining('nested'));
 
       for (const filePath of filePaths) {
@@ -67,7 +67,7 @@ describe('migration', () => {
       });
 
       expect(Array.isArray(filePaths)).toBeTruthy();
-      expect(filePaths.length).toMatchInlineSnapshot(`73`);
+      expect(filePaths.length).toMatchInlineSnapshot(`74`);
 
       for (const filePath of filePaths) {
         expect(isAbsolute(filePath)).toBeTruthy();
@@ -83,7 +83,7 @@ describe('migration', () => {
       });
 
       expect(Array.isArray(filePaths)).toBeTruthy();
-      expect(filePaths.length).toMatchInlineSnapshot(`111`);
+      expect(filePaths.length).toMatchInlineSnapshot(`112`);
       expect(filePaths).toContainEqual(expect.stringContaining('nested'));
 
       for (const filePath of filePaths) {
@@ -103,7 +103,7 @@ describe('migration', () => {
       });
 
       expect(Array.isArray(filePaths)).toBeTruthy();
-      expect(filePaths.length).toMatchInlineSnapshot(`110`);
+      expect(filePaths.length).toMatchInlineSnapshot(`111`);
       expect(filePaths).toContainEqual(expect.stringContaining('nested'));
 
       for (const filePath of filePaths) {
@@ -133,7 +133,7 @@ describe('migration', () => {
         ignorePattern
       );
 
-      expect(nextPrefix).toMatchInlineSnapshot(`"099"`);
+      expect(nextPrefix).toMatchInlineSnapshot(`"100"`);
     });
 
     it('should fail to get the next index with invalid filenames', async () => {

--- a/test/migrationBuilder.spec.ts
+++ b/test/migrationBuilder.spec.ts
@@ -2,44 +2,6 @@ import { describe, expect, it, vi } from 'vitest';
 import { MigrationBuilder } from '../src';
 
 describe('migrationBuilder', () => {
-  it.each([
-    ['renameType', 'TYPE'],
-    ['renameDomain', 'DOMAIN'],
-    ['renameView', 'VIEW'],
-    ['renameMaterializedView', 'MATERIALIZED VIEW'],
-    ['renameSequence', 'SEQUENCE'],
-    ['renameIndex', 'INDEX'],
-  ] as const)(
-    'should reverse a qualified %s chain in reverse order',
-    (operation, keyword) => {
-      const db = { query: vi.fn(), select: vi.fn() };
-      for (const reverse of [false, true]) {
-        const pgm = new MigrationBuilder(db, undefined, false, console);
-        if (reverse) {
-          pgm.enableReverseMode();
-        }
-        pgm[operation]({ schema: 'app', name: 'old' }, 'middle');
-        pgm[operation](
-          { schema: 'app', name: 'middle' },
-          { schema: 'app', name: 'new' }
-        );
-        expect(pgm.getSqlSteps()).toEqual(
-          reverse
-            ? [
-                `ALTER ${keyword} "app"."new" RENAME TO "middle";`,
-                `ALTER ${keyword} "app"."middle" RENAME TO "old";`,
-              ]
-            : [
-                `ALTER ${keyword} "app"."old" RENAME TO "middle";`,
-                `ALTER ${keyword} "app"."middle" RENAME TO "new";`,
-              ]
-        );
-      }
-      expect(db.query).not.toHaveBeenCalled();
-      expect(db.select).not.toHaveBeenCalled();
-    }
-  );
-
   it('should expose MigrationBuilder to allow using as sql builder', () => {
     const pgm = new MigrationBuilder(
       {

--- a/test/migrationBuilder.spec.ts
+++ b/test/migrationBuilder.spec.ts
@@ -2,6 +2,44 @@ import { describe, expect, it, vi } from 'vitest';
 import { MigrationBuilder } from '../src';
 
 describe('migrationBuilder', () => {
+  it.each([
+    ['renameType', 'TYPE'],
+    ['renameDomain', 'DOMAIN'],
+    ['renameView', 'VIEW'],
+    ['renameMaterializedView', 'MATERIALIZED VIEW'],
+    ['renameSequence', 'SEQUENCE'],
+    ['renameIndex', 'INDEX'],
+  ] as const)(
+    'should reverse a qualified %s chain in reverse order',
+    (operation, keyword) => {
+      const db = { query: vi.fn(), select: vi.fn() };
+      for (const reverse of [false, true]) {
+        const pgm = new MigrationBuilder(db, undefined, false, console);
+        if (reverse) {
+          pgm.enableReverseMode();
+        }
+        pgm[operation]({ schema: 'app', name: 'old' }, 'middle');
+        pgm[operation](
+          { schema: 'app', name: 'middle' },
+          { schema: 'app', name: 'new' }
+        );
+        expect(pgm.getSqlSteps()).toEqual(
+          reverse
+            ? [
+                `ALTER ${keyword} "app"."new" RENAME TO "middle";`,
+                `ALTER ${keyword} "app"."middle" RENAME TO "old";`,
+              ]
+            : [
+                `ALTER ${keyword} "app"."old" RENAME TO "middle";`,
+                `ALTER ${keyword} "app"."middle" RENAME TO "new";`,
+              ]
+        );
+      }
+      expect(db.query).not.toHaveBeenCalled();
+      expect(db.select).not.toHaveBeenCalled();
+    }
+  );
+
   it('should expose MigrationBuilder to allow using as sql builder', () => {
     const pgm = new MigrationBuilder(
       {

--- a/test/migrations/099_schema_qualified_renames.js
+++ b/test/migrations/099_schema_qualified_renames.js
@@ -1,0 +1,40 @@
+export const up = (pgm) => {
+  const schema = 'object_rename_schema';
+  const name = (name) => ({ schema, name });
+  pgm.createSchema(schema);
+
+  pgm.createType(name('old_type'), ['active']);
+  pgm.renameType(name('old_type'), 'middle_type');
+  pgm.renameType(name('middle_type'), name('new_type'));
+
+  pgm.createDomain(name('old_domain'), 'integer', { check: 'VALUE >= 0' });
+  pgm.renameDomain(name('old_domain'), 'middle_domain');
+  pgm.renameDomain(name('middle_domain'), name('new_domain'));
+
+  pgm.createView(name('old_view'), {}, 'SELECT 1 AS value');
+  pgm.renameView(name('old_view'), 'middle_view');
+  pgm.renameView(name('middle_view'), name('new_view'));
+
+  pgm.createMaterializedView(
+    name('old_materialized_view'),
+    {},
+    'SELECT 1 AS value'
+  );
+  pgm.renameMaterializedView(
+    name('old_materialized_view'),
+    'middle_materialized_view'
+  );
+  pgm.renameMaterializedView(
+    name('middle_materialized_view'),
+    name('new_materialized_view')
+  );
+
+  pgm.createSequence(name('old_sequence'), { start: 10 });
+  pgm.renameSequence(name('old_sequence'), 'middle_sequence');
+  pgm.renameSequence(name('middle_sequence'), name('new_sequence'));
+
+  pgm.createTable(name('indexed_table'), { value: 'integer' });
+  pgm.createIndex(name('indexed_table'), 'value', { name: 'old_index' });
+  pgm.renameIndex(name('old_index'), 'middle_index');
+  pgm.renameIndex(name('middle_index'), name('new_index'));
+};

--- a/test/operations/domains/renameDomain.spec.ts
+++ b/test/operations/domains/renameDomain.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { renameDomain } from '../../../src/operations/domains';
-import { options1 } from '../../presetMigrationOptions';
+import { options1, options2 } from '../../presetMigrationOptions';
 
 describe('operations', () => {
   describe('domains', () => {
@@ -16,6 +16,87 @@ describe('operations', () => {
 
         expect(statement).toBeTypeOf('string');
         expect(statement).toBe('ALTER DOMAIN "zipcode" RENAME TO "zip_code";');
+      });
+
+      it.each([
+        ['new'],
+        [{ name: 'new' }],
+        [{ schema: 'app', name: 'new' }],
+        [{ schema: undefined, name: 'new' }],
+      ])('should preserve the source schema with %j', (destination) => {
+        const source = { schema: 'app', name: 'old' };
+        expect(renameDomainFn(source, destination)).toBe(
+          'ALTER DOMAIN "app"."old" RENAME TO "new";'
+        );
+        expect(renameDomainFn.reverse(source, destination)).toBe(
+          'ALTER DOMAIN "app"."new" RENAME TO "old";'
+        );
+      });
+
+      it.each([undefined, ''])(
+        'should keep matching %j schemas unqualified',
+        (schema) => {
+          const source = { schema, name: 'old' };
+          const destination = { schema, name: 'new' };
+          expect(renameDomainFn(source, destination)).toBe(
+            'ALTER DOMAIN "old" RENAME TO "new";'
+          );
+          expect(renameDomainFn.reverse(source, destination)).toBe(
+            'ALTER DOMAIN "new" RENAME TO "old";'
+          );
+        }
+      );
+
+      it.each([
+        [
+          { schema: 'app', name: 'old' },
+          { schema: 'other', name: 'new' },
+        ],
+        ['old', { schema: 'app', name: 'new' }],
+        [
+          { schema: 'app', name: 'old' },
+          { schema: '', name: 'new' },
+        ],
+        ['old', { schema: '', name: 'new' }],
+      ])(
+        'should reject incompatible explicit schemas: %j -> %j',
+        (source, destination) => {
+          const error = new Error(
+            'renameDomain cannot change the schema of a domain'
+          );
+          expect(() => renameDomainFn(source, destination)).toThrow(error);
+          expect(() => renameDomainFn.reverse(source, destination)).toThrow(
+            error
+          );
+        }
+      );
+
+      it('should escape schema and object identifiers in both directions', () => {
+        const source = { schema: 'my"schema', name: 'old"name' };
+        expect(renameDomainFn(source, 'new"name')).toBe(
+          'ALTER DOMAIN "my""schema"."old""name" RENAME TO "new""name";'
+        );
+        expect(renameDomainFn.reverse(source, 'new"name')).toBe(
+          'ALTER DOMAIN "my""schema"."new""name" RENAME TO "old""name";'
+        );
+      });
+
+      it('should decamelize both directions and compare schemas before transformation', () => {
+        const rename = renameDomain(options2);
+        const source = { schema: 'appSchema', name: 'oldName' };
+        const destination = { schema: 'appSchema', name: 'newName' };
+        expect(rename(source, destination)).toBe(
+          'ALTER DOMAIN "app_schema"."old_name" RENAME TO "new_name";'
+        );
+        expect(rename.reverse(source, destination)).toBe(
+          'ALTER DOMAIN "app_schema"."new_name" RENAME TO "old_name";'
+        );
+        const mismatched = { schema: 'app_schema', name: 'newName' };
+        const error = new Error(
+          'renameDomain cannot change the schema of a domain'
+        );
+        expect(() => rename(source, mismatched)).toThrow(error);
+        expect(() => rename.reverse(source, mismatched)).toThrow(error);
       });
 
       describe('reverse', () => {

--- a/test/operations/indexes/renameIndex.spec.ts
+++ b/test/operations/indexes/renameIndex.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { renameIndex } from '../../../src/operations/indexes';
-import { options1 } from '../../presetMigrationOptions';
+import { options1, options2 } from '../../presetMigrationOptions';
 
 describe('operations', () => {
   describe('indexes', () => {
@@ -14,6 +14,87 @@ describe('operations', () => {
       it('should generate correct SQL for renaming an index', () => {
         const statement = renameIndexFn('my_index', 'new_index');
         expect(statement).toBe('ALTER INDEX "my_index" RENAME TO "new_index";');
+      });
+
+      it.each([
+        ['new'],
+        [{ name: 'new' }],
+        [{ schema: 'app', name: 'new' }],
+        [{ schema: undefined, name: 'new' }],
+      ])('should preserve the source schema with %j', (destination) => {
+        const source = { schema: 'app', name: 'old' };
+        expect(renameIndexFn(source, destination)).toBe(
+          'ALTER INDEX "app"."old" RENAME TO "new";'
+        );
+        expect(renameIndexFn.reverse(source, destination)).toBe(
+          'ALTER INDEX "app"."new" RENAME TO "old";'
+        );
+      });
+
+      it.each([undefined, ''])(
+        'should keep matching %j schemas unqualified',
+        (schema) => {
+          const source = { schema, name: 'old' };
+          const destination = { schema, name: 'new' };
+          expect(renameIndexFn(source, destination)).toBe(
+            'ALTER INDEX "old" RENAME TO "new";'
+          );
+          expect(renameIndexFn.reverse(source, destination)).toBe(
+            'ALTER INDEX "new" RENAME TO "old";'
+          );
+        }
+      );
+
+      it.each([
+        [
+          { schema: 'app', name: 'old' },
+          { schema: 'other', name: 'new' },
+        ],
+        ['old', { schema: 'app', name: 'new' }],
+        [
+          { schema: 'app', name: 'old' },
+          { schema: '', name: 'new' },
+        ],
+        ['old', { schema: '', name: 'new' }],
+      ])(
+        'should reject incompatible explicit schemas: %j -> %j',
+        (source, destination) => {
+          const error = new Error(
+            'renameIndex cannot change the schema of an index'
+          );
+          expect(() => renameIndexFn(source, destination)).toThrow(error);
+          expect(() => renameIndexFn.reverse(source, destination)).toThrow(
+            error
+          );
+        }
+      );
+
+      it('should escape schema and object identifiers in both directions', () => {
+        const source = { schema: 'my"schema', name: 'old"name' };
+        expect(renameIndexFn(source, 'new"name')).toBe(
+          'ALTER INDEX "my""schema"."old""name" RENAME TO "new""name";'
+        );
+        expect(renameIndexFn.reverse(source, 'new"name')).toBe(
+          'ALTER INDEX "my""schema"."new""name" RENAME TO "old""name";'
+        );
+      });
+
+      it('should decamelize both directions and compare schemas before transformation', () => {
+        const rename = renameIndex(options2);
+        const source = { schema: 'appSchema', name: 'oldName' };
+        const destination = { schema: 'appSchema', name: 'newName' };
+        expect(rename(source, destination)).toBe(
+          'ALTER INDEX "app_schema"."old_name" RENAME TO "new_name";'
+        );
+        expect(rename.reverse(source, destination)).toBe(
+          'ALTER INDEX "app_schema"."new_name" RENAME TO "old_name";'
+        );
+        const mismatched = { schema: 'app_schema', name: 'newName' };
+        const error = new Error(
+          'renameIndex cannot change the schema of an index'
+        );
+        expect(() => rename(source, mismatched)).toThrow(error);
+        expect(() => rename.reverse(source, mismatched)).toThrow(error);
       });
 
       describe('reverse', () => {

--- a/test/operations/materializedViews/renameMaterializedView.spec.ts
+++ b/test/operations/materializedViews/renameMaterializedView.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { renameMaterializedView } from '../../../src/operations/materializedViews';
-import { options1 } from '../../presetMigrationOptions';
+import { options1, options2 } from '../../presetMigrationOptions';
 
 describe('operations', () => {
   describe('materializedViews', () => {
@@ -28,8 +28,91 @@ describe('operations', () => {
 
         expect(statement).toBeTypeOf('string');
         expect(statement).toBe(
-          'ALTER MATERIALIZED VIEW "myschema"."foo" RENAME TO "myschema"."bar";'
+          'ALTER MATERIALIZED VIEW "myschema"."foo" RENAME TO "bar";'
         );
+      });
+
+      it.each([
+        ['new'],
+        [{ name: 'new' }],
+        [{ schema: 'app', name: 'new' }],
+        [{ schema: undefined, name: 'new' }],
+      ])('should preserve the source schema with %j', (destination) => {
+        const source = { schema: 'app', name: 'old' };
+        expect(renameMaterializedViewFn(source, destination)).toBe(
+          'ALTER MATERIALIZED VIEW "app"."old" RENAME TO "new";'
+        );
+        expect(renameMaterializedViewFn.reverse(source, destination)).toBe(
+          'ALTER MATERIALIZED VIEW "app"."new" RENAME TO "old";'
+        );
+      });
+
+      it.each([undefined, ''])(
+        'should keep matching %j schemas unqualified',
+        (schema) => {
+          const source = { schema, name: 'old' };
+          const destination = { schema, name: 'new' };
+          expect(renameMaterializedViewFn(source, destination)).toBe(
+            'ALTER MATERIALIZED VIEW "old" RENAME TO "new";'
+          );
+          expect(renameMaterializedViewFn.reverse(source, destination)).toBe(
+            'ALTER MATERIALIZED VIEW "new" RENAME TO "old";'
+          );
+        }
+      );
+
+      it.each([
+        [
+          { schema: 'app', name: 'old' },
+          { schema: 'other', name: 'new' },
+        ],
+        ['old', { schema: 'app', name: 'new' }],
+        [
+          { schema: 'app', name: 'old' },
+          { schema: '', name: 'new' },
+        ],
+        ['old', { schema: '', name: 'new' }],
+      ])(
+        'should reject incompatible explicit schemas: %j -> %j',
+        (source, destination) => {
+          const error = new Error(
+            'renameMaterializedView cannot change the schema of a materialized view'
+          );
+          expect(() => renameMaterializedViewFn(source, destination)).toThrow(
+            error
+          );
+          expect(() =>
+            renameMaterializedViewFn.reverse(source, destination)
+          ).toThrow(error);
+        }
+      );
+
+      it('should escape schema and object identifiers in both directions', () => {
+        const source = { schema: 'my"schema', name: 'old"name' };
+        expect(renameMaterializedViewFn(source, 'new"name')).toBe(
+          'ALTER MATERIALIZED VIEW "my""schema"."old""name" RENAME TO "new""name";'
+        );
+        expect(renameMaterializedViewFn.reverse(source, 'new"name')).toBe(
+          'ALTER MATERIALIZED VIEW "my""schema"."new""name" RENAME TO "old""name";'
+        );
+      });
+
+      it('should decamelize both directions and compare schemas before transformation', () => {
+        const rename = renameMaterializedView(options2);
+        const source = { schema: 'appSchema', name: 'oldName' };
+        const destination = { schema: 'appSchema', name: 'newName' };
+        expect(rename(source, destination)).toBe(
+          'ALTER MATERIALIZED VIEW "app_schema"."old_name" RENAME TO "new_name";'
+        );
+        expect(rename.reverse(source, destination)).toBe(
+          'ALTER MATERIALIZED VIEW "app_schema"."new_name" RENAME TO "old_name";'
+        );
+        const mismatched = { schema: 'app_schema', name: 'newName' };
+        const error = new Error(
+          'renameMaterializedView cannot change the schema of a materialized view'
+        );
+        expect(() => rename(source, mismatched)).toThrow(error);
+        expect(() => rename.reverse(source, mismatched)).toThrow(error);
       });
 
       describe('reverse', () => {

--- a/test/operations/renameChains.spec.ts
+++ b/test/operations/renameChains.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+import { MigrationBuilder } from '../../src';
+
+describe('schema-qualified rename chains', () => {
+  const operations = [
+    ['renameType', 'TYPE'],
+    ['renameDomain', 'DOMAIN'],
+    ['renameView', 'VIEW'],
+    ['renameMaterializedView', 'MATERIALIZED VIEW'],
+    ['renameSequence', 'SEQUENCE'],
+    ['renameIndex', 'INDEX'],
+  ] as const;
+  const cases = operations.flatMap(([operation, keyword]) =>
+    (['up', 'down'] as const).map((direction) => ({
+      operation,
+      keyword,
+      direction,
+    }))
+  );
+
+  it.each(cases)(
+    'should preserve schema and rename order for $operation ($direction)',
+    ({ operation, keyword, direction }) => {
+      const db = { query: vi.fn(), select: vi.fn() };
+      const pgm = new MigrationBuilder(db, undefined, false, console);
+      if (direction === 'down') {
+        pgm.enableReverseMode();
+      }
+      pgm[operation]({ schema: 'app', name: 'old' }, 'middle');
+      pgm[operation](
+        { schema: 'app', name: 'middle' },
+        { schema: 'app', name: 'new' }
+      );
+
+      expect(pgm.getSqlSteps()).toEqual(
+        direction === 'down'
+          ? [
+              `ALTER ${keyword} "app"."new" RENAME TO "middle";`,
+              `ALTER ${keyword} "app"."middle" RENAME TO "old";`,
+            ]
+          : [
+              `ALTER ${keyword} "app"."old" RENAME TO "middle";`,
+              `ALTER ${keyword} "app"."middle" RENAME TO "new";`,
+            ]
+      );
+    }
+  );
+});

--- a/test/operations/sequences/renameSequence.spec.ts
+++ b/test/operations/sequences/renameSequence.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { renameSequence } from '../../../src/operations/sequences';
-import { options1 } from '../../presetMigrationOptions';
+import { options1, options2 } from '../../presetMigrationOptions';
 
 describe('operations', () => {
   describe('sequences', () => {
@@ -26,8 +26,89 @@ describe('operations', () => {
 
         expect(statement).toBeTypeOf('string');
         expect(statement).toBe(
-          'ALTER SEQUENCE "myschema"."serial" RENAME TO "myschema"."serial2";'
+          'ALTER SEQUENCE "myschema"."serial" RENAME TO "serial2";'
         );
+      });
+
+      it.each([
+        ['new'],
+        [{ name: 'new' }],
+        [{ schema: 'app', name: 'new' }],
+        [{ schema: undefined, name: 'new' }],
+      ])('should preserve the source schema with %j', (destination) => {
+        const source = { schema: 'app', name: 'old' };
+        expect(renameSequenceFn(source, destination)).toBe(
+          'ALTER SEQUENCE "app"."old" RENAME TO "new";'
+        );
+        expect(renameSequenceFn.reverse(source, destination)).toBe(
+          'ALTER SEQUENCE "app"."new" RENAME TO "old";'
+        );
+      });
+
+      it.each([undefined, ''])(
+        'should keep matching %j schemas unqualified',
+        (schema) => {
+          const source = { schema, name: 'old' };
+          const destination = { schema, name: 'new' };
+          expect(renameSequenceFn(source, destination)).toBe(
+            'ALTER SEQUENCE "old" RENAME TO "new";'
+          );
+          expect(renameSequenceFn.reverse(source, destination)).toBe(
+            'ALTER SEQUENCE "new" RENAME TO "old";'
+          );
+        }
+      );
+
+      it.each([
+        [
+          { schema: 'app', name: 'old' },
+          { schema: 'other', name: 'new' },
+        ],
+        ['old', { schema: 'app', name: 'new' }],
+        [
+          { schema: 'app', name: 'old' },
+          { schema: '', name: 'new' },
+        ],
+        ['old', { schema: '', name: 'new' }],
+      ])(
+        'should reject incompatible explicit schemas: %j -> %j',
+        (source, destination) => {
+          const error = new Error(
+            'renameSequence cannot change the schema of a sequence'
+          );
+          expect(() => renameSequenceFn(source, destination)).toThrow(error);
+          expect(() => renameSequenceFn.reverse(source, destination)).toThrow(
+            error
+          );
+        }
+      );
+
+      it('should escape schema and object identifiers in both directions', () => {
+        const source = { schema: 'my"schema', name: 'old"name' };
+        expect(renameSequenceFn(source, 'new"name')).toBe(
+          'ALTER SEQUENCE "my""schema"."old""name" RENAME TO "new""name";'
+        );
+        expect(renameSequenceFn.reverse(source, 'new"name')).toBe(
+          'ALTER SEQUENCE "my""schema"."new""name" RENAME TO "old""name";'
+        );
+      });
+
+      it('should decamelize both directions and compare schemas before transformation', () => {
+        const rename = renameSequence(options2);
+        const source = { schema: 'appSchema', name: 'oldName' };
+        const destination = { schema: 'appSchema', name: 'newName' };
+        expect(rename(source, destination)).toBe(
+          'ALTER SEQUENCE "app_schema"."old_name" RENAME TO "new_name";'
+        );
+        expect(rename.reverse(source, destination)).toBe(
+          'ALTER SEQUENCE "app_schema"."new_name" RENAME TO "old_name";'
+        );
+        const mismatched = { schema: 'app_schema', name: 'newName' };
+        const error = new Error(
+          'renameSequence cannot change the schema of a sequence'
+        );
+        expect(() => rename(source, mismatched)).toThrow(error);
+        expect(() => rename.reverse(source, mismatched)).toThrow(error);
       });
 
       describe('reverse', () => {

--- a/test/operations/types/renameType.spec.ts
+++ b/test/operations/types/renameType.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { renameType } from '../../../src/operations/types';
-import { options1 } from '../../presetMigrationOptions';
+import { options1, options2 } from '../../presetMigrationOptions';
 
 describe('operations', () => {
   describe('types', () => {
@@ -28,8 +28,89 @@ describe('operations', () => {
 
         expect(statement).toBeTypeOf('string');
         expect(statement).toBe(
-          'ALTER TYPE "myschema"."electronic_mail" RENAME TO "myschema"."email";'
+          'ALTER TYPE "myschema"."electronic_mail" RENAME TO "email";'
         );
+      });
+
+      it.each([
+        ['new'],
+        [{ name: 'new' }],
+        [{ schema: 'app', name: 'new' }],
+        [{ schema: undefined, name: 'new' }],
+      ])('should preserve the source schema with %j', (destination) => {
+        const source = { schema: 'app', name: 'old' };
+        expect(renameTypeFn(source, destination)).toBe(
+          'ALTER TYPE "app"."old" RENAME TO "new";'
+        );
+        expect(renameTypeFn.reverse(source, destination)).toBe(
+          'ALTER TYPE "app"."new" RENAME TO "old";'
+        );
+      });
+
+      it.each([undefined, ''])(
+        'should keep matching %j schemas unqualified',
+        (schema) => {
+          const source = { schema, name: 'old' };
+          const destination = { schema, name: 'new' };
+          expect(renameTypeFn(source, destination)).toBe(
+            'ALTER TYPE "old" RENAME TO "new";'
+          );
+          expect(renameTypeFn.reverse(source, destination)).toBe(
+            'ALTER TYPE "new" RENAME TO "old";'
+          );
+        }
+      );
+
+      it.each([
+        [
+          { schema: 'app', name: 'old' },
+          { schema: 'other', name: 'new' },
+        ],
+        ['old', { schema: 'app', name: 'new' }],
+        [
+          { schema: 'app', name: 'old' },
+          { schema: '', name: 'new' },
+        ],
+        ['old', { schema: '', name: 'new' }],
+      ])(
+        'should reject incompatible explicit schemas: %j -> %j',
+        (source, destination) => {
+          const error = new Error(
+            'renameType cannot change the schema of a type'
+          );
+          expect(() => renameTypeFn(source, destination)).toThrow(error);
+          expect(() => renameTypeFn.reverse(source, destination)).toThrow(
+            error
+          );
+        }
+      );
+
+      it('should escape schema and object identifiers in both directions', () => {
+        const source = { schema: 'my"schema', name: 'old"name' };
+        expect(renameTypeFn(source, 'new"name')).toBe(
+          'ALTER TYPE "my""schema"."old""name" RENAME TO "new""name";'
+        );
+        expect(renameTypeFn.reverse(source, 'new"name')).toBe(
+          'ALTER TYPE "my""schema"."new""name" RENAME TO "old""name";'
+        );
+      });
+
+      it('should decamelize both directions and compare schemas before transformation', () => {
+        const rename = renameType(options2);
+        const source = { schema: 'appSchema', name: 'oldName' };
+        const destination = { schema: 'appSchema', name: 'newName' };
+        expect(rename(source, destination)).toBe(
+          'ALTER TYPE "app_schema"."old_name" RENAME TO "new_name";'
+        );
+        expect(rename.reverse(source, destination)).toBe(
+          'ALTER TYPE "app_schema"."new_name" RENAME TO "old_name";'
+        );
+        const mismatched = { schema: 'app_schema', name: 'newName' };
+        const error = new Error(
+          'renameType cannot change the schema of a type'
+        );
+        expect(() => rename(source, mismatched)).toThrow(error);
+        expect(() => rename.reverse(source, mismatched)).toThrow(error);
       });
 
       describe('reverse', () => {

--- a/test/operations/views/renameView.spec.ts
+++ b/test/operations/views/renameView.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { renameView } from '../../../src/operations/views';
-import { options1 } from '../../presetMigrationOptions';
+import { options1, options2 } from '../../presetMigrationOptions';
 
 describe('operations', () => {
   describe('views', () => {
@@ -25,9 +25,88 @@ describe('operations', () => {
         );
 
         expect(statement).toBeTypeOf('string');
-        expect(statement).toBe(
-          'ALTER VIEW "myschema"."foo" RENAME TO "myschema"."bar";'
+        expect(statement).toBe('ALTER VIEW "myschema"."foo" RENAME TO "bar";');
+      });
+
+      it.each([
+        ['new'],
+        [{ name: 'new' }],
+        [{ schema: 'app', name: 'new' }],
+        [{ schema: undefined, name: 'new' }],
+      ])('should preserve the source schema with %j', (destination) => {
+        const source = { schema: 'app', name: 'old' };
+        expect(renameViewFn(source, destination)).toBe(
+          'ALTER VIEW "app"."old" RENAME TO "new";'
         );
+        expect(renameViewFn.reverse(source, destination)).toBe(
+          'ALTER VIEW "app"."new" RENAME TO "old";'
+        );
+      });
+
+      it.each([undefined, ''])(
+        'should keep matching %j schemas unqualified',
+        (schema) => {
+          const source = { schema, name: 'old' };
+          const destination = { schema, name: 'new' };
+          expect(renameViewFn(source, destination)).toBe(
+            'ALTER VIEW "old" RENAME TO "new";'
+          );
+          expect(renameViewFn.reverse(source, destination)).toBe(
+            'ALTER VIEW "new" RENAME TO "old";'
+          );
+        }
+      );
+
+      it.each([
+        [
+          { schema: 'app', name: 'old' },
+          { schema: 'other', name: 'new' },
+        ],
+        ['old', { schema: 'app', name: 'new' }],
+        [
+          { schema: 'app', name: 'old' },
+          { schema: '', name: 'new' },
+        ],
+        ['old', { schema: '', name: 'new' }],
+      ])(
+        'should reject incompatible explicit schemas: %j -> %j',
+        (source, destination) => {
+          const error = new Error(
+            'renameView cannot change the schema of a view'
+          );
+          expect(() => renameViewFn(source, destination)).toThrow(error);
+          expect(() => renameViewFn.reverse(source, destination)).toThrow(
+            error
+          );
+        }
+      );
+
+      it('should escape schema and object identifiers in both directions', () => {
+        const source = { schema: 'my"schema', name: 'old"name' };
+        expect(renameViewFn(source, 'new"name')).toBe(
+          'ALTER VIEW "my""schema"."old""name" RENAME TO "new""name";'
+        );
+        expect(renameViewFn.reverse(source, 'new"name')).toBe(
+          'ALTER VIEW "my""schema"."new""name" RENAME TO "old""name";'
+        );
+      });
+
+      it('should decamelize both directions and compare schemas before transformation', () => {
+        const rename = renameView(options2);
+        const source = { schema: 'appSchema', name: 'oldName' };
+        const destination = { schema: 'appSchema', name: 'newName' };
+        expect(rename(source, destination)).toBe(
+          'ALTER VIEW "app_schema"."old_name" RENAME TO "new_name";'
+        );
+        expect(rename.reverse(source, destination)).toBe(
+          'ALTER VIEW "app_schema"."new_name" RENAME TO "old_name";'
+        );
+        const mismatched = { schema: 'app_schema', name: 'newName' };
+        const error = new Error(
+          'renameView cannot change the schema of a view'
+        );
+        expect(() => rename(source, mismatched)).toThrow(error);
+        expect(() => rename.reverse(source, mismatched)).toThrow(error);
       });
 
       describe('reverse', () => {


### PR DESCRIPTION
Fixes #1726.

Preserve the source schema when automatically reversing `renameType`, `renameDomain`, `renameView`, `renameMaterializedView`, `renameSequence`, and `renameIndex`. These operations previously qualified `RENAME TO` destinations and reversed by swapping names, producing invalid PostgreSQL SQL. For example, reversing `renameType({ schema: 'app', name: 'old' }, 'new')` now generates `ALTER TYPE "app"."new" RENAME TO "old";` instead of `ALTER TYPE "new" RENAME TO "app"."old";`.

Apply the accepted `renameTable` pattern locally to all six operations, retaining the public `Name` signatures. Same-schema destination objects are supported; explicitly incompatible destination schemas are rejected in either direction. This includes empty-schema validation consistent with `renameTable`: an explicitly empty destination schema is rejected when the source schema is omitted or nonempty, while matching empty schemas remain unqualified. Undefined schemas remain omitted, and explicit schema equality is checked before decamelization.

Add regression coverage for both directions, name objects, schema mismatch handling, quoting, and decamelization; correct four existing expectations that asserted invalid SQL. Add a `MigrationBuilder` rename-chain test and an up-only PostgreSQL fixture that creates and renames each object twice, exercising automatic down generation. Update the six documentation sections and the fixture-count snapshots.

No shared helper, changes to `renameTable`, broader `PgLiteral` handling, or #1727 operations are included.

### Validation

- Before the implementation: **70 failures and 38 passes** in the focused tests. Afterward: **108 passed**.
- Full unit suite: **823 passed across 105 files**.
- Build, type checking, lint, formatting, and diff checks passed.
- Complete migration sequence passed up and down on a fresh native **PostgreSQL 16.15**, with **Node 24.18.0**. The six renamed objects were queried/inspected after up, and removal of the fixture schema was verified after down.
- The complete PostgreSQL 16 stdout matched the updated up/down snapshots. Each of the ten PostgreSQL 14–18 snapshots adds only the new fixture SQL and its file-list entry (25 lines). The other versions received the same new SQL section executed on PostgreSQL 16; **PostgreSQL 14, 15, 17, and 18 were not run locally**.
- Docker/Testcontainers integration and CockroachDB were not run locally; those checks remain for CI.

Commands executed (with the local Node runtime on PATH and `DATABASE_URL` pointing to the disposable PostgreSQL cluster):

```sh
pnpm exec vitest run --project unit \
  test/operations/types/renameType.spec.ts \
  test/operations/domains/renameDomain.spec.ts \
  test/operations/views/renameView.spec.ts \
  test/operations/materializedViews/renameMaterializedView.spec.ts \
  test/operations/sequences/renameSequence.spec.ts \
  test/operations/indexes/renameIndex.spec.ts \
  test/migrationBuilder.spec.ts
pnpm run test:unit --run
pnpm run build
pnpm run ts-check
pnpm run lint
pnpm run format:check
git diff --check
node bin/node-pg-migrate.js up -m test/migrations
node bin/node-pg-migrate.js down 0 -m test/migrations
```

Reviewed with the help of AI.
