### PR TITLE
fix!: normalize schema handling across rename operations

### DIFF
--- a/docs/src/migrations/domains.md
+++ b/docs/src/migrations/domains.md
@@ -85,14 +85,9 @@
 | `old_domain_name` | [Name](/migrations/#type) | Old name of the domain |
 | `new_domain_name` | [Name](/migrations/#type) | New name of the domain |
 
-The destination name is unqualified in the generated SQL. If a destination object
-specifies a schema, it must match the source schema. Use `{ schema, name }` for
-schema-qualified names so automatic reversal preserves the source schema;
-the schema cannot be inferred from a string name or the database search path.
-
-Qualified `PgLiteral` names can produce invalid SQL, including during automatic
-reversal. Use structured name objects instead, or use `pgm.sql` with explicit SQL
-in both your up and down migrations.
+Renaming preserves the source schema, including during automatic reversal. See
+[Renaming and schemas](/migrations/#renaming-and-schemas) for destination-schema
+validation and supported `PgLiteral` identifiers.
 
 To move a domain between schemas, use SQL explicitly, for example
 `pgm.sql('ALTER DOMAIN "old_schema"."my_domain" SET SCHEMA "new_schema"')`.

--- a/docs/src/migrations/index.md
+++ b/docs/src/migrations/index.md
@@ -120,6 +120,45 @@ CREATE TABLE "my_schema"."my_table_name" ("id" serial);
 type Name = string | { schema: string; name: string };
 ```
 
+## Renaming and schemas
+
+`renameTable`, `renameType`, `renameDomain`, `renameView`,
+`renameMaterializedView`, `renameSequence`, and `renameIndex` preserve the
+source object's schema, including during automatic reversal:
+
+```javascript
+pgm.renameView({ schema: 'app', name: 'old_view' }, 'new_view');
+// up:   ALTER VIEW "app"."old_view" RENAME TO "new_view";
+// down: ALTER VIEW "app"."new_view" RENAME TO "old_view";
+```
+
+An omitted, `undefined`, or empty (`''`) destination schema inherits the source
+schema. An empty source schema is equivalent to omitting it. A nonempty
+destination schema must match the source schema after identifier rendering:
+with `decamelize: true`, for example, `appSchema` and `app_schema` match.
+Use `{ schema, name }` for the source when specifying a destination schema;
+these operations cannot infer a schema from a string name or `search_path`.
+A different schema raises an error. Moving an object between schemas requires
+explicit SQL and a corresponding down migration; see the individual operations
+for examples and restrictions.
+
+`PgLiteral` inputs must contain a single unqualified identifier, either an
+ordinary unquoted identifier or a nonempty double-quoted identifier. Surrounding
+SQL whitespace is allowed. Raw identifiers are neither quoted nor decamelized:
+PostgreSQL folds unquoted names to lower case, while quoted names preserve case.
+Use double quotes for reserved words. Dots and escaped double quotes inside a
+quoted identifier are supported: `pgm.func('"new.name"')` is one name, whereas
+`pgm.func('app.new_name')` is qualified and rejected.
+
+> [!WARNING]
+> Qualified `PgLiteral` sources and destinations now raise an error during SQL
+> generation in both directions. Previously, a qualified source could work going
+> up with a manually written down migration. Replace it with `{ schema, name }`,
+> which uses normal identifier quoting and decamelization, or use `pgm.sql` with
+> explicit SQL in both directions. Other raw forms, including expressions,
+> comments, multiple tokens, and `U&` Unicode escape syntax, are also rejected by
+> these seven rename operations. Other uses of `PgLiteral` are unchanged.
+
 ## Locking
 
 `node-pg-migrate` automatically checks if no other migration is running. To do so, it uses an

--- a/docs/src/migrations/index.md
+++ b/docs/src/migrations/index.md
@@ -117,7 +117,7 @@ CREATE TABLE "my_schema"."my_table_name" ("id" serial);
 ### Type
 
 ```ts
-type Name = string | { schema: string; name: string };
+type Name = string | { schema?: string; name: string } | PgLiteralValue;
 ```
 
 ## Renaming and schemas

--- a/docs/src/migrations/indexes.md
+++ b/docs/src/migrations/indexes.md
@@ -111,14 +111,9 @@ pgm.renameIndex('index_name', 'new_index_name');
 
 :::
 
-The destination name is unqualified in the generated SQL. If a destination object
-specifies a schema, it must match the source schema. Use `{ schema, name }` for
-schema-qualified names so automatic reversal preserves the source schema;
-the schema cannot be inferred from a string name or the database search path.
-
-Qualified `PgLiteral` names can produce invalid SQL, including during automatic
-reversal. Use structured name objects instead, or use `pgm.sql` with explicit SQL
-in both your up and down migrations.
+Renaming preserves the source schema, including during automatic reversal. See
+[Renaming and schemas](/migrations/#renaming-and-schemas) for destination-schema
+validation and supported `PgLiteral` identifiers.
 
 Renaming an index does not move it to another schema. PostgreSQL does not provide
 `ALTER INDEX ... SET SCHEMA`; indexes follow their table when it changes schema.

--- a/docs/src/migrations/mViews.md
+++ b/docs/src/migrations/mViews.md
@@ -86,14 +86,9 @@
 | `viewName`    | [Name](/migrations/#type) | old name of the view |
 | `newViewName` | [Name](/migrations/#type) | new name of the view |
 
-The destination name is unqualified in the generated SQL. If a destination object
-specifies a schema, it must match the source schema. Use `{ schema, name }` for
-schema-qualified names so automatic reversal preserves the source schema;
-the schema cannot be inferred from a string name or the database search path.
-
-Qualified `PgLiteral` names can produce invalid SQL, including during automatic
-reversal. Use structured name objects instead, or use `pgm.sql` with explicit SQL
-in both your up and down migrations.
+Renaming preserves the source schema, including during automatic reversal. See
+[Renaming and schemas](/migrations/#renaming-and-schemas) for destination-schema
+validation and supported `PgLiteral` identifiers.
 
 To move a materialized view between schemas, use SQL explicitly, for example
 `pgm.sql('ALTER MATERIALIZED VIEW "old_schema"."my_view" SET SCHEMA "new_schema"')`.

--- a/docs/src/migrations/sequences.md
+++ b/docs/src/migrations/sequences.md
@@ -94,14 +94,9 @@ sequence.
 | `old_sequence_name` | [Name](/migrations/#type) | Old name of the sequence |
 | `new_sequence_name` | [Name](/migrations/#type) | New name of the sequence |
 
-The destination name is unqualified in the generated SQL. If a destination object
-specifies a schema, it must match the source schema. Use `{ schema, name }` for
-schema-qualified names so automatic reversal preserves the source schema;
-the schema cannot be inferred from a string name or the database search path.
-
-Qualified `PgLiteral` names can produce invalid SQL, including during automatic
-reversal. Use structured name objects instead, or use `pgm.sql` with explicit SQL
-in both your up and down migrations.
+Renaming preserves the source schema, including during automatic reversal. See
+[Renaming and schemas](/migrations/#renaming-and-schemas) for destination-schema
+validation and supported `PgLiteral` identifiers.
 
 To move a sequence between schemas, use SQL explicitly, for example
 `pgm.sql('ALTER SEQUENCE "old_schema"."my_sequence" SET SCHEMA "new_schema"')`.

--- a/docs/src/migrations/tables.md
+++ b/docs/src/migrations/tables.md
@@ -71,10 +71,9 @@
 | `tablename`     | [Name](/migrations/#type) | name of the table to rename |
 | `new_tablename` | [Name](/migrations/#type) | new name of the table       |
 
-Renaming preserves the table’s schema, including during automatic reversal. If
-`new_tablename` specifies a schema, it must match the schema in `tablename`.
-When specifying a destination schema, use the object form for `tablename` too;
-the schema cannot be inferred from a string table name or the database search path.
+Renaming preserves the source schema, including during automatic reversal. See
+[Renaming and schemas](/migrations/#renaming-and-schemas) for destination-schema
+validation and supported `PgLiteral` identifiers.
 
 To move a table between schemas, use SQL explicitly, for example
 `pgm.sql('ALTER TABLE "old_schema"."my_table" SET SCHEMA "new_schema"')`.

--- a/docs/src/migrations/types.md
+++ b/docs/src/migrations/types.md
@@ -61,14 +61,9 @@ operation (`dropType`) when the migration is rolled back.
 | `type_name`     | [Name](/migrations/#type) | name of the type to rename |
 | `new_type_name` | [Name](/migrations/#type) | name of the new type       |
 
-The destination name is unqualified in the generated SQL. If a destination object
-specifies a schema, it must match the source schema. Use `{ schema, name }` for
-schema-qualified names so automatic reversal preserves the source schema;
-the schema cannot be inferred from a string name or the database search path.
-
-Qualified `PgLiteral` names can produce invalid SQL, including during automatic
-reversal. Use structured name objects instead, or use `pgm.sql` with explicit SQL
-in both your up and down migrations.
+Renaming preserves the source schema, including during automatic reversal. See
+[Renaming and schemas](/migrations/#renaming-and-schemas) for destination-schema
+validation and supported `PgLiteral` identifiers.
 
 To move a type between schemas, use SQL explicitly, for example
 `pgm.sql('ALTER TYPE "old_schema"."my_type" SET SCHEMA "new_schema"')`.

--- a/docs/src/migrations/views.md
+++ b/docs/src/migrations/views.md
@@ -103,14 +103,9 @@
 | `viewName`    | [Name](/migrations/#type) | old name of the view |
 | `newViewName` | [Name](/migrations/#type) | new name of the view |
 
-The destination name is unqualified in the generated SQL. If a destination object
-specifies a schema, it must match the source schema. Use `{ schema, name }` for
-schema-qualified names so automatic reversal preserves the source schema;
-the schema cannot be inferred from a string name or the database search path.
-
-Qualified `PgLiteral` names can produce invalid SQL, including during automatic
-reversal. Use structured name objects instead, or use `pgm.sql` with explicit SQL
-in both your up and down migrations.
+Renaming preserves the source schema, including during automatic reversal. See
+[Renaming and schemas](/migrations/#renaming-and-schemas) for destination-schema
+validation and supported `PgLiteral` identifiers.
 
 To move a view between schemas, use SQL explicitly, for example
 `pgm.sql('ALTER VIEW "old_schema"."my_view" SET SCHEMA "new_schema"')`.

--- a/src/operations/createRenameOperation.ts
+++ b/src/operations/createRenameOperation.ts
@@ -1,0 +1,46 @@
+import type { MigrationOptions } from '../migrationOptions';
+import type { Name, Reversible } from './generalTypes';
+import { isNameObject, isSchemaNameObject } from './generalTypes';
+
+type RenameFn = (source: Name, destination: Name) => string;
+
+interface RenameOptions {
+  operation: string;
+  keyword: string;
+  label: string;
+}
+
+/** Creates the reversible pair for an object renamed within its schema. */
+export function createRenameOperation(
+  mOptions: MigrationOptions,
+  { operation, keyword, label }: RenameOptions
+): Reversible<RenameFn> {
+  const validateSchema = (source: Name, destination: Name) => {
+    const schema = isSchemaNameObject(source) ? source.schema : undefined;
+    if (isSchemaNameObject(destination) && destination.schema !== schema) {
+      throw new Error(`${operation} cannot change the schema of ${label}`);
+    }
+    return schema;
+  };
+
+  const rename: RenameFn = (source, destination) => {
+    validateSchema(source, destination);
+    const newName = isNameObject(destination) ? destination.name : destination;
+    const destinationSql = mOptions.literal(newName);
+    const sourceSql = mOptions.literal(source);
+    return `ALTER ${keyword} ${sourceSql} RENAME TO ${destinationSql};`;
+  };
+
+  const reverse: RenameFn = (source, destination) => {
+    const schema = validateSchema(source, destination);
+    const oldName = isNameObject(source) ? source.name : source;
+    const newName = isNameObject(destination) ? destination.name : destination;
+    const newNameSql = mOptions.literal(newName);
+    const sourceSql =
+      (schema ? `${mOptions.literal(schema)}.` : '') + newNameSql;
+    const destinationSql = mOptions.literal(oldName);
+    return `ALTER ${keyword} ${sourceSql} RENAME TO ${destinationSql};`;
+  };
+
+  return Object.assign(rename, { reverse });
+}

--- a/src/operations/createRenameOperation.ts
+++ b/src/operations/createRenameOperation.ts
@@ -49,6 +49,11 @@ export function createRenameOperation(
   const resolveNames = (source: Name, destination: Name) => {
     const oldName = nameParts(source, 'source');
     const newName = nameParts(destination, 'destination');
+    if (newName.schemaSql && !oldName.schemaSql) {
+      throw new Error(
+        `${operation} cannot infer the source schema; use { schema, name } for the source`
+      );
+    }
     if (newName.schemaSql && newName.schemaSql !== oldName.schemaSql) {
       throw new Error(`${operation} cannot change the schema of ${label}`);
     }

--- a/src/operations/createRenameOperation.ts
+++ b/src/operations/createRenameOperation.ts
@@ -1,4 +1,5 @@
 import type { MigrationOptions } from '../migrationOptions';
+import { isPgLiteral } from '../utils/PgLiteral';
 import type { Name, Reversible } from './generalTypes';
 import { isNameObject, isSchemaNameObject } from './generalTypes';
 
@@ -10,36 +11,68 @@ interface RenameOptions {
   label: string;
 }
 
+// A single ordinary or double-quoted PostgreSQL identifier, with optional SQL
+// whitespace. Dots and doubled quotes inside a quoted identifier are content.
+// Raw SQL expressions, qualifications and U& escape syntax require explicit SQL.
+const SINGLE_IDENTIFIER =
+  /^[ \t\r\n\f\v]*(?:[A-Za-z_\u0080-\u{10FFFF}][A-Za-z0-9_$\u0080-\u{10FFFF}]*|"(?:[^"]|"")+")[ \t\r\n\f\v]*$/u;
+
+function qualify(schemaSql: string | undefined, nameSql: string): string {
+  return schemaSql ? `${schemaSql}.${nameSql}` : nameSql;
+}
+
 /** Creates the reversible pair for an object renamed within its schema. */
 export function createRenameOperation(
   mOptions: MigrationOptions,
   { operation, keyword, label }: RenameOptions
 ): Reversible<RenameFn> {
-  const validateSchema = (source: Name, destination: Name) => {
-    const schema = isSchemaNameObject(source) ? source.schema : undefined;
-    if (isSchemaNameObject(destination) && destination.schema !== schema) {
+  const nameParts = (value: Name, position: 'source' | 'destination') => {
+    if (isPgLiteral(value)) {
+      const nameSql = mOptions.literal(value);
+      if (nameSql.includes('\0') || !SINGLE_IDENTIFIER.test(nameSql)) {
+        throw new Error(
+          `${operation} requires a single unqualified identifier for a PgLiteral ${position}; use { schema, name } for schema-qualified names`
+        );
+      }
+      return { schemaSql: undefined, nameSql };
+    }
+
+    const schema = isSchemaNameObject(value)
+      ? value.schema || undefined
+      : undefined;
+    return {
+      schemaSql: schema ? mOptions.literal(schema) : undefined,
+      nameSql: mOptions.literal(isNameObject(value) ? value.name : value),
+    };
+  };
+
+  const resolveNames = (source: Name, destination: Name) => {
+    const oldName = nameParts(source, 'source');
+    const newName = nameParts(destination, 'destination');
+    if (newName.schemaSql && newName.schemaSql !== oldName.schemaSql) {
       throw new Error(`${operation} cannot change the schema of ${label}`);
     }
-    return schema;
+    return {
+      schemaSql: oldName.schemaSql,
+      oldNameSql: oldName.nameSql,
+      newNameSql: newName.nameSql,
+    };
   };
 
   const rename: RenameFn = (source, destination) => {
-    validateSchema(source, destination);
-    const newName = isNameObject(destination) ? destination.name : destination;
-    const destinationSql = mOptions.literal(newName);
-    const sourceSql = mOptions.literal(source);
-    return `ALTER ${keyword} ${sourceSql} RENAME TO ${destinationSql};`;
+    const { schemaSql, oldNameSql, newNameSql } = resolveNames(
+      source,
+      destination
+    );
+    return `ALTER ${keyword} ${qualify(schemaSql, oldNameSql)} RENAME TO ${newNameSql};`;
   };
 
   const reverse: RenameFn = (source, destination) => {
-    const schema = validateSchema(source, destination);
-    const oldName = isNameObject(source) ? source.name : source;
-    const newName = isNameObject(destination) ? destination.name : destination;
-    const newNameSql = mOptions.literal(newName);
-    const sourceSql =
-      (schema ? `${mOptions.literal(schema)}.` : '') + newNameSql;
-    const destinationSql = mOptions.literal(oldName);
-    return `ALTER ${keyword} ${sourceSql} RENAME TO ${destinationSql};`;
+    const { schemaSql, oldNameSql, newNameSql } = resolveNames(
+      source,
+      destination
+    );
+    return `ALTER ${keyword} ${qualify(schemaSql, newNameSql)} RENAME TO ${oldNameSql};`;
   };
 
   return Object.assign(rename, { reverse });

--- a/src/operations/domains/renameDomain.ts
+++ b/src/operations/domains/renameDomain.ts
@@ -1,6 +1,6 @@
 import type { MigrationOptions } from '../../migrationOptions';
+import { createRenameOperation } from '../createRenameOperation';
 import type { Name, Reversible } from '../generalTypes';
-import { isNameObject, isSchemaNameObject } from '../generalTypes';
 
 export type RenameDomainFn = (
   oldDomainName: Name,
@@ -10,25 +10,9 @@ export type RenameDomainFn = (
 export type RenameDomain = Reversible<RenameDomainFn>;
 
 export function renameDomain(mOptions: MigrationOptions): RenameDomain {
-  const rename = (source: Name, newName: Name, reverse = false): string => {
-    const schema = isSchemaNameObject(source) ? source.schema : undefined;
-    if (isSchemaNameObject(newName) && newName.schema !== schema) {
-      throw new Error('renameDomain cannot change the schema of a domain');
-    }
-
-    const oldName = isNameObject(source) ? source.name : source;
-    const destination = isNameObject(newName) ? newName.name : newName;
-    const newNameStr = mOptions.literal(destination);
-    const sourceStr = reverse
-      ? (schema ? `${mOptions.literal(schema)}.` : '') + newNameStr
-      : mOptions.literal(source);
-    const destinationStr = reverse ? mOptions.literal(oldName) : newNameStr;
-
-    return `ALTER DOMAIN ${sourceStr} RENAME TO ${destinationStr};`;
-  };
-
-  const _rename: RenameDomain = (source, newName) => rename(source, newName);
-  _rename.reverse = (source, newName) => rename(source, newName, true);
-
-  return _rename;
+  return createRenameOperation(mOptions, {
+    operation: 'renameDomain',
+    keyword: 'DOMAIN',
+    label: 'a domain',
+  });
 }

--- a/src/operations/indexes/renameIndex.ts
+++ b/src/operations/indexes/renameIndex.ts
@@ -1,30 +1,14 @@
 import type { MigrationOptions } from '../../migrationOptions';
+import { createRenameOperation } from '../createRenameOperation';
 import type { Name, Reversible } from '../generalTypes';
-import { isNameObject, isSchemaNameObject } from '../generalTypes';
 
 export type RenameIndexFn = (name: Name, newName: Name) => string;
 export type RenameIndex = Reversible<RenameIndexFn>;
 
 export function renameIndex(mOptions: MigrationOptions): RenameIndex {
-  const rename = (source: Name, newName: Name, reverse = false): string => {
-    const schema = isSchemaNameObject(source) ? source.schema : undefined;
-    if (isSchemaNameObject(newName) && newName.schema !== schema) {
-      throw new Error('renameIndex cannot change the schema of an index');
-    }
-
-    const oldName = isNameObject(source) ? source.name : source;
-    const destination = isNameObject(newName) ? newName.name : newName;
-    const newNameStr = mOptions.literal(destination);
-    const sourceStr = reverse
-      ? (schema ? `${mOptions.literal(schema)}.` : '') + newNameStr
-      : mOptions.literal(source);
-    const destinationStr = reverse ? mOptions.literal(oldName) : newNameStr;
-
-    return `ALTER INDEX ${sourceStr} RENAME TO ${destinationStr};`;
-  };
-
-  const _rename: RenameIndex = (source, newName) => rename(source, newName);
-  _rename.reverse = (source, newName) => rename(source, newName, true);
-
-  return _rename;
+  return createRenameOperation(mOptions, {
+    operation: 'renameIndex',
+    keyword: 'INDEX',
+    label: 'an index',
+  });
 }

--- a/src/operations/materializedViews/renameMaterializedView.ts
+++ b/src/operations/materializedViews/renameMaterializedView.ts
@@ -1,6 +1,6 @@
 import type { MigrationOptions } from '../../migrationOptions';
+import { createRenameOperation } from '../createRenameOperation';
 import type { Name, Reversible } from '../generalTypes';
-import { isNameObject, isSchemaNameObject } from '../generalTypes';
 
 export type RenameMaterializedViewFn = (
   viewName: Name,
@@ -12,28 +12,9 @@ export type RenameMaterializedView = Reversible<RenameMaterializedViewFn>;
 export function renameMaterializedView(
   mOptions: MigrationOptions
 ): RenameMaterializedView {
-  const rename = (source: Name, newName: Name, reverse = false): string => {
-    const schema = isSchemaNameObject(source) ? source.schema : undefined;
-    if (isSchemaNameObject(newName) && newName.schema !== schema) {
-      throw new Error(
-        'renameMaterializedView cannot change the schema of a materialized view'
-      );
-    }
-
-    const oldName = isNameObject(source) ? source.name : source;
-    const destination = isNameObject(newName) ? newName.name : newName;
-    const newNameStr = mOptions.literal(destination);
-    const sourceStr = reverse
-      ? (schema ? `${mOptions.literal(schema)}.` : '') + newNameStr
-      : mOptions.literal(source);
-    const destinationStr = reverse ? mOptions.literal(oldName) : newNameStr;
-
-    return `ALTER MATERIALIZED VIEW ${sourceStr} RENAME TO ${destinationStr};`;
-  };
-
-  const _rename: RenameMaterializedView = (source, newName) =>
-    rename(source, newName);
-  _rename.reverse = (source, newName) => rename(source, newName, true);
-
-  return _rename;
+  return createRenameOperation(mOptions, {
+    operation: 'renameMaterializedView',
+    keyword: 'MATERIALIZED VIEW',
+    label: 'a materialized view',
+  });
 }

--- a/src/operations/sequences/renameSequence.ts
+++ b/src/operations/sequences/renameSequence.ts
@@ -1,6 +1,6 @@
 import type { MigrationOptions } from '../../migrationOptions';
+import { createRenameOperation } from '../createRenameOperation';
 import type { Name, Reversible } from '../generalTypes';
-import { isNameObject, isSchemaNameObject } from '../generalTypes';
 
 export type RenameSequenceFn = (
   oldSequenceName: Name,
@@ -10,25 +10,9 @@ export type RenameSequenceFn = (
 export type RenameSequence = Reversible<RenameSequenceFn>;
 
 export function renameSequence(mOptions: MigrationOptions): RenameSequence {
-  const rename = (source: Name, newName: Name, reverse = false): string => {
-    const schema = isSchemaNameObject(source) ? source.schema : undefined;
-    if (isSchemaNameObject(newName) && newName.schema !== schema) {
-      throw new Error('renameSequence cannot change the schema of a sequence');
-    }
-
-    const oldName = isNameObject(source) ? source.name : source;
-    const destination = isNameObject(newName) ? newName.name : newName;
-    const newNameStr = mOptions.literal(destination);
-    const sourceStr = reverse
-      ? (schema ? `${mOptions.literal(schema)}.` : '') + newNameStr
-      : mOptions.literal(source);
-    const destinationStr = reverse ? mOptions.literal(oldName) : newNameStr;
-
-    return `ALTER SEQUENCE ${sourceStr} RENAME TO ${destinationStr};`;
-  };
-
-  const _rename: RenameSequence = (source, newName) => rename(source, newName);
-  _rename.reverse = (source, newName) => rename(source, newName, true);
-
-  return _rename;
+  return createRenameOperation(mOptions, {
+    operation: 'renameSequence',
+    keyword: 'SEQUENCE',
+    label: 'a sequence',
+  });
 }

--- a/src/operations/tables/renameTable.ts
+++ b/src/operations/tables/renameTable.ts
@@ -1,32 +1,15 @@
 import type { MigrationOptions } from '../../migrationOptions';
+import { createRenameOperation } from '../createRenameOperation';
 import type { Name, Reversible } from '../generalTypes';
-import { isNameObject, isSchemaNameObject } from '../generalTypes';
 
 export type RenameTableFn = (tableName: Name, newtableName: Name) => string;
 
 export type RenameTable = Reversible<RenameTableFn>;
 
 export function renameTable(mOptions: MigrationOptions): RenameTable {
-  const rename = (tableName: Name, newName: Name, reverse = false): string => {
-    const schema = isSchemaNameObject(tableName) ? tableName.schema : undefined;
-    if (isSchemaNameObject(newName) && newName.schema !== schema) {
-      throw new Error('renameTable cannot change the schema of a table');
-    }
-
-    const oldName = isNameObject(tableName) ? tableName.name : tableName;
-    const destination = isNameObject(newName) ? newName.name : newName;
-    const newNameStr = mOptions.literal(destination);
-    const tableNameStr = reverse
-      ? (schema ? `${mOptions.literal(schema)}.` : '') + newNameStr
-      : mOptions.literal(tableName);
-    const destinationStr = reverse ? mOptions.literal(oldName) : newNameStr;
-
-    return `ALTER TABLE ${tableNameStr} RENAME TO ${destinationStr};`;
-  };
-
-  const _rename: RenameTable = (tableName, newName) =>
-    rename(tableName, newName);
-  _rename.reverse = (tableName, newName) => rename(tableName, newName, true);
-
-  return _rename;
+  return createRenameOperation(mOptions, {
+    operation: 'renameTable',
+    keyword: 'TABLE',
+    label: 'a table',
+  });
 }

--- a/src/operations/types/renameType.ts
+++ b/src/operations/types/renameType.ts
@@ -1,31 +1,15 @@
 import type { MigrationOptions } from '../../migrationOptions';
+import { createRenameOperation } from '../createRenameOperation';
 import type { Name, Reversible } from '../generalTypes';
-import { isNameObject, isSchemaNameObject } from '../generalTypes';
 
 export type RenameTypeFn = (typeName: Name, newTypeName: Name) => string;
 
 export type RenameType = Reversible<RenameTypeFn>;
 
 export function renameType(mOptions: MigrationOptions): RenameType {
-  const rename = (source: Name, newName: Name, reverse = false): string => {
-    const schema = isSchemaNameObject(source) ? source.schema : undefined;
-    if (isSchemaNameObject(newName) && newName.schema !== schema) {
-      throw new Error('renameType cannot change the schema of a type');
-    }
-
-    const oldName = isNameObject(source) ? source.name : source;
-    const destination = isNameObject(newName) ? newName.name : newName;
-    const newNameStr = mOptions.literal(destination);
-    const sourceStr = reverse
-      ? (schema ? `${mOptions.literal(schema)}.` : '') + newNameStr
-      : mOptions.literal(source);
-    const destinationStr = reverse ? mOptions.literal(oldName) : newNameStr;
-
-    return `ALTER TYPE ${sourceStr} RENAME TO ${destinationStr};`;
-  };
-
-  const _rename: RenameType = (source, newName) => rename(source, newName);
-  _rename.reverse = (source, newName) => rename(source, newName, true);
-
-  return _rename;
+  return createRenameOperation(mOptions, {
+    operation: 'renameType',
+    keyword: 'TYPE',
+    label: 'a type',
+  });
 }

--- a/src/operations/views/renameView.ts
+++ b/src/operations/views/renameView.ts
@@ -1,31 +1,15 @@
 import type { MigrationOptions } from '../../migrationOptions';
+import { createRenameOperation } from '../createRenameOperation';
 import type { Name, Reversible } from '../generalTypes';
-import { isNameObject, isSchemaNameObject } from '../generalTypes';
 
 export type RenameViewFn = (viewName: Name, newViewName: Name) => string;
 
 export type RenameView = Reversible<RenameViewFn>;
 
 export function renameView(mOptions: MigrationOptions): RenameView {
-  const rename = (source: Name, newName: Name, reverse = false): string => {
-    const schema = isSchemaNameObject(source) ? source.schema : undefined;
-    if (isSchemaNameObject(newName) && newName.schema !== schema) {
-      throw new Error('renameView cannot change the schema of a view');
-    }
-
-    const oldName = isNameObject(source) ? source.name : source;
-    const destination = isNameObject(newName) ? newName.name : newName;
-    const newNameStr = mOptions.literal(destination);
-    const sourceStr = reverse
-      ? (schema ? `${mOptions.literal(schema)}.` : '') + newNameStr
-      : mOptions.literal(source);
-    const destinationStr = reverse ? mOptions.literal(oldName) : newNameStr;
-
-    return `ALTER VIEW ${sourceStr} RENAME TO ${destinationStr};`;
-  };
-
-  const _rename: RenameView = (source, newName) => rename(source, newName);
-  _rename.reverse = (source, newName) => rename(source, newName, true);
-
-  return _rename;
+  return createRenameOperation(mOptions, {
+    operation: 'renameView',
+    keyword: 'VIEW',
+    label: 'a view',
+  });
 }

--- a/test/integration/rename-schema-it.spec.ts
+++ b/test/integration/rename-schema-it.spec.ts
@@ -1,0 +1,260 @@
+import type { StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import pg from 'pg';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import { MigrationBuilder, PgLiteral } from '../../src';
+import { db } from '../../src/db';
+import { quote } from '../../src/utils/quote';
+import {
+  INTEGRATION_TIMEOUT,
+  PG_VERSIONS,
+  setupPostgresDatabase,
+} from './utils';
+
+const operations = [
+  [
+    'renameTable',
+    'CREATE TABLE',
+    ' (value integer)',
+    'pg_class',
+    'relname',
+    'relnamespace',
+  ],
+  [
+    'renameType',
+    'CREATE TYPE',
+    " AS ENUM ('active')",
+    'pg_type',
+    'typname',
+    'typnamespace',
+  ],
+  [
+    'renameDomain',
+    'CREATE DOMAIN',
+    ' AS integer',
+    'pg_type',
+    'typname',
+    'typnamespace',
+  ],
+  [
+    'renameView',
+    'CREATE VIEW',
+    ' AS SELECT 1 AS value',
+    'pg_class',
+    'relname',
+    'relnamespace',
+  ],
+  [
+    'renameMaterializedView',
+    'CREATE MATERIALIZED VIEW',
+    ' AS SELECT 1 AS value',
+    'pg_class',
+    'relname',
+    'relnamespace',
+  ],
+  [
+    'renameSequence',
+    'CREATE SEQUENCE',
+    '',
+    'pg_class',
+    'relname',
+    'relnamespace',
+  ],
+  ['renameIndex', 'CREATE INDEX', '', 'pg_class', 'relname', 'relnamespace'],
+] as const;
+
+type RenameOperation = (typeof operations)[number][0];
+
+const scenarios: Array<{
+  title: string;
+  original: string;
+  final: string;
+  qualified: boolean;
+  migrate: (pgm: MigrationBuilder, operation: RenameOperation) => void;
+}> = [
+  {
+    title: 'rendered schema equality and empty destination in a rename chain',
+    original: 'old_name',
+    final: 'new_name',
+    qualified: true,
+    migrate: (pgm, operation) => {
+      pgm[operation](
+        { schema: 'appSchema', name: 'oldName' },
+        { schema: 'app_schema', name: 'middleName' }
+      );
+      pgm[operation](
+        { schema: 'app_schema', name: 'middleName' },
+        { schema: '', name: 'newName' }
+      );
+    },
+  },
+  {
+    title: 'empty and omitted schemas in both argument orders',
+    original: 'old_name',
+    final: 'new_name',
+    qualified: false,
+    migrate: (pgm, operation) => {
+      pgm[operation]({ schema: '', name: 'oldName' }, { name: 'middleName' });
+      pgm[operation]({ name: 'middleName' }, { schema: '', name: 'newName' });
+    },
+  },
+  {
+    title: 'quoted raw destination with dots, escaped quotes and whitespace',
+    original: 'old_name',
+    final: 'New.Name"Quoted',
+    qualified: true,
+    migrate: (pgm, operation) => {
+      pgm[operation](
+        { schema: 'appSchema', name: 'oldName' },
+        PgLiteral.create(' \t"New.Name""Quoted"\n')
+      );
+    },
+  },
+  {
+    title: 'unquoted raw destination preserves PostgreSQL case folding',
+    original: 'old_name',
+    final: 'newname',
+    qualified: true,
+    migrate: (pgm, operation) => {
+      pgm[operation](
+        { schema: 'appSchema', name: 'oldName' },
+        PgLiteral.create('NewName')
+      );
+    },
+  },
+  {
+    title: 'unqualified raw source during automatic reversal',
+    original: 'oldname',
+    final: 'new_name',
+    qualified: false,
+    migrate: (pgm, operation) => {
+      pgm[operation](PgLiteral.create('OldName'), 'newName');
+    },
+  },
+];
+
+describe.each(PG_VERSIONS)(
+  'schema-aware renames (PG %s)',
+  { timeout: INTEGRATION_TIMEOUT },
+  (version) => {
+    let container: StartedPostgreSqlContainer;
+    let client: pg.Client;
+
+    beforeAll(async () => {
+      container = await setupPostgresDatabase(
+        `postgres:${version}-alpine`,
+        'rename_schemas'
+      );
+      client = new pg.Client(container.getConnectionUri());
+      await client.connect();
+    }, INTEGRATION_TIMEOUT);
+
+    afterAll(async () => {
+      if (client) {
+        await client.end();
+      }
+      if (container) {
+        await container.stop();
+      }
+    });
+
+    beforeEach(async () => {
+      await client.query('BEGIN');
+      await client.query(
+        'CREATE SCHEMA app_schema; CREATE SCHEMA decoy_schema'
+      );
+    });
+
+    afterEach(async () => {
+      await client.query('ROLLBACK');
+    });
+
+    describe.each(operations)(
+      '%s',
+      (operation, create, definition, catalog, nameColumn, namespaceColumn) => {
+        it.each(scenarios)(
+          '$title',
+          async ({ original, final, qualified, migrate }) => {
+            // With a qualified source, an accidentally unqualified rollback would hit
+            // the decoy first. Unqualified inputs deliberately use the session schema.
+            await client.query(
+              qualified
+                ? 'SET LOCAL search_path TO decoy_schema, app_schema'
+                : 'SET LOCAL search_path TO app_schema, decoy_schema'
+            );
+
+            async function createObject(schema: string, name: string) {
+              if (operation === 'renameIndex') {
+                await client.query(
+                  `CREATE TABLE IF NOT EXISTS ${quote(schema)}.indexed_table (value integer)`
+                );
+                await client.query(
+                  `CREATE INDEX ${quote(name)} ON ${quote(schema)}.indexed_table (value)`
+                );
+              } else {
+                await client.query(
+                  `${create} ${quote(schema)}.${quote(name)}${definition}`
+                );
+              }
+            }
+
+            async function objects(schema: string) {
+              const result = await client.query<{ name: string; oid: string }>(
+                `SELECT o.${nameColumn} AS name, o.oid::text AS oid FROM ${catalog} o
+           JOIN pg_namespace n ON n.oid = o.${namespaceColumn}
+           WHERE n.nspname = $1 AND o.${nameColumn} = ANY($2::text[]) ORDER BY name`,
+                [schema, [original, 'middle_name', final]]
+              );
+              return result.rows;
+            }
+
+            await createObject('app_schema', original);
+            await createObject('decoy_schema', original);
+            await createObject('decoy_schema', 'middle_name');
+            await createObject('decoy_schema', final);
+            const before = await objects('app_schema');
+            const decoys = await objects('decoy_schema');
+            expect(before).toHaveLength(1);
+            expect(decoys).toHaveLength(3);
+
+            const up = new MigrationBuilder(
+              db(client),
+              undefined,
+              true,
+              console
+            );
+            migrate(up, operation);
+            for (const sql of up.getSqlSteps()) {
+              await client.query(sql);
+            }
+            expect(await objects('app_schema')).toEqual([
+              { name: final, oid: before[0].oid },
+            ]);
+            expect(await objects('decoy_schema')).toEqual(decoys);
+
+            const down = new MigrationBuilder(
+              db(client),
+              undefined,
+              true,
+              console
+            );
+            down.enableReverseMode();
+            migrate(down, operation);
+            for (const sql of down.getSqlSteps()) {
+              await client.query(sql);
+            }
+            expect(await objects('app_schema')).toEqual(before);
+            expect(await objects('decoy_schema')).toEqual(decoys);
+          }
+        );
+      }
+    );
+  }
+);

--- a/test/operations/domains/renameDomain.spec.ts
+++ b/test/operations/domains/renameDomain.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { renameDomain } from '../../../src/operations/domains';
-import { options1, options2 } from '../../presetMigrationOptions';
+import { options1 } from '../../presetMigrationOptions';
 
 describe('operations', () => {
   describe('domains', () => {
@@ -16,87 +16,6 @@ describe('operations', () => {
 
         expect(statement).toBeTypeOf('string');
         expect(statement).toBe('ALTER DOMAIN "zipcode" RENAME TO "zip_code";');
-      });
-
-      it.each([
-        ['new'],
-        [{ name: 'new' }],
-        [{ schema: 'app', name: 'new' }],
-        [{ schema: undefined, name: 'new' }],
-      ])('should preserve the source schema with %j', (destination) => {
-        const source = { schema: 'app', name: 'old' };
-        expect(renameDomainFn(source, destination)).toBe(
-          'ALTER DOMAIN "app"."old" RENAME TO "new";'
-        );
-        expect(renameDomainFn.reverse(source, destination)).toBe(
-          'ALTER DOMAIN "app"."new" RENAME TO "old";'
-        );
-      });
-
-      it.each([undefined, ''])(
-        'should keep matching %j schemas unqualified',
-        (schema) => {
-          const source = { schema, name: 'old' };
-          const destination = { schema, name: 'new' };
-          expect(renameDomainFn(source, destination)).toBe(
-            'ALTER DOMAIN "old" RENAME TO "new";'
-          );
-          expect(renameDomainFn.reverse(source, destination)).toBe(
-            'ALTER DOMAIN "new" RENAME TO "old";'
-          );
-        }
-      );
-
-      it.each([
-        [
-          { schema: 'app', name: 'old' },
-          { schema: 'other', name: 'new' },
-        ],
-        ['old', { schema: 'app', name: 'new' }],
-        [
-          { schema: 'app', name: 'old' },
-          { schema: '', name: 'new' },
-        ],
-        ['old', { schema: '', name: 'new' }],
-      ])(
-        'should reject incompatible explicit schemas: %j -> %j',
-        (source, destination) => {
-          const error = new Error(
-            'renameDomain cannot change the schema of a domain'
-          );
-          expect(() => renameDomainFn(source, destination)).toThrow(error);
-          expect(() => renameDomainFn.reverse(source, destination)).toThrow(
-            error
-          );
-        }
-      );
-
-      it('should escape schema and object identifiers in both directions', () => {
-        const source = { schema: 'my"schema', name: 'old"name' };
-        expect(renameDomainFn(source, 'new"name')).toBe(
-          'ALTER DOMAIN "my""schema"."old""name" RENAME TO "new""name";'
-        );
-        expect(renameDomainFn.reverse(source, 'new"name')).toBe(
-          'ALTER DOMAIN "my""schema"."new""name" RENAME TO "old""name";'
-        );
-      });
-
-      it('should decamelize both directions and compare schemas before transformation', () => {
-        const rename = renameDomain(options2);
-        const source = { schema: 'appSchema', name: 'oldName' };
-        const destination = { schema: 'appSchema', name: 'newName' };
-        expect(rename(source, destination)).toBe(
-          'ALTER DOMAIN "app_schema"."old_name" RENAME TO "new_name";'
-        );
-        expect(rename.reverse(source, destination)).toBe(
-          'ALTER DOMAIN "app_schema"."new_name" RENAME TO "old_name";'
-        );
-        const mismatched = { schema: 'app_schema', name: 'newName' };
-        const error = new Error(
-          'renameDomain cannot change the schema of a domain'
-        );
-        expect(() => rename(source, mismatched)).toThrow(error);
-        expect(() => rename.reverse(source, mismatched)).toThrow(error);
       });
 
       describe('reverse', () => {

--- a/test/operations/indexes/renameIndex.spec.ts
+++ b/test/operations/indexes/renameIndex.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { renameIndex } from '../../../src/operations/indexes';
-import { options1, options2 } from '../../presetMigrationOptions';
+import { options1 } from '../../presetMigrationOptions';
 
 describe('operations', () => {
   describe('indexes', () => {
@@ -14,87 +14,6 @@ describe('operations', () => {
       it('should generate correct SQL for renaming an index', () => {
         const statement = renameIndexFn('my_index', 'new_index');
         expect(statement).toBe('ALTER INDEX "my_index" RENAME TO "new_index";');
-      });
-
-      it.each([
-        ['new'],
-        [{ name: 'new' }],
-        [{ schema: 'app', name: 'new' }],
-        [{ schema: undefined, name: 'new' }],
-      ])('should preserve the source schema with %j', (destination) => {
-        const source = { schema: 'app', name: 'old' };
-        expect(renameIndexFn(source, destination)).toBe(
-          'ALTER INDEX "app"."old" RENAME TO "new";'
-        );
-        expect(renameIndexFn.reverse(source, destination)).toBe(
-          'ALTER INDEX "app"."new" RENAME TO "old";'
-        );
-      });
-
-      it.each([undefined, ''])(
-        'should keep matching %j schemas unqualified',
-        (schema) => {
-          const source = { schema, name: 'old' };
-          const destination = { schema, name: 'new' };
-          expect(renameIndexFn(source, destination)).toBe(
-            'ALTER INDEX "old" RENAME TO "new";'
-          );
-          expect(renameIndexFn.reverse(source, destination)).toBe(
-            'ALTER INDEX "new" RENAME TO "old";'
-          );
-        }
-      );
-
-      it.each([
-        [
-          { schema: 'app', name: 'old' },
-          { schema: 'other', name: 'new' },
-        ],
-        ['old', { schema: 'app', name: 'new' }],
-        [
-          { schema: 'app', name: 'old' },
-          { schema: '', name: 'new' },
-        ],
-        ['old', { schema: '', name: 'new' }],
-      ])(
-        'should reject incompatible explicit schemas: %j -> %j',
-        (source, destination) => {
-          const error = new Error(
-            'renameIndex cannot change the schema of an index'
-          );
-          expect(() => renameIndexFn(source, destination)).toThrow(error);
-          expect(() => renameIndexFn.reverse(source, destination)).toThrow(
-            error
-          );
-        }
-      );
-
-      it('should escape schema and object identifiers in both directions', () => {
-        const source = { schema: 'my"schema', name: 'old"name' };
-        expect(renameIndexFn(source, 'new"name')).toBe(
-          'ALTER INDEX "my""schema"."old""name" RENAME TO "new""name";'
-        );
-        expect(renameIndexFn.reverse(source, 'new"name')).toBe(
-          'ALTER INDEX "my""schema"."new""name" RENAME TO "old""name";'
-        );
-      });
-
-      it('should decamelize both directions and compare schemas before transformation', () => {
-        const rename = renameIndex(options2);
-        const source = { schema: 'appSchema', name: 'oldName' };
-        const destination = { schema: 'appSchema', name: 'newName' };
-        expect(rename(source, destination)).toBe(
-          'ALTER INDEX "app_schema"."old_name" RENAME TO "new_name";'
-        );
-        expect(rename.reverse(source, destination)).toBe(
-          'ALTER INDEX "app_schema"."new_name" RENAME TO "old_name";'
-        );
-        const mismatched = { schema: 'app_schema', name: 'newName' };
-        const error = new Error(
-          'renameIndex cannot change the schema of an index'
-        );
-        expect(() => rename(source, mismatched)).toThrow(error);
-        expect(() => rename.reverse(source, mismatched)).toThrow(error);
       });
 
       describe('reverse', () => {

--- a/test/operations/materializedViews/renameMaterializedView.spec.ts
+++ b/test/operations/materializedViews/renameMaterializedView.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { renameMaterializedView } from '../../../src/operations/materializedViews';
-import { options1, options2 } from '../../presetMigrationOptions';
+import { options1 } from '../../presetMigrationOptions';
 
 describe('operations', () => {
   describe('materializedViews', () => {
@@ -30,89 +30,6 @@ describe('operations', () => {
         expect(statement).toBe(
           'ALTER MATERIALIZED VIEW "myschema"."foo" RENAME TO "bar";'
         );
-      });
-
-      it.each([
-        ['new'],
-        [{ name: 'new' }],
-        [{ schema: 'app', name: 'new' }],
-        [{ schema: undefined, name: 'new' }],
-      ])('should preserve the source schema with %j', (destination) => {
-        const source = { schema: 'app', name: 'old' };
-        expect(renameMaterializedViewFn(source, destination)).toBe(
-          'ALTER MATERIALIZED VIEW "app"."old" RENAME TO "new";'
-        );
-        expect(renameMaterializedViewFn.reverse(source, destination)).toBe(
-          'ALTER MATERIALIZED VIEW "app"."new" RENAME TO "old";'
-        );
-      });
-
-      it.each([undefined, ''])(
-        'should keep matching %j schemas unqualified',
-        (schema) => {
-          const source = { schema, name: 'old' };
-          const destination = { schema, name: 'new' };
-          expect(renameMaterializedViewFn(source, destination)).toBe(
-            'ALTER MATERIALIZED VIEW "old" RENAME TO "new";'
-          );
-          expect(renameMaterializedViewFn.reverse(source, destination)).toBe(
-            'ALTER MATERIALIZED VIEW "new" RENAME TO "old";'
-          );
-        }
-      );
-
-      it.each([
-        [
-          { schema: 'app', name: 'old' },
-          { schema: 'other', name: 'new' },
-        ],
-        ['old', { schema: 'app', name: 'new' }],
-        [
-          { schema: 'app', name: 'old' },
-          { schema: '', name: 'new' },
-        ],
-        ['old', { schema: '', name: 'new' }],
-      ])(
-        'should reject incompatible explicit schemas: %j -> %j',
-        (source, destination) => {
-          const error = new Error(
-            'renameMaterializedView cannot change the schema of a materialized view'
-          );
-          expect(() => renameMaterializedViewFn(source, destination)).toThrow(
-            error
-          );
-          expect(() =>
-            renameMaterializedViewFn.reverse(source, destination)
-          ).toThrow(error);
-        }
-      );
-
-      it('should escape schema and object identifiers in both directions', () => {
-        const source = { schema: 'my"schema', name: 'old"name' };
-        expect(renameMaterializedViewFn(source, 'new"name')).toBe(
-          'ALTER MATERIALIZED VIEW "my""schema"."old""name" RENAME TO "new""name";'
-        );
-        expect(renameMaterializedViewFn.reverse(source, 'new"name')).toBe(
-          'ALTER MATERIALIZED VIEW "my""schema"."new""name" RENAME TO "old""name";'
-        );
-      });
-
-      it('should decamelize both directions and compare schemas before transformation', () => {
-        const rename = renameMaterializedView(options2);
-        const source = { schema: 'appSchema', name: 'oldName' };
-        const destination = { schema: 'appSchema', name: 'newName' };
-        expect(rename(source, destination)).toBe(
-          'ALTER MATERIALIZED VIEW "app_schema"."old_name" RENAME TO "new_name";'
-        );
-        expect(rename.reverse(source, destination)).toBe(
-          'ALTER MATERIALIZED VIEW "app_schema"."new_name" RENAME TO "old_name";'
-        );
-        const mismatched = { schema: 'app_schema', name: 'newName' };
-        const error = new Error(
-          'renameMaterializedView cannot change the schema of a materialized view'
-        );
-        expect(() => rename(source, mismatched)).toThrow(error);
-        expect(() => rename.reverse(source, mismatched)).toThrow(error);
       });
 
       describe('reverse', () => {

--- a/test/operations/renameChains.spec.ts
+++ b/test/operations/renameChains.spec.ts
@@ -97,27 +97,35 @@ describe('operations', () => {
         }
       );
 
-      it.each([
-        [
-          { schema: 'app', name: 'old' },
-          { schema: 'other', name: 'new' },
-        ],
-        ['old', { schema: 'app', name: 'new' }],
-        [
-          { schema: '', name: 'old' },
-          { schema: 'app', name: 'new' },
-        ],
-        [
-          { schema: undefined, name: 'old' },
-          { schema: 'app', name: 'new' },
-        ],
-        [PgLiteral.create('old'), { schema: 'app', name: 'new' }],
-      ] satisfies Array<[Name, Name]>)(
-        'rejects incompatible schemas: %j -> %j',
-        (source, destination) => {
-          expect(() => rename(source, destination)).toThrow(
-            new Error(`${operation} cannot change the schema of ${label}`)
+      it('rejects different explicit schemas', () => {
+        const pgm = builder();
+        pgm[operation]('existing', 'renamed');
+        const before = pgm.getSqlSteps();
+        expect(() => {
+          pgm[operation](
+            { schema: 'app', name: 'old' },
+            { schema: 'other', name: 'new' }
           );
+        }).toThrow(
+          new Error(`${operation} cannot change the schema of ${label}`)
+        );
+        expect(pgm.getSqlSteps()).toEqual(before);
+      });
+
+      it.each([...unqualifiedSources, PgLiteral.create('old')])(
+        'explains how to specify the unknown source schema for %j',
+        (source) => {
+          const pgm = builder();
+          pgm[operation]('existing', 'renamed');
+          const before = pgm.getSqlSteps();
+          expect(() => {
+            pgm[operation](source, { schema: 'app', name: 'new' });
+          }).toThrow(
+            new Error(
+              `${operation} cannot infer the source schema; use { schema, name } for the source`
+            )
+          );
+          expect(pgm.getSqlSteps()).toEqual(before);
         }
       );
 

--- a/test/operations/renameChains.spec.ts
+++ b/test/operations/renameChains.spec.ts
@@ -1,48 +1,279 @@
 import { describe, expect, it, vi } from 'vitest';
-import { MigrationBuilder } from '../../src';
+import type { PgLiteralValue } from '../../src';
+import { MigrationBuilder, PgLiteral } from '../../src';
+import type { Name } from '../../src/operations/generalTypes';
 
-describe('schema-qualified rename chains', () => {
-  const operations = [
-    ['renameType', 'TYPE'],
-    ['renameDomain', 'DOMAIN'],
-    ['renameView', 'VIEW'],
-    ['renameMaterializedView', 'MATERIALIZED VIEW'],
-    ['renameSequence', 'SEQUENCE'],
-    ['renameIndex', 'INDEX'],
-  ] as const;
-  const cases = operations.flatMap(([operation, keyword]) =>
-    (['up', 'down'] as const).map((direction) => ({
-      operation,
-      keyword,
-      direction,
-    }))
-  );
+const operations = [
+  ['renameTable', 'TABLE', 'a table'],
+  ['renameType', 'TYPE', 'a type'],
+  ['renameDomain', 'DOMAIN', 'a domain'],
+  ['renameView', 'VIEW', 'a view'],
+  ['renameMaterializedView', 'MATERIALIZED VIEW', 'a materialized view'],
+  ['renameSequence', 'SEQUENCE', 'a sequence'],
+  ['renameIndex', 'INDEX', 'an index'],
+] as const;
 
-  it.each(cases)(
-    'should preserve schema and rename order for $operation ($direction)',
-    ({ operation, keyword, direction }) => {
-      const db = { query: vi.fn(), select: vi.fn() };
-      const pgm = new MigrationBuilder(db, undefined, false, console);
-      if (direction === 'down') {
-        pgm.enableReverseMode();
+const unqualifiedSources: Name[] = [
+  'old',
+  { name: 'old' },
+  { schema: undefined, name: 'old' },
+  { schema: '', name: 'old' },
+];
+const unqualifiedDestinations: Name[] = [
+  'new',
+  { name: 'new' },
+  { schema: undefined, name: 'new' },
+  { schema: '', name: 'new' },
+];
+
+describe('operations', () => {
+  describe.each(operations)('%s schemas', (operation, keyword, label) => {
+    describe.each(['up', 'down'] as const)('%s', (direction) => {
+      function builder(decamelize = false): MigrationBuilder {
+        const pgm = new MigrationBuilder(
+          { query: vi.fn(), select: vi.fn() },
+          undefined,
+          decamelize,
+          console
+        );
+        if (direction === 'down') {
+          pgm.enableReverseMode();
+        }
+        return pgm;
       }
-      pgm[operation]({ schema: 'app', name: 'old' }, 'middle');
-      pgm[operation](
-        { schema: 'app', name: 'middle' },
-        { schema: 'app', name: 'new' }
+
+      function rename(source: Name, destination: Name, decamelize = false) {
+        const pgm = builder(decamelize);
+        pgm[operation](source, destination);
+        return pgm.getSqlSteps();
+      }
+
+      it('preserves schema and rename-chain order', () => {
+        const pgm = builder();
+        pgm[operation]({ schema: 'app', name: 'old' }, 'middle');
+        pgm[operation](
+          { schema: 'app', name: 'middle' },
+          { schema: 'app', name: 'new' }
+        );
+        expect(pgm.getSqlSteps()).toEqual(
+          direction === 'down'
+            ? [
+                `ALTER ${keyword} "app"."new" RENAME TO "middle";`,
+                `ALTER ${keyword} "app"."middle" RENAME TO "old";`,
+              ]
+            : [
+                `ALTER ${keyword} "app"."old" RENAME TO "middle";`,
+                `ALTER ${keyword} "app"."middle" RENAME TO "new";`,
+              ]
+        );
+      });
+
+      it.each([...unqualifiedDestinations, { schema: 'app', name: 'new' }])(
+        'preserves the source schema for destination %j',
+        (destination) => {
+          expect(rename({ schema: 'app', name: 'old' }, destination)).toEqual([
+            direction === 'down'
+              ? `ALTER ${keyword} "app"."new" RENAME TO "old";`
+              : `ALTER ${keyword} "app"."old" RENAME TO "new";`,
+          ]);
+        }
       );
 
-      expect(pgm.getSqlSteps()).toEqual(
-        direction === 'down'
-          ? [
-              `ALTER ${keyword} "app"."new" RENAME TO "middle";`,
-              `ALTER ${keyword} "app"."middle" RENAME TO "old";`,
-            ]
-          : [
-              `ALTER ${keyword} "app"."old" RENAME TO "middle";`,
-              `ALTER ${keyword} "app"."middle" RENAME TO "new";`,
-            ]
+      it.each(
+        unqualifiedSources.flatMap((source) =>
+          unqualifiedDestinations.map((destination) => ({
+            source,
+            destination,
+          }))
+        )
+      )(
+        'normalizes omitted and empty schemas: $source -> $destination',
+        ({ source, destination }) => {
+          expect(rename(source, destination)).toEqual([
+            direction === 'down'
+              ? `ALTER ${keyword} "new" RENAME TO "old";`
+              : `ALTER ${keyword} "old" RENAME TO "new";`,
+          ]);
+        }
       );
-    }
-  );
+
+      it.each([
+        [
+          { schema: 'app', name: 'old' },
+          { schema: 'other', name: 'new' },
+        ],
+        ['old', { schema: 'app', name: 'new' }],
+        [
+          { schema: '', name: 'old' },
+          { schema: 'app', name: 'new' },
+        ],
+        [
+          { schema: undefined, name: 'old' },
+          { schema: 'app', name: 'new' },
+        ],
+        [PgLiteral.create('old'), { schema: 'app', name: 'new' }],
+      ] satisfies Array<[Name, Name]>)(
+        'rejects incompatible schemas: %j -> %j',
+        (source, destination) => {
+          expect(() => rename(source, destination)).toThrow(
+            new Error(`${operation} cannot change the schema of ${label}`)
+          );
+        }
+      );
+
+      it.each([
+        ['appSchema', 'app_schema'],
+        ['app_schema', 'appSchema'],
+        ['appSchema', 'appSchema'],
+      ])(
+        'compares rendered schemas: %s -> %s',
+        (sourceSchema, destinationSchema) => {
+          expect(
+            rename(
+              { schema: sourceSchema, name: 'oldName' },
+              { schema: destinationSchema, name: 'newName' },
+              true
+            )
+          ).toEqual([
+            direction === 'down'
+              ? `ALTER ${keyword} "app_schema"."new_name" RENAME TO "old_name";`
+              : `ALTER ${keyword} "app_schema"."old_name" RENAME TO "new_name";`,
+          ]);
+        }
+      );
+
+      it.each([false, true])(
+        'rejects schemas that still render differently (decamelize=%s)',
+        (decamelize) => {
+          expect(() =>
+            rename(
+              { schema: 'appSchema', name: 'old' },
+              {
+                schema: decamelize ? 'otherSchema' : 'app_schema',
+                name: 'new',
+              },
+              decamelize
+            )
+          ).toThrow(
+            new Error(`${operation} cannot change the schema of ${label}`)
+          );
+        }
+      );
+
+      it('escapes schema and object identifiers', () => {
+        expect(
+          rename({ schema: 'my"schema', name: 'old"name' }, 'new"name')
+        ).toEqual([
+          direction === 'down'
+            ? `ALTER ${keyword} "my""schema"."new""name" RENAME TO "old""name";`
+            : `ALTER ${keyword} "my""schema"."old""name" RENAME TO "new""name";`,
+        ]);
+      });
+
+      it.each([
+        'rawName',
+        '_name$1',
+        'ação',
+        '名字',
+        '🦉',
+        '"name.with.dot"',
+        '"escaped""quote"',
+        '"two words"',
+        ' \t"New.Name"\n',
+        '"comment--inside"',
+      ])(
+        'preserves the single raw identifier %j under decamelization',
+        (raw) => {
+          const literal = PgLiteral.create(raw);
+          expect(rename(literal, 'newName', true)).toEqual([
+            direction === 'down'
+              ? `ALTER ${keyword} "new_name" RENAME TO ${raw};`
+              : `ALTER ${keyword} ${raw} RENAME TO "new_name";`,
+          ]);
+          expect(
+            rename({ schema: 'appSchema', name: 'oldName' }, literal, true)
+          ).toEqual([
+            direction === 'down'
+              ? `ALTER ${keyword} "app_schema".${raw} RENAME TO "old_name";`
+              : `ALTER ${keyword} "app_schema"."old_name" RENAME TO ${raw};`,
+          ]);
+        }
+      );
+
+      it.each(['source', 'destination'] as const)(
+        'validates the rendered %s literal instead of its value property',
+        (position) => {
+          const literal: PgLiteralValue = {
+            literal: true,
+            value: 'safe',
+            toString: () => 'app.unsafe',
+          };
+          expect(() =>
+            rename(
+              position === 'source' ? literal : 'old',
+              position === 'destination' ? literal : 'new'
+            )
+          ).toThrow(
+            new Error(
+              `${operation} requires a single unqualified identifier for a PgLiteral ${position}; use { schema, name } for schema-qualified names`
+            )
+          );
+        }
+      );
+
+      it('accepts a literal-like object with a valid rendered identifier', () => {
+        const literal: PgLiteralValue = {
+          literal: true,
+          value: 'ignored.value',
+          toString: () => '"Raw.Name"',
+        };
+        expect(rename('old', literal)).toEqual([
+          direction === 'down'
+            ? `ALTER ${keyword} "Raw.Name" RENAME TO "old";`
+            : `ALTER ${keyword} "old" RENAME TO "Raw.Name";`,
+        ]);
+      });
+
+      it.each([
+        'app.old',
+        '"app"."old"',
+        '"app" . old',
+        'db.app.old',
+        '',
+        '""',
+        ' \t\n',
+        'old new',
+        'lower(old)',
+        'old /* comment */',
+        'old--comment',
+        'old; SELECT 1',
+        'U&"d\\0061ta"',
+        "'old'",
+        '1old',
+        '"unterminated',
+        '"old"suffix',
+        '"nul\0name"',
+      ])('rejects unsupported raw name %j before adding a SQL step', (raw) => {
+        const pgm = builder();
+        pgm[operation]('existing', 'renamed');
+        const before = pgm.getSqlSteps();
+        expect(() => {
+          pgm[operation](PgLiteral.create(raw), 'new');
+        }).toThrow(
+          new Error(
+            `${operation} requires a single unqualified identifier for a PgLiteral source; use { schema, name } for schema-qualified names`
+          )
+        );
+        expect(pgm.getSqlSteps()).toEqual(before);
+        expect(() => {
+          pgm[operation]({ schema: 'app', name: 'old' }, PgLiteral.create(raw));
+        }).toThrow(
+          new Error(
+            `${operation} requires a single unqualified identifier for a PgLiteral destination; use { schema, name } for schema-qualified names`
+          )
+        );
+        expect(pgm.getSqlSteps()).toEqual(before);
+      });
+    });
+  });
 });

--- a/test/operations/sequences/renameSequence.spec.ts
+++ b/test/operations/sequences/renameSequence.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { renameSequence } from '../../../src/operations/sequences';
-import { options1, options2 } from '../../presetMigrationOptions';
+import { options1 } from '../../presetMigrationOptions';
 
 describe('operations', () => {
   describe('sequences', () => {
@@ -28,87 +28,6 @@ describe('operations', () => {
         expect(statement).toBe(
           'ALTER SEQUENCE "myschema"."serial" RENAME TO "serial2";'
         );
-      });
-
-      it.each([
-        ['new'],
-        [{ name: 'new' }],
-        [{ schema: 'app', name: 'new' }],
-        [{ schema: undefined, name: 'new' }],
-      ])('should preserve the source schema with %j', (destination) => {
-        const source = { schema: 'app', name: 'old' };
-        expect(renameSequenceFn(source, destination)).toBe(
-          'ALTER SEQUENCE "app"."old" RENAME TO "new";'
-        );
-        expect(renameSequenceFn.reverse(source, destination)).toBe(
-          'ALTER SEQUENCE "app"."new" RENAME TO "old";'
-        );
-      });
-
-      it.each([undefined, ''])(
-        'should keep matching %j schemas unqualified',
-        (schema) => {
-          const source = { schema, name: 'old' };
-          const destination = { schema, name: 'new' };
-          expect(renameSequenceFn(source, destination)).toBe(
-            'ALTER SEQUENCE "old" RENAME TO "new";'
-          );
-          expect(renameSequenceFn.reverse(source, destination)).toBe(
-            'ALTER SEQUENCE "new" RENAME TO "old";'
-          );
-        }
-      );
-
-      it.each([
-        [
-          { schema: 'app', name: 'old' },
-          { schema: 'other', name: 'new' },
-        ],
-        ['old', { schema: 'app', name: 'new' }],
-        [
-          { schema: 'app', name: 'old' },
-          { schema: '', name: 'new' },
-        ],
-        ['old', { schema: '', name: 'new' }],
-      ])(
-        'should reject incompatible explicit schemas: %j -> %j',
-        (source, destination) => {
-          const error = new Error(
-            'renameSequence cannot change the schema of a sequence'
-          );
-          expect(() => renameSequenceFn(source, destination)).toThrow(error);
-          expect(() => renameSequenceFn.reverse(source, destination)).toThrow(
-            error
-          );
-        }
-      );
-
-      it('should escape schema and object identifiers in both directions', () => {
-        const source = { schema: 'my"schema', name: 'old"name' };
-        expect(renameSequenceFn(source, 'new"name')).toBe(
-          'ALTER SEQUENCE "my""schema"."old""name" RENAME TO "new""name";'
-        );
-        expect(renameSequenceFn.reverse(source, 'new"name')).toBe(
-          'ALTER SEQUENCE "my""schema"."new""name" RENAME TO "old""name";'
-        );
-      });
-
-      it('should decamelize both directions and compare schemas before transformation', () => {
-        const rename = renameSequence(options2);
-        const source = { schema: 'appSchema', name: 'oldName' };
-        const destination = { schema: 'appSchema', name: 'newName' };
-        expect(rename(source, destination)).toBe(
-          'ALTER SEQUENCE "app_schema"."old_name" RENAME TO "new_name";'
-        );
-        expect(rename.reverse(source, destination)).toBe(
-          'ALTER SEQUENCE "app_schema"."new_name" RENAME TO "old_name";'
-        );
-        const mismatched = { schema: 'app_schema', name: 'newName' };
-        const error = new Error(
-          'renameSequence cannot change the schema of a sequence'
-        );
-        expect(() => rename(source, mismatched)).toThrow(error);
-        expect(() => rename.reverse(source, mismatched)).toThrow(error);
       });
 
       describe('reverse', () => {

--- a/test/operations/tables/renameTable.spec.ts
+++ b/test/operations/tables/renameTable.spec.ts
@@ -32,54 +32,6 @@ describe('operations', () => {
         );
       });
 
-      it.each([
-        ['suppliers'],
-        [{ name: 'suppliers' }],
-        [{ name: 'suppliers', schema: 'myschema' }],
-      ])('should preserve the schema when reversing to %j', (newName) => {
-        expect(
-          renameTableFn.reverse(
-            { name: 'distributors', schema: 'myschema' },
-            newName
-          )
-        ).toBe('ALTER TABLE "myschema"."suppliers" RENAME TO "distributors";');
-      });
-
-      it('should reject a change of schema in either direction', () => {
-        const from = { name: 'distributors', schema: 'myschema' };
-        const to = { name: 'suppliers', schema: 'other' };
-
-        expect(() => renameTableFn(from, to)).toThrow(
-          new Error('renameTable cannot change the schema of a table')
-        );
-        expect(() => renameTableFn.reverse(from, to)).toThrow(
-          new Error('renameTable cannot change the schema of a table')
-        );
-        expect(() => renameTableFn('distributors', to)).toThrow(
-          new Error('renameTable cannot change the schema of a table')
-        );
-      });
-
-      it('should reject an explicitly empty destination schema', () => {
-        const from = { schema: 'myschema', name: 'distributors' };
-        const to = { schema: '', name: 'suppliers' };
-        const error = new Error(
-          'renameTable cannot change the schema of a table'
-        );
-
-        expect(() => renameTableFn(from, to)).toThrow(error);
-        expect(() => renameTableFn.reverse(from, to)).toThrow(error);
-      });
-
-      it('should escape schema and table names when reversing', () => {
-        expect(
-          renameTableFn.reverse(
-            { name: 'old"table', schema: 'my"schema' },
-            'new"table'
-          )
-        ).toBe('ALTER TABLE "my""schema"."new""table" RENAME TO "old""table";');
-      });
-
       describe('reverse', () => {
         it('should contain a reverse function', () => {
           expect(renameTableFn.reverse).toBeTypeOf('function');

--- a/test/operations/types/renameType.spec.ts
+++ b/test/operations/types/renameType.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { renameType } from '../../../src/operations/types';
-import { options1, options2 } from '../../presetMigrationOptions';
+import { options1 } from '../../presetMigrationOptions';
 
 describe('operations', () => {
   describe('types', () => {
@@ -30,87 +30,6 @@ describe('operations', () => {
         expect(statement).toBe(
           'ALTER TYPE "myschema"."electronic_mail" RENAME TO "email";'
         );
-      });
-
-      it.each([
-        ['new'],
-        [{ name: 'new' }],
-        [{ schema: 'app', name: 'new' }],
-        [{ schema: undefined, name: 'new' }],
-      ])('should preserve the source schema with %j', (destination) => {
-        const source = { schema: 'app', name: 'old' };
-        expect(renameTypeFn(source, destination)).toBe(
-          'ALTER TYPE "app"."old" RENAME TO "new";'
-        );
-        expect(renameTypeFn.reverse(source, destination)).toBe(
-          'ALTER TYPE "app"."new" RENAME TO "old";'
-        );
-      });
-
-      it.each([undefined, ''])(
-        'should keep matching %j schemas unqualified',
-        (schema) => {
-          const source = { schema, name: 'old' };
-          const destination = { schema, name: 'new' };
-          expect(renameTypeFn(source, destination)).toBe(
-            'ALTER TYPE "old" RENAME TO "new";'
-          );
-          expect(renameTypeFn.reverse(source, destination)).toBe(
-            'ALTER TYPE "new" RENAME TO "old";'
-          );
-        }
-      );
-
-      it.each([
-        [
-          { schema: 'app', name: 'old' },
-          { schema: 'other', name: 'new' },
-        ],
-        ['old', { schema: 'app', name: 'new' }],
-        [
-          { schema: 'app', name: 'old' },
-          { schema: '', name: 'new' },
-        ],
-        ['old', { schema: '', name: 'new' }],
-      ])(
-        'should reject incompatible explicit schemas: %j -> %j',
-        (source, destination) => {
-          const error = new Error(
-            'renameType cannot change the schema of a type'
-          );
-          expect(() => renameTypeFn(source, destination)).toThrow(error);
-          expect(() => renameTypeFn.reverse(source, destination)).toThrow(
-            error
-          );
-        }
-      );
-
-      it('should escape schema and object identifiers in both directions', () => {
-        const source = { schema: 'my"schema', name: 'old"name' };
-        expect(renameTypeFn(source, 'new"name')).toBe(
-          'ALTER TYPE "my""schema"."old""name" RENAME TO "new""name";'
-        );
-        expect(renameTypeFn.reverse(source, 'new"name')).toBe(
-          'ALTER TYPE "my""schema"."new""name" RENAME TO "old""name";'
-        );
-      });
-
-      it('should decamelize both directions and compare schemas before transformation', () => {
-        const rename = renameType(options2);
-        const source = { schema: 'appSchema', name: 'oldName' };
-        const destination = { schema: 'appSchema', name: 'newName' };
-        expect(rename(source, destination)).toBe(
-          'ALTER TYPE "app_schema"."old_name" RENAME TO "new_name";'
-        );
-        expect(rename.reverse(source, destination)).toBe(
-          'ALTER TYPE "app_schema"."new_name" RENAME TO "old_name";'
-        );
-        const mismatched = { schema: 'app_schema', name: 'newName' };
-        const error = new Error(
-          'renameType cannot change the schema of a type'
-        );
-        expect(() => rename(source, mismatched)).toThrow(error);
-        expect(() => rename.reverse(source, mismatched)).toThrow(error);
       });
 
       describe('reverse', () => {

--- a/test/operations/views/renameView.spec.ts
+++ b/test/operations/views/renameView.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { renameView } from '../../../src/operations/views';
-import { options1, options2 } from '../../presetMigrationOptions';
+import { options1 } from '../../presetMigrationOptions';
 
 describe('operations', () => {
   describe('views', () => {
@@ -26,87 +26,6 @@ describe('operations', () => {
 
         expect(statement).toBeTypeOf('string');
         expect(statement).toBe('ALTER VIEW "myschema"."foo" RENAME TO "bar";');
-      });
-
-      it.each([
-        ['new'],
-        [{ name: 'new' }],
-        [{ schema: 'app', name: 'new' }],
-        [{ schema: undefined, name: 'new' }],
-      ])('should preserve the source schema with %j', (destination) => {
-        const source = { schema: 'app', name: 'old' };
-        expect(renameViewFn(source, destination)).toBe(
-          'ALTER VIEW "app"."old" RENAME TO "new";'
-        );
-        expect(renameViewFn.reverse(source, destination)).toBe(
-          'ALTER VIEW "app"."new" RENAME TO "old";'
-        );
-      });
-
-      it.each([undefined, ''])(
-        'should keep matching %j schemas unqualified',
-        (schema) => {
-          const source = { schema, name: 'old' };
-          const destination = { schema, name: 'new' };
-          expect(renameViewFn(source, destination)).toBe(
-            'ALTER VIEW "old" RENAME TO "new";'
-          );
-          expect(renameViewFn.reverse(source, destination)).toBe(
-            'ALTER VIEW "new" RENAME TO "old";'
-          );
-        }
-      );
-
-      it.each([
-        [
-          { schema: 'app', name: 'old' },
-          { schema: 'other', name: 'new' },
-        ],
-        ['old', { schema: 'app', name: 'new' }],
-        [
-          { schema: 'app', name: 'old' },
-          { schema: '', name: 'new' },
-        ],
-        ['old', { schema: '', name: 'new' }],
-      ])(
-        'should reject incompatible explicit schemas: %j -> %j',
-        (source, destination) => {
-          const error = new Error(
-            'renameView cannot change the schema of a view'
-          );
-          expect(() => renameViewFn(source, destination)).toThrow(error);
-          expect(() => renameViewFn.reverse(source, destination)).toThrow(
-            error
-          );
-        }
-      );
-
-      it('should escape schema and object identifiers in both directions', () => {
-        const source = { schema: 'my"schema', name: 'old"name' };
-        expect(renameViewFn(source, 'new"name')).toBe(
-          'ALTER VIEW "my""schema"."old""name" RENAME TO "new""name";'
-        );
-        expect(renameViewFn.reverse(source, 'new"name')).toBe(
-          'ALTER VIEW "my""schema"."new""name" RENAME TO "old""name";'
-        );
-      });
-
-      it('should decamelize both directions and compare schemas before transformation', () => {
-        const rename = renameView(options2);
-        const source = { schema: 'appSchema', name: 'oldName' };
-        const destination = { schema: 'appSchema', name: 'newName' };
-        expect(rename(source, destination)).toBe(
-          'ALTER VIEW "app_schema"."old_name" RENAME TO "new_name";'
-        );
-        expect(rename.reverse(source, destination)).toBe(
-          'ALTER VIEW "app_schema"."new_name" RENAME TO "old_name";'
-        );
-        const mismatched = { schema: 'app_schema', name: 'newName' };
-        const error = new Error(
-          'renameView cannot change the schema of a view'
-        );
-        expect(() => rename(source, mismatched)).toThrow(error);
-        expect(() => rename.reverse(source, mismatched)).toThrow(error);
       });
 
       describe('reverse', () => {


### PR DESCRIPTION
Fixes #1731. Follow-up to #1725 and #1728; #1727 remains separate.

Normalize schema handling in `renameTable`, `renameType`, `renameDomain`, `renameView`, `renameMaterializedView`, `renameSequence`, and `renameIndex`. Empty destination schemas now inherit the source schema, and explicit schemas are compared after rendering. For example, `{ name: 'old' }` → `{ schema: '', name: 'new' }` previously threw; it now generates valid unqualified SQL in both directions. With decamelization enabled, `appSchema` and `app_schema` are accepted as the same schema. Different explicit schemas still raise the existing operation-specific error. When the destination specifies a schema but the source schema is unknown, the error now explains how to provide it: `<operation> cannot infer the source schema; use { schema, name } for the source`.

The PR has three commits:

1. Extract an internal `createRenameOperation` factory with separate forward and reverse closures, preserving behavior.
2. Apply the schema and literal corrections, consolidate regression coverage across all seven operations, add PostgreSQL round-trip tests, and link the seven documentation pages to one shared explanation.
3. Address review feedback by distinguishing an unknown source schema from a schema mismatch, testing the diagnostic in both directions, and correcting the documented `Name` type.

Public `Name` signatures are unchanged. The new integration tests verify object OIDs and automatic rollback while same-named objects in another schema remain untouched. Existing migration fixtures, fixture-count assertions, and all PostgreSQL SQL snapshots are unchanged.

### Compatibility / release note

**Qualified or unsupported `PgLiteral` names now raise an actionable error during SQL generation in both directions.** A qualified source such as `pgm.func('app.old')` could previously work going up with a manually written down migration; it is now rejected. Use `{ schema: 'app', name: 'old' }`, with normal quoting and decamelization, or explicit `pgm.sql` statements in both directions.

Single unquoted and double-quoted raw identifiers remain supported without extra quoting or decamelization, including Unicode, surrounding SQL whitespace, escaped quotes, and quoted dots (`"new.name"`). Expressions, comments, multiple tokens, and `U&` escape syntax are rejected. Validation checks the rendered literal text, not just its `value` property. This policy is limited to the seven rename operations.

### Validation

Using Node 24.18.0 and pnpm 11.25.0:

- Upstream baseline: **829 unit tests passed**.
- Refactor commit: **829 unit tests passed**; **4,732 differential calls** across all seven operations, both directions, and decamelization modes matched upstream exactly.
- New regression suite on a clean upstream `ab16973` copy: **364 failed / 532 passed**. After the fix: **896 passed**.
- Current unit suite on `64af9a8`: **1,649 passed across 106 files**, including **910 focused rename cases**. The original behavior-fix commit had 1,635 passing tests.
- On the original behavior-fix commit `c25415e`, **51 integration tests passed on native PostgreSQL 16.15**, including all 35 new rename scenarios and the existing CLI/configuration and dry-run suites. The complete migration sequence matched the existing PostgreSQL 16 up/down snapshots.
- Native integration used an untracked test adapter that replaced container provisioning with isolated databases on a disposable local PostgreSQL server; SQL execution, assertions, and snapshots were unchanged. Docker/Testcontainers itself and PostgreSQL 14, 15, 17, and 18 were not run locally; the existing CI matrix covers them.
- Package build, type checking, lint, formatting, documentation build, and `git diff --check` passed.

- **All 29 GitHub checks passed on the previous head `c25415e`**, including the real PostgreSQL 14–18 Testcontainers matrix on Node 22, 24, and 26, and the existing CockroachDB matrix. [CI run](https://github.com/salsita/node-pg-migrate/actions/runs/34376810814).

- Review follow-up: the diagnostic assertions produced **70 failures / 840 passes before the change**, then **910 passes** afterward. A **4,732-call comparison** against `c25415e` found only the intended diagnostic differences; successful SQL and rejection behavior are unchanged. Integration tests, migration fixtures, snapshots, and public types are unchanged. All **29 GitHub checks passed on `64af9a8`**, including the PostgreSQL 14–18 Testcontainers matrix on Node 22, 24, and 26, and the existing CockroachDB matrix. [CI run](https://github.com/salsita/node-pg-migrate/actions/runs/34390892245).

Reviewed with the help of AI.
