### PR TITLE
fix!: preserve schemas in function and operator renames

### DIFF
--- a/docs/src/migrations/functions.md
+++ b/docs/src/migrations/functions.md
@@ -63,7 +63,7 @@ If array of strings, it is interpreted as is, if array of objects:
 | `ifExists` | `boolean` | drops function only if it exists |
 | `cascade`  | `boolean` | drops also dependent objects     |
 
-## Operation: `alterFunction`
+## Operation: `renameFunction`
 
 #### `pgm.renameFunction( old_function_name, function_params, new_function_name )`
 
@@ -77,3 +77,22 @@ If array of strings, it is interpreted as is, if array of objects:
 | `old_function_name` | [Name](/migrations/#type)       | old name of the function   |
 | `function_params`   | `array[string]` `array[object]` | parameters of the function |
 | `new_function_name` | [Name](/migrations/#type)       | new name of the function   |
+
+See [Renaming and schemas](/migrations/#renaming-and-schemas) for schema
+normalization, automatic reversal, and supported `PgLiteral` names.
+The function parameters identify the overload and are preserved during reversal.
+Use `[]` for a function with no parameters; include the input argument types to
+select an overloaded function.
+
+```javascript
+pgm.renameFunction({ schema: 'app', name: 'old_function' }, ['integer'], {
+  schema: 'app',
+  name: 'new_function',
+});
+// up:   ALTER FUNCTION "app"."old_function"(integer) RENAME TO "new_function";
+// down: ALTER FUNCTION "app"."new_function"(integer) RENAME TO "old_function";
+```
+
+To move a function between schemas, use SQL explicitly, for example
+`pgm.sql('ALTER FUNCTION "old_schema"."my_function"(integer) SET SCHEMA "new_schema"')`.
+Provide the corresponding SQL in your down migration to reverse that move.

--- a/docs/src/migrations/functions.md
+++ b/docs/src/migrations/functions.md
@@ -83,6 +83,12 @@ normalization, automatic reversal, and supported `PgLiteral` names.
 The function parameters identify the overload and are preserved during reversal.
 Use `[]` for a function with no parameters; include the input argument types to
 select an overloaded function.
+Parameter objects may be reused from `createFunction`: their `default` values,
+including defaults supplied by type shorthands, are omitted from rename SQL.
+Argument modes, names, and types are preserved. Renaming does not change the
+function's stored defaults; `createFunction` continues to emit them.
+String parameters and object `type` fields must describe argument types without
+inline `DEFAULT` clauses.
 
 ```javascript
 pgm.renameFunction({ schema: 'app', name: 'old_function' }, ['integer'], {

--- a/docs/src/migrations/index.md
+++ b/docs/src/migrations/index.md
@@ -123,7 +123,8 @@ type Name = string | { schema?: string; name: string } | PgLiteralValue;
 ## Renaming and schemas
 
 `renameTable`, `renameType`, `renameDomain`, `renameView`,
-`renameMaterializedView`, `renameSequence`, and `renameIndex` preserve the
+`renameMaterializedView`, `renameSequence`, `renameIndex`, `renameFunction`,
+`renameOperatorClass`, and `renameOperatorFamily` preserve the
 source object's schema, including during automatic reversal:
 
 ```javascript
@@ -153,11 +154,12 @@ quoted identifier are supported: `pgm.func('"new.name"')` is one name, whereas
 > [!WARNING]
 > Qualified `PgLiteral` sources and destinations now raise an error during SQL
 > generation in both directions. Previously, a qualified source could work going
-> up with a manually written down migration. Replace it with `{ schema, name }`,
+> up with a manually written down migration, including in already-applied
+> migrations that are replayed on a fresh database. Replace it with `{ schema, name }`,
 > which uses normal identifier quoting and decamelization, or use `pgm.sql` with
 > explicit SQL in both directions. Other raw forms, including expressions,
 > comments, multiple tokens, and `U&` Unicode escape syntax, are also rejected by
-> these seven rename operations. Other uses of `PgLiteral` are unchanged.
+> these ten rename operations. Other uses of `PgLiteral` are unchanged.
 
 ## Locking
 

--- a/docs/src/migrations/operators.md
+++ b/docs/src/migrations/operators.md
@@ -112,6 +112,24 @@
 | `index_method`            | `string`                  | name of the index method of operator class |
 | `new_operator_class_name` | [Name](/migrations/#type) | new name of the operator class             |
 
+See [Renaming and schemas](/migrations/#renaming-and-schemas) for schema
+normalization, automatic reversal, and supported `PgLiteral` names.
+The index access method identifies the operator class and is preserved during
+automatic reversal, including when another access method has the same object name.
+
+```javascript
+pgm.renameOperatorClass({ schema: 'app', name: 'old_class' }, 'btree', {
+  schema: 'app',
+  name: 'new_class',
+});
+// up:   ALTER OPERATOR CLASS "app"."old_class" USING btree RENAME TO "new_class";
+// down: ALTER OPERATOR CLASS "app"."new_class" USING btree RENAME TO "old_class";
+```
+
+To move an operator class between schemas, use SQL explicitly, for example
+`pgm.sql('ALTER OPERATOR CLASS "old_schema"."my_class" USING btree SET SCHEMA "new_schema"')`.
+Provide the corresponding SQL in your down migration to reverse that move.
+
 ## Operation: `alterOperatorClass`
 
 #### `pgm.createOperatorFamily( operator_family_name, index_method )`
@@ -162,6 +180,24 @@
 | `old_operator_family_name` | [Name](/migrations/#type) | old name of the operator family             |
 | `index_method`             | `string`                  | name of the index method of operator family |
 | `new_operator_family_name` | [Name](/migrations/#type) | new name of the operator family             |
+
+See [Renaming and schemas](/migrations/#renaming-and-schemas) for schema
+normalization, automatic reversal, and supported `PgLiteral` names.
+The index access method identifies the operator family and is preserved during
+automatic reversal, including when another access method has the same object name.
+
+```javascript
+pgm.renameOperatorFamily({ schema: 'app', name: 'old_family' }, 'btree', {
+  schema: 'app',
+  name: 'new_family',
+});
+// up:   ALTER OPERATOR FAMILY "app"."old_family" USING btree RENAME TO "new_family";
+// down: ALTER OPERATOR FAMILY "app"."new_family" USING btree RENAME TO "old_family";
+```
+
+To move an operator family between schemas, use SQL explicitly, for example
+`pgm.sql('ALTER OPERATOR FAMILY "old_schema"."my_family" USING btree SET SCHEMA "new_schema"')`.
+Provide the corresponding SQL in your down migration to reverse that move.
 
 ## Operation: `alterOperatorFamily`
 

--- a/docs/src/migrations/operators.md
+++ b/docs/src/migrations/operators.md
@@ -116,6 +116,15 @@ See [Renaming and schemas](/migrations/#renaming-and-schemas) for schema
 normalization, automatic reversal, and supported `PgLiteral` names.
 The index access method identifies the operator class and is preserved during
 automatic reversal, including when another access method has the same object name.
+For both operator rename operations, `index_method` must be a string containing
+one unqualified PostgreSQL identifier, such as `'btree'` or `'"Custom.Method"'`.
+Accepted text is used as written, without extra quoting or decamelization.
+
+> [!WARNING]
+> These two renames now reject missing/non-string access methods, qualified names,
+> comments, and other SQL fragments in both directions. Previously valid raw
+> forms such as `'btree /* comment */'` must be replaced with a single identifier
+> when replaying migrations, or handled with explicit `pgm.sql` in both directions.
 
 ```javascript
 pgm.renameOperatorClass({ schema: 'app', name: 'old_class' }, 'btree', {
@@ -185,6 +194,7 @@ See [Renaming and schemas](/migrations/#renaming-and-schemas) for schema
 normalization, automatic reversal, and supported `PgLiteral` names.
 The index access method identifies the operator family and is preserved during
 automatic reversal, including when another access method has the same object name.
+The same [access-method requirements](#operation-renameoperatorclass) apply here.
 
 ```javascript
 pgm.renameOperatorFamily({ schema: 'app', name: 'old_family' }, 'btree', {

--- a/src/operations/createRenameOperation.ts
+++ b/src/operations/createRenameOperation.ts
@@ -3,7 +3,11 @@ import { isPgLiteral } from '../utils/PgLiteral';
 import type { Name, Reversible } from './generalTypes';
 import { isNameObject, isSchemaNameObject } from './generalTypes';
 
-type RenameFn = (source: Name, destination: Name) => string;
+type RenameFn = (
+  source: Name,
+  destination: Name,
+  sourceSuffix?: string
+) => string;
 
 interface RenameOptions {
   operation: string;
@@ -64,20 +68,20 @@ export function createRenameOperation(
     };
   };
 
-  const rename: RenameFn = (source, destination) => {
+  const rename: RenameFn = (source, destination, sourceSuffix = '') => {
     const { schemaSql, oldNameSql, newNameSql } = resolveNames(
       source,
       destination
     );
-    return `ALTER ${keyword} ${qualify(schemaSql, oldNameSql)} RENAME TO ${newNameSql};`;
+    return `ALTER ${keyword} ${qualify(schemaSql, oldNameSql)}${sourceSuffix} RENAME TO ${newNameSql};`;
   };
 
-  const reverse: RenameFn = (source, destination) => {
+  const reverse: RenameFn = (source, destination, sourceSuffix = '') => {
     const { schemaSql, oldNameSql, newNameSql } = resolveNames(
       source,
       destination
     );
-    return `ALTER ${keyword} ${qualify(schemaSql, newNameSql)} RENAME TO ${oldNameSql};`;
+    return `ALTER ${keyword} ${qualify(schemaSql, newNameSql)}${sourceSuffix} RENAME TO ${oldNameSql};`;
   };
 
   return Object.assign(rename, { reverse });

--- a/src/operations/createRenameOperation.ts
+++ b/src/operations/createRenameOperation.ts
@@ -1,4 +1,5 @@
 import type { MigrationOptions } from '../migrationOptions';
+import { isSingleIdentifier } from '../utils/isSingleIdentifier';
 import { isPgLiteral } from '../utils/PgLiteral';
 import type { Name, Reversible } from './generalTypes';
 import { isNameObject, isSchemaNameObject } from './generalTypes';
@@ -12,12 +13,6 @@ interface RenameOptions {
   sourceSuffix?: string;
 }
 
-// A single ordinary or double-quoted PostgreSQL identifier, with optional SQL
-// whitespace. Dots and doubled quotes inside a quoted identifier are content.
-// Raw SQL expressions, qualifications and U& escape syntax require explicit SQL.
-const SINGLE_IDENTIFIER =
-  /^[ \t\r\n\f\v]*(?:[A-Za-z_\u0080-\u{10FFFF}][A-Za-z0-9_$\u0080-\u{10FFFF}]*|"(?:[^"]|"")+")[ \t\r\n\f\v]*$/u;
-
 function qualify(schemaSql: string | undefined, nameSql: string): string {
   return schemaSql ? `${schemaSql}.${nameSql}` : nameSql;
 }
@@ -30,7 +25,7 @@ export function createRenameOperation(
   const nameParts = (value: Name, position: 'source' | 'destination') => {
     if (isPgLiteral(value)) {
       const nameSql = mOptions.literal(value);
-      if (nameSql.includes('\0') || !SINGLE_IDENTIFIER.test(nameSql)) {
+      if (!isSingleIdentifier(nameSql)) {
         throw new Error(
           `${operation} requires a single unqualified identifier for a PgLiteral ${position}; use { schema, name } for schema-qualified names`
         );

--- a/src/operations/createRenameOperation.ts
+++ b/src/operations/createRenameOperation.ts
@@ -3,16 +3,13 @@ import { isPgLiteral } from '../utils/PgLiteral';
 import type { Name, Reversible } from './generalTypes';
 import { isNameObject, isSchemaNameObject } from './generalTypes';
 
-type RenameFn = (
-  source: Name,
-  destination: Name,
-  sourceSuffix?: string
-) => string;
+type RenameFn = (source: Name, destination: Name) => string;
 
 interface RenameOptions {
   operation: string;
   keyword: string;
   label: string;
+  sourceSuffix?: string;
 }
 
 // A single ordinary or double-quoted PostgreSQL identifier, with optional SQL
@@ -28,7 +25,7 @@ function qualify(schemaSql: string | undefined, nameSql: string): string {
 /** Creates the reversible pair for an object renamed within its schema. */
 export function createRenameOperation(
   mOptions: MigrationOptions,
-  { operation, keyword, label }: RenameOptions
+  { operation, keyword, label, sourceSuffix = '' }: RenameOptions
 ): Reversible<RenameFn> {
   const nameParts = (value: Name, position: 'source' | 'destination') => {
     if (isPgLiteral(value)) {
@@ -68,7 +65,7 @@ export function createRenameOperation(
     };
   };
 
-  const rename: RenameFn = (source, destination, sourceSuffix = '') => {
+  const rename: RenameFn = (source, destination) => {
     const { schemaSql, oldNameSql, newNameSql } = resolveNames(
       source,
       destination
@@ -76,7 +73,7 @@ export function createRenameOperation(
     return `ALTER ${keyword} ${qualify(schemaSql, oldNameSql)}${sourceSuffix} RENAME TO ${newNameSql};`;
   };
 
-  const reverse: RenameFn = (source, destination, sourceSuffix = '') => {
+  const reverse: RenameFn = (source, destination) => {
     const { schemaSql, oldNameSql, newNameSql } = resolveNames(
       source,
       destination

--- a/src/operations/functions/renameFunction.ts
+++ b/src/operations/functions/renameFunction.ts
@@ -13,29 +13,22 @@ export type RenameFunctionFn = (
 export type RenameFunction = Reversible<RenameFunctionFn>;
 
 export function renameFunction(mOptions: MigrationOptions): RenameFunction {
-  const rename = createRenameOperation(mOptions, {
-    operation: 'renameFunction',
-    keyword: 'FUNCTION',
-    label: 'a function',
-  });
+  const rename = (functionParams: FunctionParam[]) =>
+    createRenameOperation(mOptions, {
+      operation: 'renameFunction',
+      keyword: 'FUNCTION',
+      label: 'a function',
+      sourceSuffix: formatParams(functionParams, mOptions),
+    });
 
   const _rename: RenameFunction = (
     oldFunctionName,
     functionParams = [],
     newFunctionName
-  ) =>
-    rename(
-      oldFunctionName,
-      newFunctionName,
-      formatParams(functionParams, mOptions)
-    );
+  ) => rename(functionParams)(oldFunctionName, newFunctionName);
 
   _rename.reverse = (oldFunctionName, functionParams = [], newFunctionName) =>
-    rename.reverse(
-      oldFunctionName,
-      newFunctionName,
-      formatParams(functionParams, mOptions)
-    );
+    rename(functionParams).reverse(oldFunctionName, newFunctionName);
 
   return _rename;
 }

--- a/src/operations/functions/renameFunction.ts
+++ b/src/operations/functions/renameFunction.ts
@@ -1,5 +1,6 @@
 import type { MigrationOptions } from '../../migrationOptions';
 import { formatParams } from '../../utils';
+import { createRenameOperation } from '../createRenameOperation';
 import type { Name, Reversible } from '../generalTypes';
 import type { FunctionParam } from './shared';
 
@@ -12,20 +13,29 @@ export type RenameFunctionFn = (
 export type RenameFunction = Reversible<RenameFunctionFn>;
 
 export function renameFunction(mOptions: MigrationOptions): RenameFunction {
+  const rename = createRenameOperation(mOptions, {
+    operation: 'renameFunction',
+    keyword: 'FUNCTION',
+    label: 'a function',
+  });
+
   const _rename: RenameFunction = (
     oldFunctionName,
     functionParams = [],
     newFunctionName
-  ) => {
-    const paramsStr = formatParams(functionParams, mOptions);
-    const oldFunctionNameStr = mOptions.literal(oldFunctionName);
-    const newFunctionNameStr = mOptions.literal(newFunctionName);
+  ) =>
+    rename(
+      oldFunctionName,
+      newFunctionName,
+      formatParams(functionParams, mOptions)
+    );
 
-    return `ALTER FUNCTION ${oldFunctionNameStr}${paramsStr} RENAME TO ${newFunctionNameStr};`;
-  };
-
-  _rename.reverse = (oldFunctionName, functionParams, newFunctionName) =>
-    _rename(newFunctionName, functionParams, oldFunctionName);
+  _rename.reverse = (oldFunctionName, functionParams = [], newFunctionName) =>
+    rename.reverse(
+      oldFunctionName,
+      newFunctionName,
+      formatParams(functionParams, mOptions)
+    );
 
   return _rename;
 }

--- a/src/operations/functions/renameFunction.ts
+++ b/src/operations/functions/renameFunction.ts
@@ -1,5 +1,5 @@
 import type { MigrationOptions } from '../../migrationOptions';
-import { formatParams } from '../../utils';
+import { formatFunctionIdentityParams } from '../../utils/formatParams';
 import { createRenameOperation } from '../createRenameOperation';
 import type { Name, Reversible } from '../generalTypes';
 import type { FunctionParam } from './shared';
@@ -18,7 +18,7 @@ export function renameFunction(mOptions: MigrationOptions): RenameFunction {
       operation: 'renameFunction',
       keyword: 'FUNCTION',
       label: 'a function',
-      sourceSuffix: formatParams(functionParams, mOptions),
+      sourceSuffix: formatFunctionIdentityParams(functionParams, mOptions),
     });
 
   const _rename: RenameFunction = (

--- a/src/operations/operators/formatIndexMethod.ts
+++ b/src/operations/operators/formatIndexMethod.ts
@@ -1,0 +1,13 @@
+import { isSingleIdentifier } from '../../utils/isSingleIdentifier';
+
+export function formatIndexMethod(
+  indexMethod: string,
+  operation: string
+): string {
+  if (!isSingleIdentifier(indexMethod)) {
+    throw new Error(
+      `${operation} requires indexMethod to be a string containing a single unqualified identifier`
+    );
+  }
+  return ` USING ${indexMethod}`;
+}

--- a/src/operations/operators/renameOperatorClass.ts
+++ b/src/operations/operators/renameOperatorClass.ts
@@ -1,4 +1,5 @@
 import type { MigrationOptions } from '../../migrationOptions';
+import { createRenameOperation } from '../createRenameOperation';
 import type { Name, Reversible } from '../generalTypes';
 
 export type RenameOperatorClassFn = (
@@ -12,19 +13,25 @@ export type RenameOperatorClass = Reversible<RenameOperatorClassFn>;
 export function renameOperatorClass(
   mOptions: MigrationOptions
 ): RenameOperatorClass {
+  const rename = createRenameOperation(mOptions, {
+    operation: 'renameOperatorClass',
+    keyword: 'OPERATOR CLASS',
+    label: 'an operator class',
+  });
+
   const _rename: RenameOperatorClass = (
     oldOperatorClassName,
     indexMethod,
     newOperatorClassName
-  ) => {
-    const oldOperatorClassNameStr = mOptions.literal(oldOperatorClassName);
-    const newOperatorClassNameStr = mOptions.literal(newOperatorClassName);
-
-    return `ALTER OPERATOR CLASS ${oldOperatorClassNameStr} USING ${indexMethod} RENAME TO ${newOperatorClassNameStr};`;
-  };
+  ) =>
+    rename(oldOperatorClassName, newOperatorClassName, ` USING ${indexMethod}`);
 
   _rename.reverse = (oldOperatorClassName, indexMethod, newOperatorClassName) =>
-    _rename(newOperatorClassName, indexMethod, oldOperatorClassName);
+    rename.reverse(
+      oldOperatorClassName,
+      newOperatorClassName,
+      ` USING ${indexMethod}`
+    );
 
   return _rename;
 }

--- a/src/operations/operators/renameOperatorClass.ts
+++ b/src/operations/operators/renameOperatorClass.ts
@@ -13,25 +13,22 @@ export type RenameOperatorClass = Reversible<RenameOperatorClassFn>;
 export function renameOperatorClass(
   mOptions: MigrationOptions
 ): RenameOperatorClass {
-  const rename = createRenameOperation(mOptions, {
-    operation: 'renameOperatorClass',
-    keyword: 'OPERATOR CLASS',
-    label: 'an operator class',
-  });
+  const rename = (indexMethod: string) =>
+    createRenameOperation(mOptions, {
+      operation: 'renameOperatorClass',
+      keyword: 'OPERATOR CLASS',
+      label: 'an operator class',
+      sourceSuffix: ` USING ${indexMethod}`,
+    });
 
   const _rename: RenameOperatorClass = (
     oldOperatorClassName,
     indexMethod,
     newOperatorClassName
-  ) =>
-    rename(oldOperatorClassName, newOperatorClassName, ` USING ${indexMethod}`);
+  ) => rename(indexMethod)(oldOperatorClassName, newOperatorClassName);
 
   _rename.reverse = (oldOperatorClassName, indexMethod, newOperatorClassName) =>
-    rename.reverse(
-      oldOperatorClassName,
-      newOperatorClassName,
-      ` USING ${indexMethod}`
-    );
+    rename(indexMethod).reverse(oldOperatorClassName, newOperatorClassName);
 
   return _rename;
 }

--- a/src/operations/operators/renameOperatorClass.ts
+++ b/src/operations/operators/renameOperatorClass.ts
@@ -1,6 +1,7 @@
 import type { MigrationOptions } from '../../migrationOptions';
 import { createRenameOperation } from '../createRenameOperation';
 import type { Name, Reversible } from '../generalTypes';
+import { formatIndexMethod } from './formatIndexMethod';
 
 export type RenameOperatorClassFn = (
   oldOperatorClassName: Name,
@@ -18,7 +19,7 @@ export function renameOperatorClass(
       operation: 'renameOperatorClass',
       keyword: 'OPERATOR CLASS',
       label: 'an operator class',
-      sourceSuffix: ` USING ${indexMethod}`,
+      sourceSuffix: formatIndexMethod(indexMethod, 'renameOperatorClass'),
     });
 
   const _rename: RenameOperatorClass = (

--- a/src/operations/operators/renameOperatorFamily.ts
+++ b/src/operations/operators/renameOperatorFamily.ts
@@ -1,6 +1,7 @@
 import type { MigrationOptions } from '../../migrationOptions';
 import { createRenameOperation } from '../createRenameOperation';
 import type { Name, Reversible } from '../generalTypes';
+import { formatIndexMethod } from './formatIndexMethod';
 
 export type RenameOperatorFamilyFn = (
   oldOperatorFamilyName: Name,
@@ -18,7 +19,7 @@ export function renameOperatorFamily(
       operation: 'renameOperatorFamily',
       keyword: 'OPERATOR FAMILY',
       label: 'an operator family',
-      sourceSuffix: ` USING ${indexMethod}`,
+      sourceSuffix: formatIndexMethod(indexMethod, 'renameOperatorFamily'),
     });
 
   const _rename: RenameOperatorFamily = (

--- a/src/operations/operators/renameOperatorFamily.ts
+++ b/src/operations/operators/renameOperatorFamily.ts
@@ -13,33 +13,26 @@ export type RenameOperatorFamily = Reversible<RenameOperatorFamilyFn>;
 export function renameOperatorFamily(
   mOptions: MigrationOptions
 ): RenameOperatorFamily {
-  const rename = createRenameOperation(mOptions, {
-    operation: 'renameOperatorFamily',
-    keyword: 'OPERATOR FAMILY',
-    label: 'an operator family',
-  });
+  const rename = (indexMethod: string) =>
+    createRenameOperation(mOptions, {
+      operation: 'renameOperatorFamily',
+      keyword: 'OPERATOR FAMILY',
+      label: 'an operator family',
+      sourceSuffix: ` USING ${indexMethod}`,
+    });
 
   const _rename: RenameOperatorFamily = (
     oldOperatorFamilyName,
     indexMethod,
     newOperatorFamilyName
-  ) =>
-    rename(
-      oldOperatorFamilyName,
-      newOperatorFamilyName,
-      ` USING ${indexMethod}`
-    );
+  ) => rename(indexMethod)(oldOperatorFamilyName, newOperatorFamilyName);
 
   _rename.reverse = (
     oldOperatorFamilyName,
     indexMethod,
     newOperatorFamilyName
   ) =>
-    rename.reverse(
-      oldOperatorFamilyName,
-      newOperatorFamilyName,
-      ` USING ${indexMethod}`
-    );
+    rename(indexMethod).reverse(oldOperatorFamilyName, newOperatorFamilyName);
 
   return _rename;
 }

--- a/src/operations/operators/renameOperatorFamily.ts
+++ b/src/operations/operators/renameOperatorFamily.ts
@@ -1,4 +1,5 @@
 import type { MigrationOptions } from '../../migrationOptions';
+import { createRenameOperation } from '../createRenameOperation';
 import type { Name, Reversible } from '../generalTypes';
 
 export type RenameOperatorFamilyFn = (
@@ -12,22 +13,33 @@ export type RenameOperatorFamily = Reversible<RenameOperatorFamilyFn>;
 export function renameOperatorFamily(
   mOptions: MigrationOptions
 ): RenameOperatorFamily {
+  const rename = createRenameOperation(mOptions, {
+    operation: 'renameOperatorFamily',
+    keyword: 'OPERATOR FAMILY',
+    label: 'an operator family',
+  });
+
   const _rename: RenameOperatorFamily = (
     oldOperatorFamilyName,
     indexMethod,
     newOperatorFamilyName
-  ) => {
-    const oldOperatorFamilyNameStr = mOptions.literal(oldOperatorFamilyName);
-    const newOperatorFamilyNameStr = mOptions.literal(newOperatorFamilyName);
-
-    return `ALTER OPERATOR FAMILY ${oldOperatorFamilyNameStr} USING ${indexMethod} RENAME TO ${newOperatorFamilyNameStr};`;
-  };
+  ) =>
+    rename(
+      oldOperatorFamilyName,
+      newOperatorFamilyName,
+      ` USING ${indexMethod}`
+    );
 
   _rename.reverse = (
     oldOperatorFamilyName,
     indexMethod,
     newOperatorFamilyName
-  ) => _rename(newOperatorFamilyName, indexMethod, oldOperatorFamilyName);
+  ) =>
+    rename.reverse(
+      oldOperatorFamilyName,
+      newOperatorFamilyName,
+      ` USING ${indexMethod}`
+    );
 
   return _rename;
 }

--- a/src/utils/formatParams.ts
+++ b/src/utils/formatParams.ts
@@ -3,7 +3,8 @@ import type { MigrationOptions } from '../migrationOptions';
 import type { FunctionParam } from '../operations/functions';
 
 function formatParam(
-  mOptions: MigrationOptions
+  mOptions: MigrationOptions,
+  includeDefaults: boolean
 ): (param: FunctionParam) => string {
   return (param) => {
     const {
@@ -27,7 +28,7 @@ function formatParam(
       options.push(type);
     }
 
-    if (defaultValue !== undefined) {
+    if (includeDefaults && defaultValue !== undefined) {
       options.push(`DEFAULT ${escapeValue(defaultValue)}`);
     }
 
@@ -39,5 +40,13 @@ export function formatParams(
   params: ReadonlyArray<FunctionParam>,
   mOptions: MigrationOptions
 ): string {
-  return `(${params.map(formatParam(mOptions)).join(', ')})`;
+  return `(${params.map(formatParam(mOptions, true)).join(', ')})`;
+}
+
+/** Format a function identity without defaults, including shorthand defaults. */
+export function formatFunctionIdentityParams(
+  params: ReadonlyArray<FunctionParam>,
+  mOptions: MigrationOptions
+): string {
+  return `(${params.map(formatParam(mOptions, false)).join(', ')})`;
 }

--- a/src/utils/isSingleIdentifier.ts
+++ b/src/utils/isSingleIdentifier.ts
@@ -1,0 +1,13 @@
+// A single ordinary or double-quoted PostgreSQL identifier, with optional SQL
+// whitespace. Dots and doubled quotes inside a quoted identifier are content.
+// Raw SQL expressions, qualifications and U& escape syntax require explicit SQL.
+const SINGLE_IDENTIFIER =
+  /^[ \t\r\n\f\v]*(?:[A-Za-z_\u0080-\u{10FFFF}][A-Za-z0-9_$\u0080-\u{10FFFF}]*|"(?:[^"]|"")+")[ \t\r\n\f\v]*$/u;
+
+export function isSingleIdentifier(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    !value.includes('\0') &&
+    SINGLE_IDENTIFIER.test(value)
+  );
+}

--- a/test/integration/rename-identity-it.spec.ts
+++ b/test/integration/rename-identity-it.spec.ts
@@ -155,6 +155,92 @@ const scenarios: Array<{
   },
 ];
 
+const functionsWithDefaults: Array<{
+  title: string;
+  params: FunctionParam[];
+  returns: string;
+  expected: unknown;
+}> = [
+  {
+    title: 'named IN parameter',
+    params: [{ mode: 'IN', name: 'inputValue', type: 'integer', default: 1 }],
+    returns: 'integer',
+    expected: 1,
+  },
+  {
+    title: 'zero',
+    params: [{ type: 'int', default: 0 }],
+    returns: 'integer',
+    expected: 0,
+  },
+  {
+    title: 'false',
+    params: [{ type: 'bool', default: false }],
+    returns: 'boolean',
+    expected: false,
+  },
+  {
+    title: 'empty string',
+    params: [{ type: 'string', default: '' }],
+    returns: 'text',
+    expected: '',
+  },
+  {
+    title: 'null',
+    params: [{ type: 'integer', default: null }],
+    returns: 'integer',
+    expected: null,
+  },
+  {
+    title: 'literal expression',
+    params: [{ type: 'integer', default: PgLiteral.create('1 + 2') }],
+    returns: 'integer',
+    expected: 3,
+  },
+  {
+    title: 'string shorthand',
+    params: ['inherited'],
+    returns: 'integer',
+    expected: 2,
+  },
+  {
+    title: 'nested object shorthand',
+    params: [{ type: 'nested', name: 'inputValue' }],
+    returns: 'integer',
+    expected: 2,
+  },
+  {
+    title: 'INOUT parameter',
+    params: [
+      { mode: 'INOUT', name: 'inputValue', type: 'integer', default: 1 },
+    ],
+    returns: 'integer',
+    expected: 1,
+  },
+  {
+    title: 'OUT with input default',
+    params: [
+      { mode: 'IN', name: 'inputValue', type: 'integer', default: 1 },
+      { mode: 'OUT', name: 'resultValue', type: 'integer' },
+    ],
+    returns: 'integer',
+    expected: 1,
+  },
+  {
+    title: 'VARIADIC parameter',
+    params: [
+      {
+        mode: 'VARIADIC',
+        name: 'inputValues',
+        type: 'integer[]',
+        default: PgLiteral.create('ARRAY[1, 2]'),
+      },
+    ],
+    returns: 'integer[]',
+    expected: [1, 2],
+  },
+];
+
 describe.each(PG_VERSIONS)(
   'schema-aware rename identities (PG %s)',
   { timeout: INTEGRATION_TIMEOUT },
@@ -335,6 +421,107 @@ describe.each(PG_VERSIONS)(
             expect(await objects('decoy_schema')).toEqual(decoys);
           }
         );
+      }
+    );
+
+    it.each(functionsWithDefaults)(
+      'preserves stored defaults and overloads through a rename chain: $title',
+      async ({ params, returns, expected }) => {
+        const typeShorthands = {
+          inherited: { type: 'int', default: 2 },
+          nested: 'inherited',
+        };
+        const builder = () =>
+          new MigrationBuilder(db(client), typeShorthands, true, console);
+        await client.query('SET LOCAL search_path TO decoy_schema, app_schema');
+
+        const creation = builder();
+        creation.createFunction(
+          { schema: 'appSchema', name: 'oldName' },
+          params,
+          { language: 'sql', returns },
+          'SELECT $1'
+        );
+        for (const sql of creation.getSqlSteps()) {
+          await client.query(sql);
+        }
+
+        const otherIdentity = returns === 'text' ? 'integer' : 'text';
+        for (const name of ['old_name', 'middle_name', 'new_name']) {
+          await client.query(
+            `CREATE FUNCTION decoy_schema.${quote(name)}(${returns}) RETURNS integer LANGUAGE SQL AS 'SELECT 9'`
+          );
+          await client.query(
+            `CREATE FUNCTION app_schema.${quote(name)}(${otherIdentity}) RETURNS integer LANGUAGE SQL AS 'SELECT 8'`
+          );
+        }
+
+        async function catalog() {
+          return (
+            await client.query<{
+              schema: string;
+              name: string;
+              oid: string;
+              identity: string;
+              defaults: string | null;
+              defaultCount: number;
+            }>(`SELECT n.nspname AS schema, p.proname AS name, p.oid::text AS oid,
+              pg_catalog.oidvectortypes(p.proargtypes) AS identity,
+              pg_catalog.pg_get_expr(p.proargdefaults, 0) AS defaults,
+              p.pronargdefaults AS "defaultCount"
+            FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+            WHERE n.nspname IN ('app_schema', 'decoy_schema') ORDER BY p.oid`)
+          ).rows;
+        }
+
+        const before = await catalog();
+        const target = before.find(
+          (row) =>
+            row.schema === 'app_schema' &&
+            row.name === 'old_name' &&
+            row.identity === returns
+        );
+        expect(before).toHaveLength(7);
+        expect(target?.defaultCount).toBe(1);
+        expect(target?.defaults).toBeTypeOf('string');
+
+        function migrate(pgm: MigrationBuilder) {
+          pgm.renameFunction({ schema: 'appSchema', name: 'oldName' }, params, {
+            schema: 'app_schema',
+            name: 'middleName',
+          });
+          pgm.renameFunction(
+            { schema: 'app_schema', name: 'middleName' },
+            params,
+            'newName'
+          );
+        }
+
+        const up = builder();
+        migrate(up);
+        for (const sql of up.getSqlSteps()) {
+          await client.query(sql);
+        }
+        expect(await catalog()).toEqual(
+          before.map((row) =>
+            row.oid === target?.oid ? { ...row, name: 'new_name' } : row
+          )
+        );
+        expect(
+          (await client.query('SELECT app_schema.new_name() AS value')).rows[0]
+            .value
+        ).toEqual(expected);
+
+        const down = builder().enableReverseMode();
+        migrate(down);
+        for (const sql of down.getSqlSteps()) {
+          await client.query(sql);
+        }
+        expect(await catalog()).toEqual(before);
+        expect(
+          (await client.query('SELECT app_schema.old_name() AS value')).rows[0]
+            .value
+        ).toEqual(expected);
       }
     );
   }

--- a/test/integration/rename-identity-it.spec.ts
+++ b/test/integration/rename-identity-it.spec.ts
@@ -25,6 +25,7 @@ const operations: Array<{
   operation: 'renameFunction' | 'renameOperatorClass' | 'renameOperatorFamily';
   identity: string;
   otherIdentity: string;
+  indexMethod?: string;
   params?: FunctionParam[];
 }> = [
   {
@@ -67,6 +68,18 @@ const operations: Array<{
     operation: 'renameOperatorFamily',
     identity: 'hash',
     otherIdentity: 'btree',
+  },
+  {
+    operation: 'renameOperatorClass',
+    identity: 'Custom.Method',
+    otherIdentity: 'hash',
+    indexMethod: '"Custom.Method"',
+  },
+  {
+    operation: 'renameOperatorFamily',
+    identity: 'Custom.Method',
+    otherIdentity: 'hash',
+    indexMethod: '"Custom.Method"',
   },
 ];
 
@@ -180,18 +193,23 @@ describe.each(PG_VERSIONS)(
 
     describe.each(operations)(
       '$operation ($identity)',
-      ({ operation, identity, otherIdentity, params }) => {
+      ({ operation, identity, otherIdentity, params, indexMethod }) => {
         const rename: Rename = (pgm, source, destination) => {
           if (operation === 'renameFunction') {
             pgm.renameFunction(source, params ?? [], destination);
           } else {
-            pgm[operation](source, identity, destination);
+            pgm[operation](source, indexMethod ?? identity, destination);
           }
         };
 
         it.each(scenarios)(
           '$title',
           async ({ original, final, qualified, migrate }) => {
+            if (indexMethod) {
+              await client.query(
+                'CREATE ACCESS METHOD "Custom.Method" TYPE INDEX HANDLER pg_catalog.bthandler'
+              );
+            }
             // Qualified calls must bypass the first search-path entry. Other
             // overloads/access methods must also survive every rename unchanged.
             await client.query(
@@ -212,7 +230,7 @@ describe.each(PG_VERSIONS)(
                 );
               } else if (operation === 'renameOperatorFamily') {
                 await client.query(
-                  `CREATE OPERATOR FAMILY ${qualifiedName} USING ${objectIdentity}`
+                  `CREATE OPERATOR FAMILY ${qualifiedName} USING ${quote(objectIdentity)}`
                 );
               } else {
                 const definition =
@@ -225,7 +243,7 @@ describe.each(PG_VERSIONS)(
                  OPERATOR 5 pg_catalog.> (integer, integer),
                  FUNCTION 1 pg_catalog.btint4cmp(integer, integer)`;
                 await client.query(
-                  `CREATE OPERATOR CLASS ${qualifiedName} FOR TYPE integer USING ${objectIdentity} AS ${definition}`
+                  `CREATE OPERATOR CLASS ${qualifiedName} FOR TYPE integer USING ${quote(objectIdentity)} AS ${definition}`
                 );
               }
             }

--- a/test/integration/rename-identity-it.spec.ts
+++ b/test/integration/rename-identity-it.spec.ts
@@ -1,0 +1,323 @@
+import type { StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import pg from 'pg';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import type { FunctionParam, Name } from '../../src';
+import { MigrationBuilder, PgLiteral } from '../../src';
+import { db } from '../../src/db';
+import { quote } from '../../src/utils/quote';
+import {
+  INTEGRATION_TIMEOUT,
+  PG_VERSIONS,
+  setupPostgresDatabase,
+} from './utils';
+
+type Rename = (pgm: MigrationBuilder, source: Name, destination: Name) => void;
+
+const operations: Array<{
+  operation: 'renameFunction' | 'renameOperatorClass' | 'renameOperatorFamily';
+  identity: string;
+  otherIdentity: string;
+  params?: FunctionParam[];
+}> = [
+  {
+    operation: 'renameFunction',
+    identity: '',
+    otherIdentity: 'text',
+    params: [],
+  },
+  {
+    operation: 'renameFunction',
+    identity: 'integer',
+    otherIdentity: 'text',
+    params: ['integer'],
+  },
+  {
+    operation: 'renameFunction',
+    identity: 'integer, text',
+    otherIdentity: 'text',
+    params: [
+      { mode: 'IN', name: 'inputValue', type: 'integer' },
+      { mode: 'IN', name: 'otherValue', type: 'text' },
+    ],
+  },
+  {
+    operation: 'renameOperatorClass',
+    identity: 'btree',
+    otherIdentity: 'hash',
+  },
+  {
+    operation: 'renameOperatorClass',
+    identity: 'hash',
+    otherIdentity: 'btree',
+  },
+  {
+    operation: 'renameOperatorFamily',
+    identity: 'btree',
+    otherIdentity: 'hash',
+  },
+  {
+    operation: 'renameOperatorFamily',
+    identity: 'hash',
+    otherIdentity: 'btree',
+  },
+];
+
+const scenarios: Array<{
+  title: string;
+  original: string;
+  final: string;
+  qualified: boolean;
+  migrate: (pgm: MigrationBuilder, rename: Rename) => void;
+}> = [
+  {
+    title: 'rendered schema equality and empty destination in a rename chain',
+    original: 'old_name',
+    final: 'new_name',
+    qualified: true,
+    migrate: (pgm, rename) => {
+      rename(
+        pgm,
+        { schema: 'appSchema', name: 'oldName' },
+        { schema: 'app_schema', name: 'middleName' }
+      );
+      rename(
+        pgm,
+        { schema: 'app_schema', name: 'middleName' },
+        { schema: '', name: 'newName' }
+      );
+    },
+  },
+  {
+    title: 'empty and omitted schemas in both argument orders',
+    original: 'old_name',
+    final: 'new_name',
+    qualified: false,
+    migrate: (pgm, rename) => {
+      rename(pgm, { schema: '', name: 'oldName' }, { name: 'middleName' });
+      rename(pgm, { name: 'middleName' }, { schema: '', name: 'newName' });
+    },
+  },
+  {
+    title: 'quoted raw destination with dots, escaped quotes and whitespace',
+    original: 'old_name',
+    final: 'New.Name"Quoted',
+    qualified: true,
+    migrate: (pgm, rename) => {
+      rename(
+        pgm,
+        { schema: 'appSchema', name: 'oldName' },
+        PgLiteral.create(' \t"New.Name""Quoted"\n')
+      );
+    },
+  },
+  {
+    title: 'unquoted raw destination preserves PostgreSQL case folding',
+    original: 'old_name',
+    final: 'newname',
+    qualified: true,
+    migrate: (pgm, rename) => {
+      rename(
+        pgm,
+        { schema: 'appSchema', name: 'oldName' },
+        PgLiteral.create('NewName')
+      );
+    },
+  },
+  {
+    title: 'unqualified raw source during automatic reversal',
+    original: 'oldname',
+    final: 'new_name',
+    qualified: false,
+    migrate: (pgm, rename) => {
+      rename(pgm, PgLiteral.create('OldName'), 'newName');
+    },
+  },
+];
+
+describe.each(PG_VERSIONS)(
+  'schema-aware rename identities (PG %s)',
+  { timeout: INTEGRATION_TIMEOUT },
+  (version) => {
+    let container: StartedPostgreSqlContainer;
+    let client: pg.Client;
+
+    beforeAll(async () => {
+      container = await setupPostgresDatabase(
+        `postgres:${version}-alpine`,
+        'rename_identities'
+      );
+      client = new pg.Client(container.getConnectionUri());
+      await client.connect();
+    }, INTEGRATION_TIMEOUT);
+
+    afterAll(async () => {
+      if (client) {
+        await client.end();
+      }
+      if (container) {
+        await container.stop();
+      }
+    });
+
+    beforeEach(async () => {
+      await client.query('BEGIN');
+      await client.query(
+        'CREATE SCHEMA app_schema; CREATE SCHEMA decoy_schema'
+      );
+    });
+
+    afterEach(async () => {
+      await client.query('ROLLBACK');
+    });
+
+    describe.each(operations)(
+      '$operation ($identity)',
+      ({ operation, identity, otherIdentity, params }) => {
+        const rename: Rename = (pgm, source, destination) => {
+          if (operation === 'renameFunction') {
+            pgm.renameFunction(source, params ?? [], destination);
+          } else {
+            pgm[operation](source, identity, destination);
+          }
+        };
+
+        it.each(scenarios)(
+          '$title',
+          async ({ original, final, qualified, migrate }) => {
+            // Qualified calls must bypass the first search-path entry. Other
+            // overloads/access methods must also survive every rename unchanged.
+            await client.query(
+              qualified
+                ? 'SET LOCAL search_path TO decoy_schema, app_schema'
+                : 'SET LOCAL search_path TO app_schema, decoy_schema'
+            );
+
+            async function createObject(
+              schema: string,
+              name: string,
+              objectIdentity: string
+            ) {
+              const qualifiedName = `${quote(schema)}.${quote(name)}`;
+              if (operation === 'renameFunction') {
+                await client.query(
+                  `CREATE FUNCTION ${qualifiedName}(${objectIdentity}) RETURNS integer LANGUAGE SQL AS 'SELECT 1'`
+                );
+              } else if (operation === 'renameOperatorFamily') {
+                await client.query(
+                  `CREATE OPERATOR FAMILY ${qualifiedName} USING ${objectIdentity}`
+                );
+              } else {
+                const definition =
+                  objectIdentity === 'hash'
+                    ? 'OPERATOR 1 pg_catalog.= (integer, integer), FUNCTION 1 pg_catalog.hashint4(integer)'
+                    : `OPERATOR 1 pg_catalog.< (integer, integer),
+                 OPERATOR 2 pg_catalog.<= (integer, integer),
+                 OPERATOR 3 pg_catalog.= (integer, integer),
+                 OPERATOR 4 pg_catalog.>= (integer, integer),
+                 OPERATOR 5 pg_catalog.> (integer, integer),
+                 FUNCTION 1 pg_catalog.btint4cmp(integer, integer)`;
+                await client.query(
+                  `CREATE OPERATOR CLASS ${qualifiedName} FOR TYPE integer USING ${objectIdentity} AS ${definition}`
+                );
+              }
+            }
+
+            async function objects(schema: string) {
+              const catalog =
+                operation === 'renameFunction'
+                  ? 'pg_proc'
+                  : operation === 'renameOperatorClass'
+                    ? 'pg_opclass'
+                    : 'pg_opfamily';
+              const prefix =
+                operation === 'renameFunction'
+                  ? 'pro'
+                  : operation === 'renameOperatorClass'
+                    ? 'opc'
+                    : 'opf';
+              const identitySql =
+                operation === 'renameFunction'
+                  ? 'pg_catalog.oidvectortypes(o.proargtypes)'
+                  : 'a.amname';
+              const accessMethodJoin =
+                operation === 'renameFunction'
+                  ? ''
+                  : `JOIN pg_am a ON a.oid = o.${prefix}method`;
+              const result = await client.query<{
+                name: string;
+                oid: string;
+                identity: string;
+              }>(
+                `SELECT o.${prefix}name AS name, o.oid::text AS oid, ${identitySql} AS identity
+             FROM ${catalog} o JOIN pg_namespace n ON n.oid = o.${prefix}namespace
+             ${accessMethodJoin}
+             WHERE n.nspname = $1 AND o.${prefix}name = ANY($2::text[])
+             ORDER BY name, identity`,
+                [schema, [original, 'middle_name', final]]
+              );
+              return result.rows;
+            }
+
+            await createObject('app_schema', original, identity);
+            for (const name of [original, 'middle_name', final]) {
+              await createObject('decoy_schema', name, identity);
+              await createObject('app_schema', name, otherIdentity);
+            }
+            const before = await objects('app_schema');
+            const decoys = await objects('decoy_schema');
+            const target = before.find(
+              (object) => object.identity === identity
+            );
+            expect(before).toHaveLength(4);
+            expect(decoys).toHaveLength(3);
+            expect(target).toBeDefined();
+
+            const up = new MigrationBuilder(
+              db(client),
+              undefined,
+              true,
+              console
+            );
+            migrate(up, rename);
+            for (const sql of up.getSqlSteps()) {
+              await client.query(sql);
+            }
+            const after = await objects('app_schema');
+            expect(after).toHaveLength(4);
+            expect(
+              after.filter((object) => object.identity === identity)
+            ).toEqual([{ name: final, oid: target?.oid, identity }]);
+            expect(
+              after.filter((object) => object.identity === otherIdentity)
+            ).toEqual(
+              before.filter((object) => object.identity === otherIdentity)
+            );
+            expect(await objects('decoy_schema')).toEqual(decoys);
+
+            const down = new MigrationBuilder(
+              db(client),
+              undefined,
+              true,
+              console
+            );
+            down.enableReverseMode();
+            migrate(down, rename);
+            for (const sql of down.getSqlSteps()) {
+              await client.query(sql);
+            }
+            expect(await objects('app_schema')).toEqual(before);
+            expect(await objects('decoy_schema')).toEqual(decoys);
+          }
+        );
+      }
+    );
+  }
+);

--- a/test/operations/createRenameOperation.spec.ts
+++ b/test/operations/createRenameOperation.spec.ts
@@ -17,17 +17,47 @@ describe('operations', () => {
           operation: 'rename',
           keyword,
           label: 'an object',
+          sourceSuffix: suffix,
         });
         const source = { schema: 'app', name: 'old' };
         const destination = { schema: 'app', name: 'new' };
 
-        expect(rename(source, destination, suffix)).toBe(
+        expect(rename(source, destination)).toBe(
           `ALTER ${keyword} "app"."old"${expectedSuffix} RENAME TO "new";`
         );
-        expect(rename.reverse(source, destination, suffix)).toBe(
+        expect(rename.reverse(source, destination)).toBe(
           `ALTER ${keyword} "app"."new"${expectedSuffix} RENAME TO "old";`
         );
       }
     );
+
+    it('keeps each identity independent of other pairs and extra arguments', () => {
+      const options = {
+        operation: 'renameFunction',
+        keyword: 'FUNCTION',
+        label: 'a function',
+      };
+      const first = createRenameOperation(options1, {
+        ...options,
+        sourceSuffix: '(integer)',
+      });
+      const second = createRenameOperation(options1, {
+        ...options,
+        sourceSuffix: '()',
+      });
+      const plain = createRenameOperation(options1, {
+        ...options,
+        keyword: 'TABLE',
+      });
+
+      expect(Reflect.apply(first, undefined, ['a', 'b', '(text)'])).toBe(
+        'ALTER FUNCTION "a"(integer) RENAME TO "b";'
+      );
+      expect(second('a', 'b')).toBe('ALTER FUNCTION "a"() RENAME TO "b";');
+      expect(
+        Reflect.apply(first.reverse, undefined, ['a', 'b', '(text)'])
+      ).toBe('ALTER FUNCTION "b"(integer) RENAME TO "a";');
+      expect(plain('a', 'b')).toBe('ALTER TABLE "a" RENAME TO "b";');
+    });
   });
 });

--- a/test/operations/createRenameOperation.spec.ts
+++ b/test/operations/createRenameOperation.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { createRenameOperation } from '../../src/operations/createRenameOperation';
+import { options1 } from '../presetMigrationOptions';
+
+describe('operations', () => {
+  describe('createRenameOperation', () => {
+    it.each([
+      ['TABLE', undefined, ''],
+      ['FUNCTION', '()', '()'],
+      ['FUNCTION', '(integer, text)', '(integer, text)'],
+      ['OPERATOR CLASS', ' USING btree', ' USING btree'],
+      ['OPERATOR FAMILY', ' USING hash', ' USING hash'],
+    ])(
+      'preserves the source identity for %s with suffix %j',
+      (keyword, suffix, expectedSuffix) => {
+        const rename = createRenameOperation(options1, {
+          operation: 'rename',
+          keyword,
+          label: 'an object',
+        });
+        const source = { schema: 'app', name: 'old' };
+        const destination = { schema: 'app', name: 'new' };
+
+        expect(rename(source, destination, suffix)).toBe(
+          `ALTER ${keyword} "app"."old"${expectedSuffix} RENAME TO "new";`
+        );
+        expect(rename.reverse(source, destination, suffix)).toBe(
+          `ALTER ${keyword} "app"."new"${expectedSuffix} RENAME TO "old";`
+        );
+      }
+    );
+  });
+});

--- a/test/operations/functions/renameFunction.spec.ts
+++ b/test/operations/functions/renameFunction.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import type { FunctionParam } from '../../../src';
 import { renameFunction } from '../../../src/operations/functions';
-import { options1 } from '../../presetMigrationOptions';
+import { options1, options2 } from '../../presetMigrationOptions';
 
 describe('operations', () => {
   describe('functions', () => {
@@ -11,13 +12,75 @@ describe('operations', () => {
         expect(renameFunctionFn).toBeTypeOf('function');
       });
 
-      it('should return sql statement with domainOptions default', () => {
+      it('should return sql statement for a function signature', () => {
         const statement = renameFunctionFn('sqrt', ['integer'], 'square_root');
 
         expect(statement).toBeTypeOf('string');
         expect(statement).toBe(
           'ALTER FUNCTION "sqrt"(integer) RENAME TO "square_root";'
         );
+      });
+
+      describe.each(['up', 'down'] as const)('%s identity', (direction) => {
+        const rename = renameFunction({
+          ...options2,
+          typeShorthands: { customId: 'integer' },
+        });
+        const operation = direction === 'down' ? rename.reverse : rename;
+        const identities: Array<{ params: FunctionParam[]; sql: string }> = [
+          { params: [], sql: '()' },
+          { params: ['integer', 'text[]'], sql: '(integer, text[])' },
+          { params: ['customId'], sql: '(integer)' },
+          {
+            params: ['"custom_schema"."custom_type"'],
+            sql: '("custom_schema"."custom_type")',
+          },
+          {
+            params: [
+              { mode: 'IN', name: 'inputValue', type: 'integer' },
+              { mode: 'OUT', name: 'resultValue', type: 'text' },
+            ],
+            sql: '(IN "input_value" integer, OUT "result_value" text)',
+          },
+          {
+            params: [{ mode: 'INOUT', name: 'mixedValue', type: 'integer' }],
+            sql: '(INOUT "mixed_value" integer)',
+          },
+          {
+            params: [{ mode: 'VARIADIC', name: 'otherValues', type: 'text[]' }],
+            sql: '(VARIADIC "other_values" text[])',
+          },
+        ];
+
+        it.each(identities)(
+          'preserves the signature $sql',
+          ({ params, sql }) => {
+            expect(
+              operation({ schema: 'appSchema', name: 'oldName' }, params, {
+                schema: 'app_schema',
+                name: 'newName',
+              })
+            ).toBe(
+              direction === 'down'
+                ? `ALTER FUNCTION "app_schema"."new_name"${sql} RENAME TO "old_name";`
+                : `ALTER FUNCTION "app_schema"."old_name"${sql} RENAME TO "new_name";`
+            );
+          }
+        );
+
+        it('defaults undefined parameters to an empty signature at runtime', () => {
+          expect(
+            Reflect.apply(operation, undefined, [
+              { schema: 'appSchema', name: 'oldName' },
+              undefined,
+              'newName',
+            ])
+          ).toBe(
+            direction === 'down'
+              ? 'ALTER FUNCTION "app_schema"."new_name"() RENAME TO "old_name";'
+              : 'ALTER FUNCTION "app_schema"."old_name"() RENAME TO "new_name";'
+          );
+        });
       });
 
       describe('reverse', () => {

--- a/test/operations/functions/renameFunctionDefaults.spec.ts
+++ b/test/operations/functions/renameFunctionDefaults.spec.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { FunctionParam } from '../../../src';
+import { MigrationBuilder, PgLiteral } from '../../../src';
+import {
+  createFunction,
+  renameFunction,
+} from '../../../src/operations/functions';
+import { options2 } from '../../presetMigrationOptions';
+
+const typeShorthands = Object.freeze({
+  inherited: Object.freeze({ type: 'int', default: 2 }),
+  nested: 'inherited',
+});
+
+const cases: Array<{
+  title: string;
+  params: FunctionParam[];
+  identity: string;
+  definition: string;
+}> = [
+  {
+    title: 'named input',
+    params: [{ mode: 'IN', name: 'inputValue', type: 'integer', default: 1 }],
+    identity: '(IN "input_value" integer)',
+    definition: '(IN "input_value" integer DEFAULT 1)',
+  },
+  {
+    title: 'zero',
+    params: [{ type: 'int', default: 0 }],
+    identity: '(integer)',
+    definition: '(integer DEFAULT 0)',
+  },
+  {
+    title: 'false',
+    params: [{ type: 'bool', default: false }],
+    identity: '(boolean)',
+    definition: '(boolean DEFAULT false)',
+  },
+  {
+    title: 'empty string',
+    params: [{ type: 'string', default: '' }],
+    identity: '(text)',
+    definition: '(text DEFAULT $pga$$pga$)',
+  },
+  {
+    title: 'null',
+    params: [{ type: 'integer', default: null }],
+    identity: '(integer)',
+    definition: '(integer DEFAULT NULL)',
+  },
+  {
+    title: 'literal expression',
+    params: [{ type: 'integer', default: PgLiteral.create('1 + 2') }],
+    identity: '(integer)',
+    definition: '(integer DEFAULT 1 + 2)',
+  },
+  {
+    title: 'string shorthand',
+    params: ['inherited'],
+    identity: '(integer)',
+    definition: '(integer DEFAULT 2)',
+  },
+  {
+    title: 'nested object shorthand',
+    params: [{ name: 'inputValue', type: 'nested' }],
+    identity: '("input_value" integer)',
+    definition: '("input_value" integer DEFAULT 2)',
+  },
+  {
+    title: 'overridden shorthand',
+    params: [{ type: 'nested', default: 3 }],
+    identity: '(integer)',
+    definition: '(integer DEFAULT 3)',
+  },
+  {
+    title: 'undefined override',
+    params: [{ type: 'nested', default: undefined }],
+    identity: '(integer)',
+    definition: '(integer)',
+  },
+  {
+    title: 'INOUT',
+    params: [
+      { mode: 'INOUT', name: 'inputValue', type: 'integer', default: 1 },
+    ],
+    identity: '(INOUT "input_value" integer)',
+    definition: '(INOUT "input_value" integer DEFAULT 1)',
+  },
+  {
+    title: 'OUT with input default',
+    params: [
+      { mode: 'IN', type: 'integer', default: 1 },
+      { mode: 'OUT', type: 'integer' },
+    ],
+    identity: '(IN integer, OUT integer)',
+    definition: '(IN integer DEFAULT 1, OUT integer)',
+  },
+  {
+    title: 'VARIADIC',
+    params: [
+      {
+        mode: 'VARIADIC',
+        type: 'integer[]',
+        default: PgLiteral.create('ARRAY[1, 2]'),
+      },
+    ],
+    identity: '(VARIADIC integer[])',
+    definition: '(VARIADIC integer[] DEFAULT ARRAY[1, 2])',
+  },
+];
+
+describe('renameFunction defaults', () => {
+  describe.each(['up', 'down'] as const)('%s', (direction) => {
+    it.each(cases)(
+      'omits $title defaults without changing creation or inputs',
+      ({ params, identity, definition }) => {
+        for (const param of params) {
+          if (typeof param === 'object') {
+            Object.freeze(param);
+          }
+        }
+        Object.freeze(params);
+        const options = { ...options2, typeShorthands };
+        const source = { schema: 'appSchema', name: 'oldName' };
+        const destination = { schema: 'app_schema', name: 'newName' };
+        const create = createFunction(options);
+        const creationBefore = create(
+          source,
+          params,
+          { language: 'sql', returns: 'integer' },
+          'SELECT 1'
+        );
+        expect(creationBefore).toContain(
+          `"app_schema"."old_name"${definition}`
+        );
+
+        const rename = renameFunction(options);
+        const expected =
+          direction === 'down'
+            ? `ALTER FUNCTION "app_schema"."new_name"${identity} RENAME TO "old_name";`
+            : `ALTER FUNCTION "app_schema"."old_name"${identity} RENAME TO "new_name";`;
+        expect(
+          (direction === 'down' ? rename.reverse : rename)(
+            source,
+            params,
+            destination
+          )
+        ).toBe(expected);
+
+        const pgm = new MigrationBuilder(
+          { query: vi.fn(), select: vi.fn() },
+          typeShorthands,
+          true,
+          console
+        );
+        if (direction === 'down') {
+          pgm.enableReverseMode();
+        }
+        pgm.renameFunction(source, params, destination);
+        expect(pgm.getSqlSteps()).toEqual([expected]);
+        expect(
+          create(
+            source,
+            params,
+            { language: 'sql', returns: 'integer' },
+            'SELECT 1'
+          )
+        ).toBe(creationBefore);
+      }
+    );
+
+    it('does not render an unused default expression', () => {
+      const toString = vi.fn(() => {
+        throw new Error('Unexpected default rendering');
+      });
+      const rename = renameFunction(options2);
+      const fn = direction === 'down' ? rename.reverse : rename;
+      expect(
+        fn(
+          'old',
+          [
+            {
+              type: 'integer',
+              default: { literal: true, value: 'unused', toString },
+            },
+          ],
+          'new'
+        )
+      ).toBe(
+        direction === 'down'
+          ? 'ALTER FUNCTION "new"(integer) RENAME TO "old";'
+          : 'ALTER FUNCTION "old"(integer) RENAME TO "new";'
+      );
+      expect(toString).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/test/operations/operators/renameAccessMethod.spec.ts
+++ b/test/operations/operators/renameAccessMethod.spec.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import { MigrationBuilder, PgLiteral } from '../../../src';
+import {
+  renameOperatorClass,
+  renameOperatorFamily,
+} from '../../../src/operations/operators';
+import { options2 } from '../../presetMigrationOptions';
+
+const operations = [
+  {
+    operation: 'renameOperatorClass',
+    keyword: 'OPERATOR CLASS',
+    create: renameOperatorClass,
+  },
+  {
+    operation: 'renameOperatorFamily',
+    keyword: 'OPERATOR FAMILY',
+    create: renameOperatorFamily,
+  },
+] as const;
+
+const invalidMethods: unknown[] = [
+  undefined,
+  null,
+  42,
+  true,
+  {},
+  { name: 'btree' },
+  PgLiteral.create('btree'),
+  Symbol('btree'),
+  {
+    toString() {
+      throw new Error('Must not coerce an access method');
+    },
+  },
+  '',
+  ' \t\n',
+  '""',
+  'app.btree',
+  '"app"."btree"',
+  'btree hash',
+  'btree /* comment */',
+  'btree--comment',
+  'btree RENAME TO pwned; --',
+  '"nul\0method"',
+  'U&"btree"',
+  '"unterminated',
+  '1btree',
+  '"btree"tail',
+];
+
+describe.each(operations)(
+  '$operation access methods',
+  ({ operation, keyword, create }) => {
+    describe.each(['up', 'down'] as const)('%s', (direction) => {
+      const source = { schema: 'appSchema', name: 'oldName' };
+      const destination = { schema: 'app_schema', name: 'newName' };
+      const rename = create(options2);
+      const fn = direction === 'down' ? rename.reverse : rename;
+
+      it.each([
+        'btree',
+        'hash',
+        'customMethod',
+        '"Custom.Method"',
+        '"escaped""quote"',
+        '"comment--inside"',
+        'ação',
+        '名字',
+        ' \tBTREE\n',
+      ])(
+        'preserves the single identifier %j without decamelization',
+        (method) => {
+          expect(fn(source, method, destination)).toBe(
+            direction === 'down'
+              ? `ALTER ${keyword} "app_schema"."new_name" USING ${method} RENAME TO "old_name";`
+              : `ALTER ${keyword} "app_schema"."old_name" USING ${method} RENAME TO "new_name";`
+          );
+        }
+      );
+
+      it.each(invalidMethods)('rejects %j before adding SQL', (method) => {
+        const error = new Error(
+          `${operation} requires indexMethod to be a string containing a single unqualified identifier`
+        );
+        expect(() =>
+          Reflect.apply(fn, undefined, [source, method, destination])
+        ).toThrow(error);
+
+        const pgm = new MigrationBuilder(
+          { query: vi.fn(), select: vi.fn() },
+          undefined,
+          true,
+          console
+        );
+        if (direction === 'down') {
+          pgm.enableReverseMode();
+        }
+        pgm[operation]('existing', 'btree', 'renamed');
+        const before = pgm.getSqlSteps();
+        expect(() =>
+          Reflect.apply(pgm[operation], pgm, [source, method, destination])
+        ).toThrow(error);
+        expect(pgm.getSqlSteps()).toEqual(before);
+      });
+    });
+  }
+);

--- a/test/operations/operators/renameOperatorClass.spec.ts
+++ b/test/operations/operators/renameOperatorClass.spec.ts
@@ -33,7 +33,30 @@ describe('operations', () => {
 
         expect(statement).toBeTypeOf('string');
         expect(statement).toBe(
-          'ALTER OPERATOR CLASS "myschema"."gist__int_ops" USING gist RENAME TO "myschema"."gist__int_ops_new";'
+          'ALTER OPERATOR CLASS "myschema"."gist__int_ops" USING gist RENAME TO "gist__int_ops_new";'
+        );
+      });
+
+      describe.each(['up', 'down'] as const)('%s identity', (direction) => {
+        const operation =
+          direction === 'down'
+            ? renameOperatorClassFn.reverse
+            : renameOperatorClassFn;
+
+        it.each(['btree', 'hash', '"customMethod"'])(
+          'preserves access method %s',
+          (method) => {
+            expect(
+              operation({ schema: 'app', name: 'old' }, method, {
+                schema: 'app',
+                name: 'new',
+              })
+            ).toBe(
+              direction === 'down'
+                ? `ALTER OPERATOR CLASS "app"."new" USING ${method} RENAME TO "old";`
+                : `ALTER OPERATOR CLASS "app"."old" USING ${method} RENAME TO "new";`
+            );
+          }
         );
       });
 

--- a/test/operations/operators/renameOperatorFamily.spec.ts
+++ b/test/operations/operators/renameOperatorFamily.spec.ts
@@ -33,7 +33,30 @@ describe('operations', () => {
 
         expect(statement).toBeTypeOf('string');
         expect(statement).toBe(
-          'ALTER OPERATOR FAMILY "myschema"."integer_ops" USING btree RENAME TO "myschema"."integer_ops_new";'
+          'ALTER OPERATOR FAMILY "myschema"."integer_ops" USING btree RENAME TO "integer_ops_new";'
+        );
+      });
+
+      describe.each(['up', 'down'] as const)('%s identity', (direction) => {
+        const operation =
+          direction === 'down'
+            ? renameOperatorFamilyFn.reverse
+            : renameOperatorFamilyFn;
+
+        it.each(['btree', 'hash', '"customMethod"'])(
+          'preserves access method %s',
+          (method) => {
+            expect(
+              operation({ schema: 'app', name: 'old' }, method, {
+                schema: 'app',
+                name: 'new',
+              })
+            ).toBe(
+              direction === 'down'
+                ? `ALTER OPERATOR FAMILY "app"."new" USING ${method} RENAME TO "old";`
+                : `ALTER OPERATOR FAMILY "app"."old" USING ${method} RENAME TO "new";`
+            );
+          }
         );
       });
 

--- a/test/operations/renameArguments.spec.ts
+++ b/test/operations/renameArguments.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+import { MigrationBuilder } from '../../src';
+import { renameDomain } from '../../src/operations/domains';
+import { renameIndex } from '../../src/operations/indexes';
+import { renameMaterializedView } from '../../src/operations/materializedViews';
+import { renameSequence } from '../../src/operations/sequences';
+import { renameTable } from '../../src/operations/tables';
+import { renameType } from '../../src/operations/types';
+import { renameView } from '../../src/operations/views';
+import { options1 } from '../presetMigrationOptions';
+
+const operations = [
+  { operation: 'renameTable', keyword: 'TABLE', create: renameTable },
+  { operation: 'renameType', keyword: 'TYPE', create: renameType },
+  { operation: 'renameDomain', keyword: 'DOMAIN', create: renameDomain },
+  { operation: 'renameView', keyword: 'VIEW', create: renameView },
+  {
+    operation: 'renameMaterializedView',
+    keyword: 'MATERIALIZED VIEW',
+    create: renameMaterializedView,
+  },
+  { operation: 'renameSequence', keyword: 'SEQUENCE', create: renameSequence },
+  { operation: 'renameIndex', keyword: 'INDEX', create: renameIndex },
+] as const;
+
+const extraArguments = [
+  { title: 'undefined', value: undefined },
+  { title: 'null', value: null },
+  { title: 'SQL fragment', value: ' CASCADE; DROP TABLE users; --' },
+  { title: 'number', value: 0 },
+  { title: 'object', value: { some: 'object' } },
+  { title: 'symbol', value: Symbol('extra') },
+  { title: 'array', value: ['extra'] },
+  {
+    title: 'object that must not be coerced',
+    value: {
+      [Symbol.toPrimitive]() {
+        throw new Error('Unexpected coercion of an ignored argument');
+      },
+    },
+  },
+];
+
+describe.each(operations)(
+  '$operation runtime arguments',
+  ({ operation, keyword, create }) => {
+    describe.each(['up', 'down'] as const)('%s', (direction) => {
+      const source = { schema: 'app', name: 'old' };
+      const destination = { schema: 'app', name: 'new' };
+      const expected =
+        direction === 'down'
+          ? `ALTER ${keyword} "app"."new" RENAME TO "old";`
+          : `ALTER ${keyword} "app"."old" RENAME TO "new";`;
+
+      it.each(extraArguments)('ignores $title in direct calls', ({ value }) => {
+        const rename = create(options1);
+        const fn = direction === 'down' ? rename.reverse : rename;
+        expect(
+          Reflect.apply(fn, undefined, [source, destination, value, 'extra'])
+        ).toBe(expected);
+      });
+
+      it.each(extraArguments)(
+        'ignores $title through MigrationBuilder',
+        ({ value }) => {
+          const pgm = new MigrationBuilder(
+            { query: vi.fn(), select: vi.fn() },
+            undefined,
+            false,
+            console
+          );
+          if (direction === 'down') {
+            pgm.enableReverseMode();
+          }
+          Reflect.apply(pgm[operation], pgm, [
+            source,
+            destination,
+            value,
+            'extra',
+          ]);
+          expect(pgm.getSqlSteps()).toEqual([expected]);
+        }
+      );
+    });
+  }
+);

--- a/test/operations/renameChains.spec.ts
+++ b/test/operations/renameChains.spec.ts
@@ -3,7 +3,7 @@ import type { PgLiteralValue } from '../../src';
 import { MigrationBuilder, PgLiteral } from '../../src';
 import type { Name } from '../../src/operations/generalTypes';
 
-const operations = [
+const simpleOperations = [
   ['renameTable', 'TABLE', 'a table'],
   ['renameType', 'TYPE', 'a type'],
   ['renameDomain', 'DOMAIN', 'a domain'],
@@ -12,6 +12,51 @@ const operations = [
   ['renameSequence', 'SEQUENCE', 'a sequence'],
   ['renameIndex', 'INDEX', 'an index'],
 ] as const;
+
+const operations: Array<{
+  operation: string;
+  keyword: string;
+  label: string;
+  sourceSuffix: string;
+  invoke: (pgm: MigrationBuilder, source: Name, destination: Name) => void;
+}> = [
+  ...simpleOperations.map(([operation, keyword, label]) => ({
+    operation,
+    keyword,
+    label,
+    sourceSuffix: '',
+    invoke: (pgm: MigrationBuilder, source: Name, destination: Name) => {
+      pgm[operation](source, destination);
+    },
+  })),
+  {
+    operation: 'renameFunction',
+    keyword: 'FUNCTION',
+    label: 'a function',
+    sourceSuffix: '(integer)',
+    invoke: (pgm, source, destination) => {
+      pgm.renameFunction(source, ['integer'], destination);
+    },
+  },
+  {
+    operation: 'renameOperatorClass',
+    keyword: 'OPERATOR CLASS',
+    label: 'an operator class',
+    sourceSuffix: ' USING btree',
+    invoke: (pgm, source, destination) => {
+      pgm.renameOperatorClass(source, 'btree', destination);
+    },
+  },
+  {
+    operation: 'renameOperatorFamily',
+    keyword: 'OPERATOR FAMILY',
+    label: 'an operator family',
+    sourceSuffix: ' USING hash',
+    invoke: (pgm, source, destination) => {
+      pgm.renameOperatorFamily(source, 'hash', destination);
+    },
+  },
+];
 
 const unqualifiedSources: Name[] = [
   'old',
@@ -27,7 +72,8 @@ const unqualifiedDestinations: Name[] = [
 ];
 
 describe('operations', () => {
-  describe.each(operations)('%s schemas', (operation, keyword, label) => {
+  describe.each(operations)('$operation schemas', (entry) => {
+    const { operation, keyword, label, sourceSuffix, invoke } = entry;
     describe.each(['up', 'down'] as const)('%s', (direction) => {
       function builder(decamelize = false): MigrationBuilder {
         const pgm = new MigrationBuilder(
@@ -44,26 +90,27 @@ describe('operations', () => {
 
       function rename(source: Name, destination: Name, decamelize = false) {
         const pgm = builder(decamelize);
-        pgm[operation](source, destination);
+        invoke(pgm, source, destination);
         return pgm.getSqlSteps();
       }
 
       it('preserves schema and rename-chain order', () => {
         const pgm = builder();
-        pgm[operation]({ schema: 'app', name: 'old' }, 'middle');
-        pgm[operation](
+        invoke(pgm, { schema: 'app', name: 'old' }, 'middle');
+        invoke(
+          pgm,
           { schema: 'app', name: 'middle' },
           { schema: 'app', name: 'new' }
         );
         expect(pgm.getSqlSteps()).toEqual(
           direction === 'down'
             ? [
-                `ALTER ${keyword} "app"."new" RENAME TO "middle";`,
-                `ALTER ${keyword} "app"."middle" RENAME TO "old";`,
+                `ALTER ${keyword} "app"."new"${sourceSuffix} RENAME TO "middle";`,
+                `ALTER ${keyword} "app"."middle"${sourceSuffix} RENAME TO "old";`,
               ]
             : [
-                `ALTER ${keyword} "app"."old" RENAME TO "middle";`,
-                `ALTER ${keyword} "app"."middle" RENAME TO "new";`,
+                `ALTER ${keyword} "app"."old"${sourceSuffix} RENAME TO "middle";`,
+                `ALTER ${keyword} "app"."middle"${sourceSuffix} RENAME TO "new";`,
               ]
         );
       });
@@ -73,8 +120,8 @@ describe('operations', () => {
         (destination) => {
           expect(rename({ schema: 'app', name: 'old' }, destination)).toEqual([
             direction === 'down'
-              ? `ALTER ${keyword} "app"."new" RENAME TO "old";`
-              : `ALTER ${keyword} "app"."old" RENAME TO "new";`,
+              ? `ALTER ${keyword} "app"."new"${sourceSuffix} RENAME TO "old";`
+              : `ALTER ${keyword} "app"."old"${sourceSuffix} RENAME TO "new";`,
           ]);
         }
       );
@@ -91,18 +138,19 @@ describe('operations', () => {
         ({ source, destination }) => {
           expect(rename(source, destination)).toEqual([
             direction === 'down'
-              ? `ALTER ${keyword} "new" RENAME TO "old";`
-              : `ALTER ${keyword} "old" RENAME TO "new";`,
+              ? `ALTER ${keyword} "new"${sourceSuffix} RENAME TO "old";`
+              : `ALTER ${keyword} "old"${sourceSuffix} RENAME TO "new";`,
           ]);
         }
       );
 
       it('rejects different explicit schemas', () => {
         const pgm = builder();
-        pgm[operation]('existing', 'renamed');
+        invoke(pgm, 'existing', 'renamed');
         const before = pgm.getSqlSteps();
         expect(() => {
-          pgm[operation](
+          invoke(
+            pgm,
             { schema: 'app', name: 'old' },
             { schema: 'other', name: 'new' }
           );
@@ -116,10 +164,10 @@ describe('operations', () => {
         'explains how to specify the unknown source schema for %j',
         (source) => {
           const pgm = builder();
-          pgm[operation]('existing', 'renamed');
+          invoke(pgm, 'existing', 'renamed');
           const before = pgm.getSqlSteps();
           expect(() => {
-            pgm[operation](source, { schema: 'app', name: 'new' });
+            invoke(pgm, source, { schema: 'app', name: 'new' });
           }).toThrow(
             new Error(
               `${operation} cannot infer the source schema; use { schema, name } for the source`
@@ -144,8 +192,8 @@ describe('operations', () => {
             )
           ).toEqual([
             direction === 'down'
-              ? `ALTER ${keyword} "app_schema"."new_name" RENAME TO "old_name";`
-              : `ALTER ${keyword} "app_schema"."old_name" RENAME TO "new_name";`,
+              ? `ALTER ${keyword} "app_schema"."new_name"${sourceSuffix} RENAME TO "old_name";`
+              : `ALTER ${keyword} "app_schema"."old_name"${sourceSuffix} RENAME TO "new_name";`,
           ]);
         }
       );
@@ -173,8 +221,8 @@ describe('operations', () => {
           rename({ schema: 'my"schema', name: 'old"name' }, 'new"name')
         ).toEqual([
           direction === 'down'
-            ? `ALTER ${keyword} "my""schema"."new""name" RENAME TO "old""name";`
-            : `ALTER ${keyword} "my""schema"."old""name" RENAME TO "new""name";`,
+            ? `ALTER ${keyword} "my""schema"."new""name"${sourceSuffix} RENAME TO "old""name";`
+            : `ALTER ${keyword} "my""schema"."old""name"${sourceSuffix} RENAME TO "new""name";`,
         ]);
       });
 
@@ -195,15 +243,15 @@ describe('operations', () => {
           const literal = PgLiteral.create(raw);
           expect(rename(literal, 'newName', true)).toEqual([
             direction === 'down'
-              ? `ALTER ${keyword} "new_name" RENAME TO ${raw};`
-              : `ALTER ${keyword} ${raw} RENAME TO "new_name";`,
+              ? `ALTER ${keyword} "new_name"${sourceSuffix} RENAME TO ${raw};`
+              : `ALTER ${keyword} ${raw}${sourceSuffix} RENAME TO "new_name";`,
           ]);
           expect(
             rename({ schema: 'appSchema', name: 'oldName' }, literal, true)
           ).toEqual([
             direction === 'down'
-              ? `ALTER ${keyword} "app_schema".${raw} RENAME TO "old_name";`
-              : `ALTER ${keyword} "app_schema"."old_name" RENAME TO ${raw};`,
+              ? `ALTER ${keyword} "app_schema".${raw}${sourceSuffix} RENAME TO "old_name";`
+              : `ALTER ${keyword} "app_schema"."old_name"${sourceSuffix} RENAME TO ${raw};`,
           ]);
         }
       );
@@ -237,8 +285,8 @@ describe('operations', () => {
         };
         expect(rename('old', literal)).toEqual([
           direction === 'down'
-            ? `ALTER ${keyword} "Raw.Name" RENAME TO "old";`
-            : `ALTER ${keyword} "old" RENAME TO "Raw.Name";`,
+            ? `ALTER ${keyword} "Raw.Name"${sourceSuffix} RENAME TO "old";`
+            : `ALTER ${keyword} "old"${sourceSuffix} RENAME TO "Raw.Name";`,
         ]);
       });
 
@@ -263,10 +311,10 @@ describe('operations', () => {
         '"nul\0name"',
       ])('rejects unsupported raw name %j before adding a SQL step', (raw) => {
         const pgm = builder();
-        pgm[operation]('existing', 'renamed');
+        invoke(pgm, 'existing', 'renamed');
         const before = pgm.getSqlSteps();
         expect(() => {
-          pgm[operation](PgLiteral.create(raw), 'new');
+          invoke(pgm, PgLiteral.create(raw), 'new');
         }).toThrow(
           new Error(
             `${operation} requires a single unqualified identifier for a PgLiteral source; use { schema, name } for schema-qualified names`
@@ -274,7 +322,7 @@ describe('operations', () => {
         );
         expect(pgm.getSqlSteps()).toEqual(before);
         expect(() => {
-          pgm[operation]({ schema: 'app', name: 'old' }, PgLiteral.create(raw));
+          invoke(pgm, { schema: 'app', name: 'old' }, PgLiteral.create(raw));
         }).toThrow(
           new Error(
             `${operation} requires a single unqualified identifier for a PgLiteral destination; use { schema, name } for schema-qualified names`


### PR DESCRIPTION
Fixes #1727. Completes the schema-aware rename work from #1725, #1728, and #1732.

`renameFunction`, `renameOperatorClass`, and `renameOperatorFamily` previously lost the source schema during automatic rollback and produced invalid qualified `RENAME TO` targets for same-schema destination objects. These were pre-existing gaps in the three remaining rename operations.

For example, automatic rollback of a function rename now changes from:

```sql
ALTER FUNCTION "new_function"(integer) RENAME TO "app"."old_function";
```

to:

```sql
ALTER FUNCTION "app"."new_function"(integer) RENAME TO "old_function";
```

### What changed

- All ten renames share schema normalization, rendered-schema comparison, and precise schema/literal diagnostics. Function parameters and operator access methods stay attached to the object identity in both directions.
- Breno's suffix-leak finding is fixed with private factory configuration. Extra JavaScript arguments remain ignored by the seven ordinary rename operations, including arguments that throw if coerced.
- Both operator renames validate access methods before queuing SQL. Function rename identities omit parameter defaults after shorthand expansion, preserving stored defaults and creation SQL.
- Documentation explains schemas, automatic reversal, supported identifiers, and explicit SQL for schema moves. Public signatures remain unchanged.

### Compatibility

Retain both breaking-change notices in the squash commit:

- **BREAKING CHANGE:** The three newly supported renames reject qualified or unsupported `PgLiteral` names in both directions. Replayed migrations may need `{ schema, name }` or explicit SQL for up and down.
- **BREAKING CHANGE:** Operator rename access methods must be primitive strings containing one unqualified identifier. Previously valid fragments such as `'btree /* comment */'` are rejected. Quoted identifiers remain supported.

Following Shini's guidance, additional `dropFunction`, whitespace-validation, helper-naming, and documentation improvements are deferred to separate PRs.

### Validation after rebase

Rebased onto upstream `98b1cd6`; the new head is `ae07215e5e58f6ea5b07b6ade07a595ffa283067`. All five reviewed patches are unchanged according to `git range-diff`. The PR still changes 19 files.

Local validation used Node 24.18.0 and pnpm 11.25.0:

- `pnpm exec vitest run --project unit --coverage`: **2,496 tests pass**. Coverage exceeds every repository threshold.
- Full native PostgreSQL 16.15 integration suite: **131 tests pass**, including the new upstream tests. Local provisioning uses an untracked adapter; Docker/Testcontainers were not run locally.
- Package/docs builds, type checking, lint, formatting, six executable documentation examples, and diff checks pass.

The committed regressions cover ignored runtime arguments, exact rejection errors and unchanged SQL queues, defaults from parameter objects and shorthands, and rename chains with OID/catalog assertions, overloads, and decoys first in `search_path`.

[GitHub checks](https://github.com/salsita/node-pg-migrate/pull/1733/checks) run the PostgreSQL 14–18 Testcontainers matrix on Node 22/24/26 and the existing CockroachDB fixtures. The PostgreSQL identity suite does not run against CockroachDB. Earlier local comparison counts and their corrections remain historical context in the review discussion.

Reviewed with the help of AI.
